### PR TITLE
Suffix list update

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -181,7 +181,7 @@ def _fetch_page(url):
         return u''
 
 def _PublicSuffixListSource():
-    page = _fetch_page('http://mxr.mozilla.org/mozilla/source/netwerk/dns/src/effective_tld_names.dat?raw=1')
+    page = _fetch_page('http://mxr.mozilla.org/mozilla-central/source/netwerk/dns/effective_tld_names.dat?raw=1')
 
     tld_finder = re.compile(r'^(?P<tld>[.*!]*\w[\S]*)', re.UNICODE | re.MULTILINE)
     tlds = [m.group('tld') for m in tld_finder.finditer(page)]


### PR DESCRIPTION
The old suffix list is missing lots of things, e.g. Russia’s .рф TLD, which is in use for over a year now.

Also, this is where http://publicsuffix.org/list/ link points to, as of now.
