### PR TITLE
Allow setting timeouts for public suffix list downloads

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 '''Main tldextract unit tests.'''
 
+import sys
+
 import responses
 import tldextract
 from .helpers import temporary_file
+if sys.version_info >= (3,):  # pragma: no cover
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
 
 # pylint: disable=invalid-name
@@ -219,11 +223,11 @@ def test_result_as_dict():
     assert result._asdict() == expected_dict
 
 
-@responses.activate # pylint: disable=no-member
+@responses.activate  # pylint: disable=no-member
 def test_cache_timeouts():
     server = 'http://some-server.com'
-    responses.add( # pylint: disable=no-member
-        responses.GET, # pylint: disable=no-member
+    responses.add(  # pylint: disable=no-member
+        responses.GET,  # pylint: disable=no-member
         server,
         status=408
     )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 '''Main tldextract unit tests.'''
 
+import responses
 import tldextract
 from .helpers import temporary_file
 
@@ -216,3 +217,15 @@ def test_result_as_dict():
                      'domain': 'google',
                      'suffix': 'com'}
     assert result._asdict() == expected_dict
+
+
+@responses.activate # pylint: disable=no-member
+def test_cache_timeouts():
+    server = 'http://some-server.com'
+    responses.add( # pylint: disable=no-member
+        responses.GET, # pylint: disable=no-member
+        server,
+        status=408
+    )
+
+    assert tldextract.remote.find_first_response([server], 5) == unicode('')

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -161,7 +161,7 @@ class TLDExtract(object):
     # TODO: Agreed with Pylint: too-many-arguments
     def __init__(self, cache_file=CACHE_FILE, suffix_list_urls=PUBLIC_SUFFIX_LIST_URLS,  # pylint: disable=too-many-arguments
                  fallback_to_snapshot=True, include_psl_private_domains=False, extra_suffixes=(),
-                 cache_fetch_timeout=None):
+                 cache_fetch_timeout=CACHE_TIMEOUT):
         """
         Constructs a callable for extracting subdomain, domain, and suffix
         components from a URL.
@@ -218,18 +218,17 @@ class TLDExtract(object):
         self.extra_suffixes = extra_suffixes
         self._extractor = None
 
-        self.cache_fetch_timeout = None
-        if CACHE_TIMEOUT is not None:
+        self.cache_fetch_timeout = cache_fetch_timeout
+        if not isinstance(self.cache_fetch_timeout, (tuple, float,)):
             try:
-                self.cache_fetch_timeout = float(CACHE_TIMEOUT)
-            except ValueError:
+                self.cache_fetch_timeout = float(self.cache_fetch_timeout)
+            except (ValueError, TypeError):
                 LOG.error(
-                    'EnvVar TLDEXTRACT_CACHE_TIMEOUT is not a float: %s.'
-                    ' Defaulting to no timeout.',
-                    CACHE_TIMEOUT
+                    'invalid cache timeout specified (%s). Defaulting to None',
+                    self.cache_fetch_timeout,
+                    exc_info=True
                 )
-        else:
-            self.cache_fetch_timeout = cache_fetch_timeout
+
 
     def __call__(self, url):
         """

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -92,6 +92,7 @@ LOG = logging.getLogger("tldextract")
 
 CACHE_FILE_DEFAULT = os.path.join(os.path.dirname(__file__), '.tld_set')
 CACHE_FILE = os.path.expanduser(os.environ.get("TLDEXTRACT_CACHE", CACHE_FILE_DEFAULT))
+CACHE_TIMEOUT = os.environ.get('TLDEXTRACT_CACHE_TIMEOUT')
 
 PUBLIC_SUFFIX_LIST_URLS = (
     'https://publicsuffix.org/list/public_suffix_list.dat',
@@ -159,7 +160,8 @@ class TLDExtract(object):
 
     # TODO: Agreed with Pylint: too-many-arguments
     def __init__(self, cache_file=CACHE_FILE, suffix_list_urls=PUBLIC_SUFFIX_LIST_URLS,  # pylint: disable=too-many-arguments
-                 fallback_to_snapshot=True, include_psl_private_domains=False, extra_suffixes=()):
+                 fallback_to_snapshot=True, include_psl_private_domains=False, extra_suffixes=(),
+                 cache_fetch_timeout=None):
         """
         Constructs a callable for extracting subdomain, domain, and suffix
         components from a URL.
@@ -189,6 +191,18 @@ class TLDExtract(object):
         included instead, set `include_psl_private_domains` to True.
 
         You can pass additional suffixes in `extra_suffixes` argument without changing list URL
+
+        cache_fetch_timeout is passed unmodified to the underlying request object
+        per the requests documentation here:
+        http://docs.python-requests.org/en/master/user/advanced/#timeouts
+
+        cache_fetch_timeout can also be set to a single value with the
+        environment variable TLDEXTRACT_CACHE_TIMEOUT, like so:
+
+        TLDEXTRACT_CACHE_TIMEOUT="1.2"
+
+        When set this way, the same timeout value will be used for both connect
+        and read timeouts
         """
         suffix_list_urls = suffix_list_urls or ()
         self.suffix_list_urls = tuple(url.strip() for url in suffix_list_urls if url.strip())
@@ -203,6 +217,19 @@ class TLDExtract(object):
         self.include_psl_private_domains = include_psl_private_domains
         self.extra_suffixes = extra_suffixes
         self._extractor = None
+
+        self.cache_fetch_timeout = None
+        if CACHE_TIMEOUT is not None:
+            try:
+                self.cache_fetch_timeout = float(CACHE_TIMEOUT)
+            except ValueError:
+                LOG.error(
+                    'EnvVar TLDEXTRACT_CACHE_TIMEOUT is not a float: %s.'
+                    ' Defaulting to no timeout.',
+                    CACHE_TIMEOUT
+                )
+        else:
+            self.cache_fetch_timeout = cache_fetch_timeout
 
     def __call__(self, url):
         """
@@ -275,7 +302,10 @@ class TLDExtract(object):
             self._extractor = _PublicSuffixListTLDExtractor(tlds)
             return self._extractor
         elif self.suffix_list_urls:
-            raw_suffix_list_data = find_first_response(self.suffix_list_urls)
+            raw_suffix_list_data = find_first_response(
+                self.suffix_list_urls,
+                self.cache_fetch_timeout
+            )
             tlds = get_tlds_from_raw_suffix_list_data(
                 raw_suffix_list_data,
                 self.include_psl_private_domains

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -229,7 +229,6 @@ class TLDExtract(object):
                     exc_info=True
                 )
 
-
     def __call__(self, url):
         """
         Takes a string URL and splits it into its subdomain, domain, and

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -219,15 +219,8 @@ class TLDExtract(object):
         self._extractor = None
 
         self.cache_fetch_timeout = cache_fetch_timeout
-        if not isinstance(self.cache_fetch_timeout, (tuple, float,)):
-            try:
-                self.cache_fetch_timeout = float(self.cache_fetch_timeout)
-            except (ValueError, TypeError):
-                LOG.error(
-                    'invalid cache timeout specified (%s). Defaulting to None',
-                    self.cache_fetch_timeout,
-                    exc_info=True
-                )
+        if isinstance(self.cache_fetch_timeout, STRING_TYPE):
+            self.cache_fetch_timeout = float(self.cache_fetch_timeout)
 
     def __call__(self, url):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest-gitignore
     pytest-mock
     pytest-pylint
+    responses
 
     py{27,33,34,35,36,py}-requests-current: requests
     py{27,33,34,35,36,py}-requests-2.1.0: requests==2.1.0


### PR DESCRIPTION
Heya!

We've been working with some apps that use tldextract to initialize some things at startup time. We recently put these apps in a datacenter that doesn't have much access to the outside world. Then when tldextract tries to reach out for refreshed publix suffix lists, the apps hang indefinitely since the requests never go through.

We'll probably end up solving our specific problem by supplying a cache file and setting `TLDEXTRACT_CACHE` per the docs, but it seems like the kind of problem where being able to set a timeout would be beneficial.

Would you be interested in pursuing something like this?

Thanks!