### PR TITLE
ipv4 suggestion

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -78,6 +78,7 @@ except ImportError:
 from .remote import find_first_response
 from .remote import looks_like_ip
 from .remote import SCHEME_RE
+from .remote import IP_RE
 
 # pylint: disable=invalid-name,undefined-variable
 try:
@@ -133,6 +134,24 @@ class ExtractResult(collections.namedtuple('ExtractResult', 'subdomain domain su
         if self.domain and self.suffix:
             # self is the namedtuple (subdomain domain suffix)
             return '.'.join(i for i in self if i)
+        return ''
+
+    @property
+    def ipv4(self):
+        """
+        Returns the ipv4 if that is what the presented domain/url is
+
+        >>> extract('http://127.0.0.1/path/to/file').ipv4
+        '127.0.0.1'
+        >>> extract('http://127.0.0.1.1/path/to/file').ipv4
+        ''
+        >>> extract('http://256.1.1.1').ipv4
+        ''
+        """
+        if not self.suffix and not self.subdomain:
+            if IP_RE.match(self.domain):
+                return self.domain
+            return ''
         return ''
 
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -148,10 +148,8 @@ class ExtractResult(collections.namedtuple('ExtractResult', 'subdomain domain su
         >>> extract('http://256.1.1.1').ipv4
         ''
         """
-        if not self.suffix and not self.subdomain:
-            if IP_RE.match(self.domain):
-                return self.domain
-            return ''
+        if not (self.suffix or self.subdomain) and IP_RE.match(self.domain):
+            return self.domain
         return ''
 
 


### PR DESCRIPTION
This is regarding the proposal in https://github.com/john-kurkowski/tldextract/issues/128

It simply uses the ipv4 regex.

This should also explain why I reorganized the tests... `expected` was renamed `expected_domain_data` and `expected_ip_data` was added.  this will make tests for extending to ipv6 a lot easier if/when needed.