### PR TITLE
Changes related to #38, #39, #41 (PSL flexibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.tld_set
+*.tld_cache_file.pickle
 build
 dist
 tldextract_app/tldextract

--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ callable by setting TLDEXTRACT_CACHE environment variable or by setting the
 cache_file path in TLDExtract initialization.
 
     # extract callable that falls back to the included TLD snapshot, no live HTTP fetching
-    no_fetch_extract = tldextract.TLDExtract(fetch=False)
+    no_fetch_extract = tldextract.TLDExtract(suffix_list_file=False)
     no_fetch_extract('http://www.google.com')
 
     # extract callable that reads/writes the updated TLD set to a different path
     custom_cache_extract = tldextract.TLDExtract(cache_file='/path/to/your/cache/file')
     custom_cache_extract('http://www.google.com')
+
+    # extract callable that doesn't use caching
+    no_cache_extract = tldextract.TLDExtract(cache_file=False)
+    no_cache_extract('http://www.google.com')
 
 If you want to stay fresh with the TLD definitions--though they don't change
 often--delete the cache file occasionally, or run
@@ -90,6 +94,28 @@ or:
     env TLDEXTRACT_CACHE="~/tldextract.cache" tldextract --update
 
 It is also recommended to delete the file after upgrading this lib.
+
+### Specifying your own URL or file for the Suffix List data
+
+You can specify your own input data in place of the default Mozilla Public Suffix List:
+
+    extract = tldextract.TLDExtract(
+        suffix_list_url="http://foo.bar.baz",
+        # Recommended: Specify your own cache file, to minimize ambiguities about where
+        # tldextract is getting its data, or cached data, from.
+        cache_file='/path/to/your/cache/file')
+
+The above snippet will fetch from the URL *you* specified, upon first need to download the
+suffix list (i.e. if the cache_file doesn't exist).
+
+If you want to use input data from your local filesystem, just use the `file://` protocol:
+
+    extract = tldextract.TLDExtract(
+        suffix_list_url="file://absolute/path/to/your/local/suffix/list/file",
+        cache_file='/path/to/your/cache/file')
+
+Use an absolute path when specifying the `suffix_list_url` keyword argument. `os.path` is your
+friend.
 
 # Public API
 

--- a/tldextract/tests/all.py
+++ b/tldextract/tests/all.py
@@ -2,31 +2,85 @@ import doctest
 import logging
 import os
 import sys
+import tempfile
+import traceback
 import unittest
 
 import tldextract
-from tldextract import extract
+
+
+def _temporary_file():
+    """ Make a writable temporary file and return its absolute path.
+    """
+    return tempfile.mkstemp()[1]
+
+
+fake_suffix_list_url = "file://" + os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'fixtures/fake_suffix_list_fixture.dat'
+)
+
+extract = tldextract.TLDExtract(cache_file=_temporary_file())
+extract_no_cache = tldextract.TLDExtract(cache_file=False)
+extract_using_real_local_suffix_list = tldextract.TLDExtract(cache_file=_temporary_file())
+extract_using_real_local_suffix_list_no_cache = tldextract.TLDExtract(cache_file=False)
+extract_using_fallback_to_snapshot_no_cache = tldextract.TLDExtract(
+    cache_file=None,
+    suffix_list_url=None
+)
+extract_using_fake_suffix_list = tldextract.TLDExtract(
+    cache_file=_temporary_file(),
+    suffix_list_url=fake_suffix_list_url
+)
+extract_using_fake_suffix_list_no_cache = tldextract.TLDExtract(
+    cache_file=None,
+    suffix_list_url=fake_suffix_list_url
+)
+
 
 class IntegrationTest(unittest.TestCase):
+
     def test_log_snapshot_diff(self):
         logging.basicConfig(level=logging.DEBUG)
 
         extractor = tldextract.TLDExtract()
         try:
             os.remove(extractor.cache_file)
-        except IOError:
-            pass
+        except (IOError, OSError):
+            logging.warning(traceback.format_exc())
 
         # TODO: if .tld_set_snapshot is up to date, this won't trigger a diff
         extractor('ignore.com')
 
+    def test_bad_kwargs(self):
+        self.assertRaises(
+            ValueError,
+            tldextract.TLDExtract,
+            cache_file=False, suffix_list_url=False, fallback_to_snapshot=False
+        )
+
+    def test_fetch_and_suffix_list_conflict(self):
+        """ Make sure we support both fetch and suffix_list_url kwargs for this version.
+
+        GitHub issue #41.
+        """
+        extractor = tldextract.TLDExtract(suffix_list_url='foo', fetch=False)
+        assert not extractor.suffix_list_url
+
 class ExtractTest(unittest.TestCase):
-    def assertExtract(self, expected_subdomain, expected_domain, expected_tld, url, fns=(extract,)):
+    def assertExtract(self, expected_subdomain, expected_domain, expected_tld, url,
+                      fns=(
+                          extract,
+                          extract_no_cache,
+                          extract_using_real_local_suffix_list,
+                          extract_using_real_local_suffix_list_no_cache,
+                          extract_using_fallback_to_snapshot_no_cache
+                      )):
         for fn in fns:
-          ext = fn(url)
-          self.assertEquals(expected_subdomain, ext.subdomain)
-          self.assertEquals(expected_domain, ext.domain)
-          self.assertEquals(expected_tld, ext.tld)
+            ext = fn(url)
+            self.assertEquals(expected_subdomain, ext.subdomain)
+            self.assertEquals(expected_domain, ext.domain)
+            self.assertEquals(expected_tld, ext.tld)
 
     def test_american(self):
         self.assertExtract('www', 'google', 'com', 'http://www.google.com')
@@ -38,7 +92,8 @@ class ExtractTest(unittest.TestCase):
         self.assertExtract("", "gmail", "com", "http://gmail.com")
 
     def test_nested_subdomain(self):
-        self.assertExtract("media.forums", "theregister", "co.uk", "http://media.forums.theregister.co.uk")
+        self.assertExtract("media.forums", "theregister", "co.uk",
+            "http://media.forums.theregister.co.uk")
 
     def test_odd_but_possible(self):
         self.assertExtract('www', 'www', 'com', 'http://www.www.com')
@@ -88,21 +143,39 @@ class ExtractTest(unittest.TestCase):
 
     def test_tld_is_a_website_too(self):
         self.assertExtract('www', 'metp', 'net.cn', 'http://www.metp.net.cn')
-        #self.assertExtract('www', 'net', 'cn', 'http://www.net.cn') # This is unhandled by the PSL. Or is it?
+        #self.assertExtract('www', 'net', 'cn', 'http://www.net.cn') # This is unhandled by the
+        # PSL. Or is it?
 
     def test_dns_root_label(self):
         self.assertExtract('www', 'example', 'com', 'http://www.example.com./')
+
+
+class ExtractTestUsingCustomSuffixListFile(unittest.TestCase):
+    def test_suffix_which_is_not_in_custom_list(self):
+        for fn in (extract_using_fake_suffix_list, extract_using_fake_suffix_list_no_cache):
+            result = fn("www.google.com")
+            self.assertEquals(result.suffix, "")
+
+    def test_custom_suffixes(self):
+        for fn in (extract_using_fake_suffix_list, extract_using_fake_suffix_list_no_cache):
+            for custom_suffix in ('foo', 'bar', 'baz'):
+                result = fn("www.foo.bar.baz.quux" + "." + custom_suffix)
+                self.assertEquals(result.suffix, custom_suffix)
+
 
 def test_suite():
     return unittest.TestSuite([
         doctest.DocTestSuite(tldextract.tldextract),
         unittest.TestLoader().loadTestsFromTestCase(IntegrationTest),
         unittest.TestLoader().loadTestsFromTestCase(ExtractTest),
+        unittest.TestLoader().loadTestsFromTestCase(ExtractTestUsingCustomSuffixListFile),
     ])
+
 
 def run_tests(stream=sys.stderr):
     suite = test_suite()
     unittest.TextTestRunner(stream).run(suite)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/tldextract/tests/fixtures/fake_suffix_list_fixture.dat
+++ b/tldextract/tests/fixtures/fake_suffix_list_fixture.dat
@@ -1,0 +1,6 @@
+// comment
+
+foo
+bar
+baz
+*.co.jp

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -20,6 +20,7 @@ top-level domain) from the registered domain and subdomains of a URL.
 """
 
 from __future__ import with_statement
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -49,7 +50,7 @@ import re
 import socket
 try: # pragma: no cover
     # Python 2
-    from urllib2 import urlopen, URLError
+    from urllib2 import urlopen, URLError, Request
     from urlparse import scheme_chars
 except ImportError: # pragma: no cover
     # Python 3
@@ -59,6 +60,12 @@ except ImportError: # pragma: no cover
     unicode = str
 
 LOG = logging.getLogger("tldextract")
+
+CACHE_FILE_DEFAULT = os.path.join(os.path.dirname(__file__), '.tld_cache_file.pickle')
+CACHE_FILE = os.path.expanduser(os.environ.get("TLDEXTRACT_CACHE", CACHE_FILE_DEFAULT))
+
+PUBLIC_SUFFIX_LIST_URL = \
+    'http://mxr.mozilla.org/mozilla-central/source/netwerk/dns/effective_tld_names.dat?raw=1'
 
 SCHEME_RE = re.compile(r'^([' + scheme_chars + ']+:)?//')
 IP_RE = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')
@@ -125,30 +132,49 @@ class ExtractResult(tuple):
       return ''
 
 class TLDExtract(object):
-    def __init__(self, fetch=True, cache_file=''):
+    def __init__(self, cache_file=CACHE_FILE, suffix_list_url=PUBLIC_SUFFIX_LIST_URL, fetch=True,
+                 fallback_to_snapshot=True):
         """
-        Constructs a callable for extracting subdomain, domain, and TLD
+        Constructs a callable for extracting subdomain, domain, and suffix
         components from a URL.
 
-        If fetch is True (the default) and no cached TLD set is found, this
-        extractor will fetch TLD sources live over HTTP on first use. Set to
-        False to not make HTTP requests. Either way, if the TLD set can't be
-        read, the module will fall back to the included TLD set snapshot.
+        Upon calling it, it first checks for a Python-pickled `cache_file`.
+        By default, the `cache_file` will live in the tldextract directory.
 
-        Specifying cache_file will override the location of the TLD set.
-        Defaults to /path/to/tldextract/.tld_set.
+        You can disable the caching functionality of this module  by setting `cache_file` to False.
 
+        If the `cache_file` does not exist (such as on the first run), a live HTTP request
+        will be made to obtain the data at the `suffix_list_url` -- unless `suffix_list_url`
+        evaluates to `False`. Therefore you can deactivate the HTTP request functionality
+        by setting this argument to `False` or `None`, like `suffix_list_url=None`.
+
+        The default URL points to the latest version of the Mozilla Public Suffix List, but any
+        similar document could be specified.
+
+        Local files can be specified by using the `file://` protocol. (See `urllib2` documentation.)
+
+        If there is no `cache_file` loaded and no data is found from the `suffix_list_url`,
+        the module will fall back to the included TLD set snapshot. If you do not want
+        this behavior, you may set `fallback_to_snapshot` to False, and an exception will be
+        raised instead.
         """
-        self.fetch = fetch
-        self.cache_file = os.path.expanduser(cache_file or
-            os.environ.get("TLDEXTRACT_CACHE",
-                os.path.join(os.path.dirname(__file__), '.tld_set')))
+        if not fetch:
+            LOG.warning("The 'fetch' argument is deprecated. Instead of specifying fetch, "
+                        "you should specify suffix_list_url. The equivalent of fetch=False would "
+                        "be suffix_list_url=None.")
+        self.suffix_list_url = suffix_list_url if suffix_list_url and fetch else None
+        self.cache_file = os.path.expanduser(cache_file or '')
+        self.fallback_to_snapshot = fallback_to_snapshot
+        if not (self.suffix_list_url or self.cache_file or self.fallback_to_snapshot):
+            raise ValueError("The arguments you have provided disable all ways for tldextract "
+                             "to obtain data. Please provide a suffix list data, a cache_file, "
+                             "or set `fallback_to_snapshot` to `True`.")
         self._extractor = None
 
     def __call__(self, url):
         """
         Takes a string URL and splits it into its subdomain, domain, and
-        gTLD/ccTLD component.
+        suffix (effective TLD, gTLD, ccTLD, etc.) component.
 
         >>> extract = TLDExtract()
         >>> extract('http://forums.news.cnn.com/')
@@ -186,30 +212,35 @@ class TLDExtract(object):
             self._get_tld_extractor()
 
     def _get_tld_extractor(self):
+
         if self._extractor:
             return self._extractor
 
-        cached_file = self.cache_file
-        try:
-            with open(cached_file) as f:
-                self._extractor = _PublicSuffixListTLDExtractor(pickle.load(f))
-                return self._extractor
-        except IOError as ioe:
-            file_not_found = ioe.errno == errno.ENOENT
-            if not file_not_found:
-              LOG.error("error reading TLD cache file %s: %s", cached_file, ioe)
-        except Exception as ex:
-            LOG.error("error reading TLD cache file %s: %s", cached_file, ex)
+        if self.cache_file:
+            try:
+                with open(self.cache_file) as f:
+                    self._extractor = _PublicSuffixListTLDExtractor(pickle.load(f))
+                    return self._extractor
+            except IOError as ioe:
+                file_not_found = ioe.errno == errno.ENOENT
+                if not file_not_found:
+                  LOG.error("error reading TLD cache file %s: %s", self.cache_file, ioe)
+            except Exception as ex:
+                LOG.error("error reading TLD cache file %s: %s", self.cache_file, ex)
 
         tlds = frozenset()
-        if self.fetch:
-            tld_sources = (_PublicSuffixListSource,)
-            tlds = frozenset(tld for tld_source in tld_sources for tld in tld_source())
+        if self.suffix_list_url:
+            raw_suffix_list_data = fetch_file(self.suffix_list_url)
+            tlds = get_tlds_from_raw_suffix_list_data(raw_suffix_list_data)
 
         if not tlds:
-            with pkg_resources.resource_stream(__name__, '.tld_set_snapshot') as snapshot_file:
-                self._extractor = _PublicSuffixListTLDExtractor(pickle.load(snapshot_file))
-                return self._extractor
+            if self.fallback_to_snapshot:
+                with pkg_resources.resource_stream(__name__, '.tld_set_snapshot') as snapshot_file:
+                    self._extractor = _PublicSuffixListTLDExtractor(pickle.load(snapshot_file))
+                    return self._extractor
+            else:
+                raise Exception("tlds is empty, but fallback_to_snapshot is set"
+                                " to false. Cannot proceed without tlds.")
 
         LOG.info("computed TLDs: [%s, ...]", ', '.join(list(tlds)[:10]))
         if LOG.isEnabledFor(logging.DEBUG):
@@ -217,17 +248,18 @@ class TLDExtract(object):
             with pkg_resources.resource_stream(__name__, '.tld_set_snapshot') as snapshot_file:
                 snapshot = sorted(pickle.load(snapshot_file))
             new = sorted(tlds)
-            for line in difflib.unified_diff(snapshot, new, fromfile=".tld_set_snapshot", tofile=cached_file):
+            for line in difflib.unified_diff(snapshot, new, fromfile=".tld_set_snapshot", tofile=self.cache_file):
                 if sys.version_info < (3,):
                     sys.stderr.write(line.encode('utf-8') + "\n")
                 else:
                     sys.stderr.write(line + "\n")
 
-        try:
-            with open(cached_file, 'wb') as f:
-                pickle.dump(tlds, f)
-        except IOError as e:
-            LOG.warn("unable to cache TLDs in file %s: %s", cached_file, e)
+        if self.cache_file:
+            try:
+                with open(self.cache_file, 'wb') as f:
+                    pickle.dump(tlds, f)
+            except IOError as e:
+                LOG.warn("unable to cache TLDs in file %s: %s", self.cache_file, e)
 
         self._extractor = _PublicSuffixListTLDExtractor(tlds)
         return self._extractor
@@ -242,19 +274,30 @@ def extract(url):
 def update(*args, **kwargs):
     return TLD_EXTRACTOR.update(*args, **kwargs)
 
-def _fetch_page(url):
+def get_tlds_from_raw_suffix_list_data(suffix_list_source):
+    tld_finder = re.compile(r'^(?P<tld>[.*!]*\w[\S]*)', re.UNICODE | re.MULTILINE)
+    tld_iter = (m.group('tld') for m in tld_finder.finditer(suffix_list_source))
+    return frozenset(tld_iter)
+
+
+def fetch_file(url):
+    """ Fetch the file and decode it from UTF-8 encoding to Python unicode.
+    """
+    conn = urlopen(url)
     try:
-        return unicode(urlopen(url).read(), 'utf-8')
+        s = conn.read()
     except URLError as e:
         LOG.error(e)
-        return u''
+        s = ''
+    return _decode_utf8(s)
 
-def _PublicSuffixListSource():
-    page = _fetch_page('http://mxr.mozilla.org/mozilla-central/source/netwerk/dns/effective_tld_names.dat?raw=1')
+def _decode_utf8(s):
+    """ Decode from utf8 to Python unicode string.
 
-    tld_finder = re.compile(r'^(?P<tld>[.*!]*\w[\S]*)', re.UNICODE | re.MULTILINE)
-    tlds = [m.group('tld') for m in tld_finder.finditer(page)]
-    return tlds
+    The suffix list, wherever its origin, should be UTF-8 encoded.
+    """
+    return unicode(s, 'utf-8')
+
 
 class _PublicSuffixListTLDExtractor(object):
     def __init__(self, tlds):
@@ -280,7 +323,6 @@ class _PublicSuffixListTLDExtractor(object):
 
 
 def main():
-    """docstring for main"""
     import argparse
 
     distribution = pkg_resources.get_distribution('tldextract')


### PR DESCRIPTION
Make changes with the goal of more flexibility when using
`TLDExtract` (i.e. instantiating your own callable, with custom options).

Goal: control of data source & network activity, while maintaining
the nice, clean API.
- Add more tests covering most or all new cases introduced
- No regressions for existing tests
- Update docstring of `tldextract.TLDExtract`
- #38
  - Add `suffix_list_url` kwarg. Allows you to specify
    the location of the Public Suffix List, or anything like
    this file. This is expected to be a UTF-8 encoded text file.
  - Rename keyword argument for TLDExtract from `suffix_list_file` to
    `suffix_list_url`. Update docstring accordingly. This makes it so
    that it is compatible with the `fetch` keyword argument.
  - Add `fallback_to_snapshot` kwarg. Defaults to `True`.
    If disabled, it will NOT use the distributed snapshot
    of the PSL when `tlds` is empty.
  - README += section re: features from #38
- #39
  - Simplification of keyword arguments.
    - `suffix_list_url` for both files and public suffix list url;
      remove `Fetch`. (if you don't want it to fetch, set
      `suffix_list_url` to `False`.)
    - `cache_file` can now be set to something that evaluates to
      `False`, in order to disable caching.
  - Only complain about 1 combination of keyword arguments, where it's
    necessary - and complain on construction, not calling.
  - Update README examples
- #41
  - Address concerns in Pull Request #41.
  - keep `fetch` around; if EITHER `fetch` or `suffix_list_url` are falsey,
    it will disable anything that depends on `suffix_list_url` (i.e.
    pulling in from the net or from local).
    **\* log warning
