### PR TITLE
Unpin the requests library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
+env:
+  - REQUESTS_VERSION=2.2.1
+  - REQUESTS_VERSION=2.8.1
+  - REQUESTS_VERSION=2.9.1
 python:
   - "2.6"
   - "2.7"
@@ -8,4 +12,5 @@ python:
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6* ]]; then export PYTEST_ADDOPTS='-p no:pylint'; fi
   - pip install -r requirements.txt
+  - pip install --upgrade --force-reinstall requests==$REQUESTS_VERSION
 script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-  - REQUESTS_VERSION=2.2.1
+  - REQUESTS_VERSION=2.1.0
   - REQUESTS_VERSION=2.8.1
   - REQUESTS_VERSION=2.9.1
 python:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pytest==2.7.3
 pytest-gitignore==1.3
 pytest-mock==0.9.0
 pytest-pylint==0.4.0
-requests
+requests>=2.1.0
 requests-file>=1.4
 tox==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ pytest==2.7.3
 pytest-gitignore==1.3
 pytest-mock==0.9.0
 pytest-pylint==0.4.0
-requests>=2.9.1,<3
+requests
 requests-file>=1.4
 tox==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 LONG_DESCRIPTION_MD = __doc__
 LONG_DESCRIPTION = re.sub(r'(?s)\[(.*?)\]\((http.*?)\)', r'\1', LONG_DESCRIPTION_MD)
 
-INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.9.1,<3", "requests-file>=1.4"]
+INSTALL_REQUIRES = ["setuptools", "idna", "requests", "requests-file>=1.4"]
 if (2, 7) > sys.version_info:
     INSTALL_REQUIRES.append("argparse>=1.2.1")
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ from setuptools import setup
 LONG_DESCRIPTION_MD = __doc__
 LONG_DESCRIPTION = re.sub(r'(?s)\[(.*?)\]\((http.*?)\)', r'\1', LONG_DESCRIPTION_MD)
 
-INSTALL_REQUIRES = ["setuptools", "idna", "requests", "requests-file>=1.4"]
+INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.1.0", "requests-file>=1.4"]
 if (2, 7) > sys.version_info:
     INSTALL_REQUIRES.append("argparse>=1.2.1")
 


### PR DESCRIPTION
Hi all,

Is pinning requests>2.9.1,<3 necessary? We have a few packages that rely on both tldextract and requests 2.2 (long story), and we're getting version conflicts because of it.

I ran the test suite with requests 2.2.1, requests 2.8.1, and requests 2.9.1 and they all pass.

Related to #89 