### PR TITLE
On Python 3+, the ExtractResult namedtuples __dict__ attribute was not populated

### DIFF
--- a/tldextract/tests/all.py
+++ b/tldextract/tests/all.py
@@ -206,6 +206,16 @@ class ExtractTestUsingExtraSuffixes(TldextractTestCase):
             self.assertEquals(result.suffix, custom_suffix)
 
 
+class ExtractTestAsDict(TldextractTestCase):
+
+    def test_result_as_dict(self):
+        result = extract("http://admin:password1@www.google.com:666/secret/admin/interface?param1=42")
+        expected_dict = {'subdomain' : 'www',
+                         'domain' : 'google',
+                         'suffix' : 'com'}
+        self.assertEquals(result._asdict(), expected_dict)
+
+
 def test_suite():
     logging.basicConfig()
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -87,6 +87,9 @@ IP_RE = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0
 
 class ExtractResult(collections.namedtuple('ExtractResult', 'subdomain domain suffix')):
 
+    # Necessary for __dict__ member to get populated in Python 3+
+    __slots__ = ()
+
     @property
     def tld(self):
         warnings.warn('This use of tld is misleading. Use `suffix` instead.', DeprecationWarning)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, pypy
+envlist = py26, py27, py33, py34, pypy
 
 [testenv]
 commands = nosetests {posargs:-v tldextract.tests.all}


### PR DESCRIPTION
Fixing that and adding unit test to exercise issue.