### PR TITLE
Fixing encoding problem while printing debugging info in tldextract module

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -172,7 +172,7 @@ class TLDExtract(object):
                 snapshot = sorted(pickle.load(snapshot_file))
             new = sorted(tlds)
             for line in difflib.unified_diff(snapshot, new, fromfile=".tld_set_snapshot", tofile=cached_file):
-                print >> sys.stderr, line
+                print >> sys.stderr, line.encode('utf-8')
 
         try:
             with open(cached_file, 'w') as f:


### PR DESCRIPTION
This fix closes #11
