### PR TITLE
use a fixed logger name instead of the ever changing __file__

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -48,7 +48,7 @@ import socket
 import urllib2
 import urlparse
 
-LOG = logging.getLogger(__file__)
+LOG = logging.getLogger("tldextract")
 
 SCHEME_RE = re.compile(r'^([' + urlparse.scheme_chars + ']+:)?//')
 IP_RE = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')


### PR DESCRIPTION
if you want to configure a logger that is constructed via getLogger(**file**) then you have to type in the whole path, which can get tedious very fast in frameworks like django and when you are running the code on different distros.

so instead just using a "tldextract" logger name which i believe makes perfect sense here
