### PR TITLE
reflecting new filename, .tld_set_snapshot

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -73,7 +73,7 @@ except ImportError:  # pragma: no cover
 
 LOG = logging.getLogger("tldextract")
 
-CACHE_FILE_DEFAULT = os.path.join(os.path.dirname(__file__), '.tld_set')
+CACHE_FILE_DEFAULT = os.path.join(os.path.dirname(__file__), '.tld_set_snapshot')
 CACHE_FILE = os.path.expanduser(os.environ.get("TLDEXTRACT_CACHE", CACHE_FILE_DEFAULT))
 
 PUBLIC_SUFFIX_LIST_URLS = (


### PR DESCRIPTION
Logger was complaining about this:

WARNING:tldextract:unable to cache TLDs in file /usr/local/lib/python2.7/site-packages/tldextract/.tld_set: [Errno 13] Permission denied: '/usr/local/lib/python2.7/site-packages/tldextract/.tld_set'

Looked at the copy on my localhost to find the file did not exist, but the closest name file was the snapshot file.

Chriss-MacBook-Pro:PcapDiag cswanson$ ls -alh /usr/local/lib/python2.7/site-packages/tldextract/.tld_set
ls: /usr/local/lib/python2.7/site-packages/tldextract/.tld_set: No such file or directory
Chriss-MacBook-Pro:PcapDiag cswanson$ ls -alh /usr/local/lib/python2.7/site-packages/tldextract/.tld*
-rw-r--r--  1 root  admin   124K May 24 22:05 /usr/local/lib/python2.7/site-packages/tldextract/.tld_set_snapshot

Changed tldextract.py locally and verified the fix.