### PR TITLE
Add LICENSE to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include tldextract/.tld_set_snapshot
+include LICENSE
 recursive-include tests *.py *.dat


### PR DESCRIPTION
I'm building a version of `tldextract` using [`conda`](http://conda.pydata.org) for [conda-forge](http://conda-forge.github.io). When possible, we try to include a link to the license file in the `meta.yaml` specification. Doing so requires the LICENSE be linked in the manifest file.