### PR TITLE
setup.py: Added a few more classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",
         "License :: OSI Approved :: BSD License",
+ 	"Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.5",
         "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+ 	"Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
     ],
     entry_points = {


### PR DESCRIPTION
A bit more metadata for PyPI... In particular, the "Python 3" tag gives you a "3" in the upper left corner of your PyPI page and that tag is also looked for by PyPI scraping services like python3wos. 
