### PR TITLE
Add option to update TLDs list over proxy

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -3,6 +3,7 @@
 
 import sys
 
+import requests
 import responses
 import tldextract
 from .helpers import temporary_file
@@ -233,3 +234,19 @@ def test_cache_timeouts():
     )
 
     assert tldextract.remote.find_first_response([server], 5) == unicode('')
+
+
+def test_update_proxies(mocker):
+    mock_request = mocker.patch('requests.sessions.Session.request',
+                                return_value=requests.models.Response())
+
+    # Without proxies
+    extract_no_cache.update(fetch_now=True, proxies={})
+    assert mock_request.call_count == 1
+    assert mock_request.call_args.proxies == {}
+
+    # With proxies
+    proxies = {'https': 'https://www.example.proxy:123'}
+    extract_no_cache.update(fetch_now=True, proxies=proxies)
+    assert mock_request.call_count == 2
+    assert mock_request.call_args.proxies == proxies

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -243,10 +243,10 @@ def test_update_proxies(mocker):
     # Without proxies
     extract_no_cache.update(fetch_now=True, proxies={})
     assert mock_request.call_count == 1
-    assert mock_request.call_args.proxies == {}
+    assert mock_request.call_args[1]['proxies'] == {}
 
     # With proxies
     proxies = {'https': 'https://www.example.proxy:123'}
     extract_no_cache.update(fetch_now=True, proxies=proxies)
     assert mock_request.call_count == 2
-    assert mock_request.call_args.proxies == proxies
+    assert mock_request.call_args[1]['proxies'] == proxies

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -24,7 +24,7 @@ SCHEME_RE = re.compile(r'^([' + scheme_chars + ']+:)?//')
 LOG = logging.getLogger('tldextract')
 
 
-def find_first_response(urls, cache_fetch_timeout=None):
+def find_first_response(urls, cache_fetch_timeout=None, proxies=None):
     """ Decode the first successfully fetched URL, from UTF-8 encoding to
     Python unicode.
     """
@@ -33,7 +33,7 @@ def find_first_response(urls, cache_fetch_timeout=None):
 
         for url in urls:
             try:
-                text = session.get(url, timeout=cache_fetch_timeout).text
+                text = session.get(url, timeout=cache_fetch_timeout, proxies=proxies).text
             except requests.exceptions.RequestException:
                 LOG.exception(
                     'Exception reading Public Suffix List url %s',

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -264,18 +264,18 @@ class TLDExtract(object):
         subdomain, _, domain = registered_domain.rpartition('.')
         return ExtractResult(subdomain, domain, suffix)
 
-    def update(self, fetch_now=False):
+    def update(self, fetch_now=False, proxies=None):
         if os.path.exists(self.cache_file):
             os.unlink(self.cache_file)
         self._extractor = None
         if fetch_now:
-            self._get_tld_extractor()
+            self._get_tld_extractor(proxies)
 
     @property
     def tlds(self):
         return self._get_tld_extractor().tlds
 
-    def _get_tld_extractor(self):
+    def _get_tld_extractor(self, proxies=None):
         '''Get or compute this object's TLDExtractor. Looks up the TLDExtractor
         in roughly the following order, based on the settings passed to
         __init__:
@@ -295,7 +295,8 @@ class TLDExtract(object):
         elif self.suffix_list_urls:
             raw_suffix_list_data = find_first_response(
                 self.suffix_list_urls,
-                self.cache_fetch_timeout
+                self.cache_fetch_timeout,
+                proxies=proxies
             )
             tlds = get_tlds_from_raw_suffix_list_data(
                 raw_suffix_list_data,


### PR DESCRIPTION
I am in a scenario where the Internet can only be accessed over a proxy, yet that proxy is not meant to be in env. vars.
This PR adds option to update the TLDs over a proxy, without unnecessarily cluttering the main class initializer with proxies.