### PR TITLE
Fix narrow python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 After upgrading, update your cache file by deleting it or via `tldextract
 --update`.
 
+## 2.1.1 (?)
+
+* Bugfixes
+    * Basic support for 'narrow' Python2 builds ([#122](https://github.com/john-kurkowski/tldextract/issues/122))
+
 ## 2.1.0 (2017-05-24)
 
 * Features

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -216,3 +216,19 @@ def test_result_as_dict():
                      'domain': 'google',
                      'suffix': 'com'}
     assert result._asdict() == expected_dict
+
+
+def test_punycode_extended():
+    """
+    "narrow python" builds may break on certain unicode characters
+    see https://github.com/john-kurkowski/tldextract/issues/122
+    """
+    # this one breaks on narrow python, needs the bypass
+    assert_extract('xn--vi8hiv.ws',
+                   ('xn--vi8hiv.ws', '', 'xn--vi8hiv', 'ws'))
+
+    # these two are the same domain, different representations
+    assert_extract(u'http://➡.ws/♥',
+                   (u'➡.ws', '', u'\u27a1', 'ws'))
+    assert_extract('http://\xe2\x9e\xa1.ws/\xe2\x99\xa5',
+                   ('\xe2\x9e\xa1.ws', '', '\xe2\x9e\xa1', 'ws'))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -124,11 +124,11 @@ def test_puny_with_non_puny():
 def test_punycode_narrow_python():
     """
     see https://github.com/john-kurkowski/tldextract/issues/122
-    
+
     Python2 through 3.3 stores unicode data as either UCS-2 (roughly UTF-16)
     or UCS-4 (UTF-32). The default storage format was UCS-2; supporting UCS-4
     requires compiling Python with extended support using this configure option:
-    
+
         ./configure --enable-unicode=ucs4
 
     The max unicode point is available by the variable `sys.maxunicode`
@@ -136,9 +136,17 @@ def test_punycode_narrow_python():
     'narrow' Python27 builds will raise exceptions on unicode characters that are
     outside the UCS-2 range. Python3.3+ handles Unicode differently (see PEP-393)
 
-    This test (& fix offered in PR#130) is a punycoded domain name with a 
+    This test (& fix offered in PR#130) is a punycoded domain name with a
     "wide" unicode character.  No change should be determined in 3.3+ builds;
     narrow builds will simply not have the domain decoded.
+
+    This test is redundant on wide builds, and only exists for testing support
+    against narrow builds.  If one has a "narrow" Python build (the default for
+    python through 3.3), the punycode decoding would raise an Exception when
+    encountering a UTF-16 character in earlier versions of this package. The
+    current expected behavior is to catcht the decoding error and leave it as
+    punycode (which is the same behavior in this library for other unicode
+    exceptions).
     """
     assert_extract('xn--vi8hiv.ws',
                    ('xn--vi8hiv.ws', '', 'xn--vi8hiv', 'ws'))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -121,6 +121,29 @@ def test_puny_with_non_puny():
                     'xn--zckzap6140b352by.blog', 'so-net', u'教育.hk'))
 
 
+def test_punycode_narrow_python():
+    """
+    see https://github.com/john-kurkowski/tldextract/issues/122
+    
+    Python2 through 3.3 stores unicode data as either UCS-2 (roughly UTF-16)
+    or UCS-4 (UTF-32). The default storage format was UCS-2; supporting UCS-4
+    requires compiling Python with extended support using this configure option:
+    
+        ./configure --enable-unicode=ucs4
+
+    The max unicode point is available by the variable `sys.maxunicode`
+
+    'narrow' Python27 builds will raise exceptions on unicode characters that are
+    outside the UCS-2 range. Python3.3+ handles Unicode differently (see PEP-393)
+
+    This test (& fix offered in PR#130) is a punycoded domain name with a 
+    "wide" unicode character.  No change should be determined in 3.3+ builds;
+    narrow builds will simply not have the domain decoded.
+    """
+    assert_extract('xn--vi8hiv.ws',
+                   ('xn--vi8hiv.ws', '', 'xn--vi8hiv', 'ws'))
+
+
 def test_idna_2008():
     """Python supports IDNA 2003.
     The IDNA library adds 2008 support for characters like ß.
@@ -216,19 +239,3 @@ def test_result_as_dict():
                      'domain': 'google',
                      'suffix': 'com'}
     assert result._asdict() == expected_dict
-
-
-def test_punycode_extended():
-    """
-    "narrow python" builds may break on certain unicode characters
-    see https://github.com/john-kurkowski/tldextract/issues/122
-    """
-    # this one breaks on narrow python, needs the bypass
-    assert_extract('xn--vi8hiv.ws',
-                   ('xn--vi8hiv.ws', '', 'xn--vi8hiv', 'ws'))
-
-    # these two are the same domain, different representations
-    assert_extract(u'http://➡.ws/♥',
-                   (u'➡.ws', '', u'\u27a1', 'ws'))
-    assert_extract('http://\xe2\x9e\xa1.ws/\xe2\x99\xa5',
-                   ('\xe2\x9e\xa1.ws', '', '\xe2\x9e\xa1', 'ws'))

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -229,7 +229,7 @@ class TLDExtract(object):
         labels = netloc.split(".")
 
         def decode_punycode(label):
-            """helper function"""
+            """helper function; decodes a section of the netloc from punycode."""
             if label.startswith("xn--"):
                 try:
                     return idna.decode(label.encode('ascii'))


### PR DESCRIPTION
This is a lightweight attempt to handle the "narrow Python build" I mentioned in #122

If a ValueError is detected, it looks in the exception message (Py2 and Py3 compliant) to see if the 'narrow Python build' warning is detected.  If so, it emits the message as a `warning` and returns the label unaltered.

I only put the docstring on `decode_punycode` to pass tests.