### PR TITLE
Mixed puny

### DIFF
--- a/tldextract/tests/all.py
+++ b/tldextract/tests/all.py
@@ -178,6 +178,9 @@ class ExtractTest(TldextractTestCase):
     def test_private_domains(self):
         self.assertExtract('waiterrant', 'blogspot', 'com', 'http://waiterrant.blogspot.com')
 
+    def test_invalid_puny_with_puny(self):
+        self.assertExtract('xn--zckzap6140b352by.blog', 'so-net', 'xn--wcvs22d.hk', 'http://xn--zckzap6140b352by.blog.so-net.xn--wcvs22d.hk')
+
 
 class ExtractTestUsingCustomSuffixListFile(TldextractTestCase):
 

--- a/tldextract/tests/all.py
+++ b/tldextract/tests/all.py
@@ -181,6 +181,9 @@ class ExtractTest(TldextractTestCase):
     def test_invalid_puny_with_puny(self):
         self.assertExtract('xn--zckzap6140b352by.blog', 'so-net', 'xn--wcvs22d.hk', 'http://xn--zckzap6140b352by.blog.so-net.xn--wcvs22d.hk')
 
+    def test_puny_with_non_puny(self):
+        self.assertExtract('xn--zckzap6140b352by.blog', 'so-net', u'教育.hk', u'http://xn--zckzap6140b352by.blog.so-net.教育.hk')
+
 
 class ExtractTestUsingCustomSuffixListFile(TldextractTestCase):
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -189,14 +189,19 @@ class TLDExtract(object):
             .partition(":")[0] \
             .rstrip(".")
 
-        is_punycode = netloc.startswith('xn--') or '.xn--' in netloc
-        # Some IDN urls might generate an error
-        if is_punycode:
-            try:
-                netloc = codecs.decode(netloc.encode('ascii'), 'idna')
-            except UnicodeError:
-                # We return the answer as it is, not considering the input punycode
-                is_punycode = False
+        unicode_labels = []
+        is_punycode = False
+        for label in netloc.split("."):
+            tmp_is_punycode = netloc.startswith('xn--')
+            if tmp_is_punycode:
+                try:
+                    label = codecs.decode(label.encode('ascii'), 'idna')
+                    is_punycode = True
+                except UnicodeError:
+                    pass
+
+            unicode_labels.append(label)
+        netloc = ".".join(unicode_labels)
 
         registered_domain, tld = self._get_tld_extractor().extract(netloc)
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -340,24 +340,6 @@ def _decode_utf8(s):
     return unicode(s, 'utf-8')
 
 
-def merge_to_puny(unicode_labels, puny_index):
-    """ Joins the unicode list with "." sepearators but first converts any
-    unicode label to puny if it's corresponding puny index is True
-
-    >>> merge_to_puny(
-    ...     [u"\u7e54\u572d\u30c6\u30cb\u30b9", u"blog", u"so-net",
-    ...      u"\u7e54\u572d\u30c6\u30cb", "jp"],
-    ...     [True, False, False, False, False])
-    u'xn--zckzap6140b352b.blog.so-net.\u7e54\u572d\u30c6\u30cb.jp'
-    """
-    puny_labels = []
-    for unicode_label, is_puny in zip(unicode_labels, puny_index):
-        if is_puny:
-            unicode_label = codecs.encode(unicode_label, 'idna').decode('utf-8')
-        puny_labels.append(unicode_label)
-    return ".".join(puny_labels)
-
-
 class _PublicSuffixListTLDExtractor(object):
 
     def __init__(self, tlds):
@@ -381,13 +363,6 @@ class _PublicSuffixListTLDExtractor(object):
                 return i
 
         return len(lower_spl)
-
-    def extract(self, netloc):
-        spl = netloc.split('.')
-        lower_spl = tuple(el.lower() for el in spl)
-        suffix_index = self.suffix_index(lower_spl)
-
-        return ".".join(spl[:suffix_index]), ".".join(spl[suffix_index:])
 
 
 def main():


### PR DESCRIPTION
I'm not sure if you want this in the code base. It came to mind so I thought I'd write the code and then open a dialog with you.

Take the following url for example, xn--zckzap6140b352b.blog.so-net.大分.jp. The code would currently convert all of it to unicode, then convert all of it back to puny causing the unicode text to not be returned the way it was presented. Keeping an index on the labels that were originally puny code takes care of this.

This pull request includes the other pull request I submitted as there was no way to do this one without the other.