### PR TITLE
Returns the registered domain in lowercase

### DIFF
--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -110,15 +110,17 @@ class ExtractResult(collections.namedtuple('ExtractResult', 'subdomain domain su
     @property
     def registered_domain(self):
         """
-        Joins the domain and suffix fields with a dot, if they're both set.
+        Creates a new string Joins the domain and suffix fields with a dot, if they're both set.
 
         >>> extract('http://forums.bbc.co.uk').registered_domain
         'bbc.co.uk'
         >>> extract('http://localhost:8080').registered_domain
         ''
+        >>> extract('http://cdn.dev.BrwnPpr.com').registered_domain
+        'brwnppr.com'
         """
         if self.domain and self.suffix:
-            return self.domain + '.' + self.suffix
+            return '{domain}.{suffix}'.format(domain=self.domain, suffix=self.suffix, ).lower()
         return ''
 
     @property

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -110,7 +110,7 @@ class ExtractResult(collections.namedtuple('ExtractResult', 'subdomain domain su
     @property
     def registered_domain(self):
         """
-        Creates a new string, containing the the domain (in lowercase), a dot and 
+        Creates a new string, containing the the domain (in lowercase), a dot and
         the suffix (in lowercase) when both domain and suffix are set. Returns an
         empty string otherwise
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -110,7 +110,9 @@ class ExtractResult(collections.namedtuple('ExtractResult', 'subdomain domain su
     @property
     def registered_domain(self):
         """
-        Creates a new string Joins the domain and suffix fields with a dot, if they're both set.
+        Creates a new string, containing the the domain (in lowercase), a dot and 
+        the suffix (in lowercase) when both domain and suffix are set. Returns an
+        empty string otherwise
 
         >>> extract('http://forums.bbc.co.uk').registered_domain
         'bbc.co.uk'


### PR DESCRIPTION
Thanks for building and maintaining this incredibly useful module.

I added a small update to `registered_domain`, returning the value in lowercase. I ran into a potential issue when comparing user provided input provided. I verified this PR on Python 2.7 