### PR TITLE
Fix __init__.py when pkg_resources is missing

### DIFF
--- a/tldextract/__init__.py
+++ b/tldextract/__init__.py
@@ -1,13 +1,4 @@
 """Export tldextract's public interface."""
 
-import os
-
-try:
-    import pkg_resources
-    __version__ = pkg_resources.get_distribution('tldextract').version  # pylint: disable=no-member
-except ImportError:
-    __version__ = '(local)'
-except pkg_resources.DistributionNotFound:
-    __version__ = '(local)'
-
+from .cli import __version__
 from .tldextract import extract, TLDExtract

--- a/tldextract/__init__.py
+++ b/tldextract/__init__.py
@@ -11,4 +11,3 @@ except pkg_resources.DistributionNotFound:
     __version__ = '(local)'
 
 from .tldextract import extract, TLDExtract
-

--- a/tldextract/__init__.py
+++ b/tldextract/__init__.py
@@ -1,5 +1,7 @@
 """Export tldextract's public interface."""
 
+import os
+
 try:
     import pkg_resources
 except ImportError:

--- a/tldextract/__init__.py
+++ b/tldextract/__init__.py
@@ -4,21 +4,11 @@ import os
 
 try:
     import pkg_resources
+    __version__ = pkg_resources.get_distribution('tldextract').version  # pylint: disable=no-member
 except ImportError:
-    class pkg_resources(object):  # pylint: disable=invalid-name
-
-        """Fake pkg_resources interface which falls back to getting resources
-        inside `tldextract`'s directory.
-        """
-        @classmethod
-        def resource_stream(cls, _, resource_name):
-            moddir = os.path.dirname(__file__)
-            path = os.path.join(moddir, resource_name)
-            return open(path)
+    __version__ = '(local)'
+except pkg_resources.DistributionNotFound:
+    __version__ = '(local)'
 
 from .tldextract import extract, TLDExtract
 
-try:
-    __version__ = pkg_resources.get_distribution('tldextract').version  # pylint: disable=no-member
-except pkg_resources.DistributionNotFound as _:
-    __version__ = '(local)'

--- a/tldextract/__init__.py
+++ b/tldextract/__init__.py
@@ -1,6 +1,18 @@
 """Export tldextract's public interface."""
 
-import pkg_resources
+try:
+    import pkg_resources
+except ImportError:
+    class pkg_resources(object):  # pylint: disable=invalid-name
+
+        """Fake pkg_resources interface which falls back to getting resources
+        inside `tldextract`'s directory.
+        """
+        @classmethod
+        def resource_stream(cls, _, resource_name):
+            moddir = os.path.dirname(__file__)
+            path = os.path.join(moddir, resource_name)
+            return open(path)
 
 from .tldextract import extract, TLDExtract
 

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -3,6 +3,14 @@
 
 import logging
 
+try:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution('tldextract').version  # pylint: disable=no-member
+except ImportError:
+    __version__ = '(local)'
+except pkg_resources.DistributionNotFound:
+    __version__ = '(local)'
+
 from .tldextract import TLDExtract
 
 try:
@@ -16,14 +24,6 @@ def main():
     import argparse
 
     logging.basicConfig()
-
-    try:
-        import pkg_resources
-        __version__ = pkg_resources.get_distribution('tldextract').version  # pylint: disable=no-member
-    except ImportError:
-        __version__ = '(local)'
-    except pkg_resources.DistributionNotFound:
-        __version__ = '(local)'
 
     parser = argparse.ArgumentParser(
         prog='tldextract',

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -2,7 +2,6 @@
 
 
 import logging
-import pkg_resources
 
 from .tldextract import TLDExtract
 
@@ -19,8 +18,11 @@ def main():
     logging.basicConfig()
 
     try:
+        import pkg_resources
         __version__ = pkg_resources.get_distribution('tldextract').version  # pylint: disable=no-member
-    except pkg_resources.DistributionNotFound as _:
+    except ImportError:
+        __version__ = '(local)'
+    except pkg_resources.DistributionNotFound:
         __version__ = '(local)'
 
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
Simply copied the `pkg_resources` fake fallback from `tldextract.py` into `__init__.py` to prevent failure if `pkg_resources` is missing.