### PR TITLE
Catching exceptions when calling .encode and .decode on punycode that isn't punycode

### DIFF
--- a/tldextract/tests/all.py
+++ b/tldextract/tests/all.py
@@ -131,6 +131,11 @@ class ExtractTest(TldextractTestCase):
 
     def test_punycode(self):
         self.assertExtract('', 'xn--h1alffa9f', 'xn--p1ai', 'http://xn--h1alffa9f.xn--p1ai')
+        # Entries that might generate UnicodeError exception
+        # This subdomain generates UnicodeError 'IDNA does not round-trip'
+        self.assertExtract('xn--tub-1m9d15sfkkhsifsbqygyujjrw602gk4li5qqk98aca0w','google', 'com', 'xn--tub-1m9d15sfkkhsifsbqygyujjrw602gk4li5qqk98aca0w.google.com')
+        # This subdomain generates UnicodeError 'incomplete punicode string'
+        self.assertExtract('xn--tub-1m9d15sfkkhsifsbqygyujjrw60','google','com','xn--tub-1m9d15sfkkhsifsbqygyujjrw60.google.com')
 
     def test_empty(self):
         self.assertExtract('', '', '', 'http://')

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -192,9 +192,7 @@ class TLDExtract(object):
             try:
                 netloc = codecs.decode(netloc.encode('ascii'), 'idna')
             except UnicodeError:
-                LOG.warn('UnicodeError when decoding netloc ' + netloc)
-                # We return the answer as it is
-                # We consider this not to be punycode!
+                # We return the answer as it is, not considering the input punycode
                 is_punycode = False
 
         registered_domain, tld = self._get_tld_extractor().extract(netloc)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -192,7 +192,7 @@ class TLDExtract(object):
             try:
                 netloc = codecs.decode(netloc.encode('ascii'), 'idna')
             except UnicodeError:
-                LOG.error('UnicodeError when decoding netloc ' + netloc)
+                LOG.warn('UnicodeError when decoding netloc ' + netloc)
                 # We return the answer as it is
                 # We consider this not to be punycode!
                 is_punycode = False
@@ -200,19 +200,8 @@ class TLDExtract(object):
         registered_domain, tld = self._get_tld_extractor().extract(netloc)
 
         if is_punycode:
-            """
-            If we are here, means that:
-            1) netloc is punycode
-            2) netloc decoded successfully to unicode
-            As such, we'll try to encode the netloc to ascii
-            """
-            try:
-                registered_domain = codecs.encode(registered_domain, 'idna')
-                tld = codecs.encode(tld, 'idna')
-            except UnicodeError:
-                LOG.error('UnicodeError when encoding netloc ' + netloc)
-                # If we get an error here, we give up
-                return ExtractResult('', '', '')
+            registered_domain = codecs.encode(registered_domain, 'idna')
+            tld = codecs.encode(tld, 'idna')
 
         if not tld and netloc and netloc[0].isdigit():
             try:


### PR DESCRIPTION
On line https://github.com/john-kurkowski/tldextract/blob/master/tldextract/tldextract.py#L191 `.encode` or `.decode` should catch at least `UnicodeError`. 

Example bad domain: `xn--tub-test.google.com` :

```
UnicodeError: ('IDNA does not round-trip', 'xn--tub-', 'tub')
```
I don't know exactly why this happens, I think it's something to do with the .decode function, but it's irrelevant to this project. 
