### PR TITLE
convert bytes to str for StringIO

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -371,7 +371,7 @@ def fetch_file(urls):
         try:
             response = urlopen(url)
             if response.info().get('Content-Encoding') == 'gzip':
-                buf = StringIO(response.read())
+                buf = StringIO(str(response.read()))
                 gzip_response = gzip.GzipFile(fileobj=buf)
                 text = gzip_response.read()
             else:


### PR DESCRIPTION
In Python3 the result of HTTPResponse.read() is of type bytes. StringIO cannot
handle this, it will throw the error: TypeError: initial_value must be str or
None, not bytes. This commit fixes this behaviour.