### PR TITLE
Fixed concurrent access to cache file

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -358,7 +358,7 @@ max-statements=50
 max-parents=7
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=1


### PR DESCRIPTION
An error occures when tldextract is used with multithreading. Some threads try to write the cache file while some threads try to read it. Putting a lock on the read/write operation fixed this issue.