### PR TITLE
Use Markdown as long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,8 @@ By default, this package supports the public ICANN TLDs and their exceptions.
 You can optionally support the Public Suffix List's private domains as well.
 """
 
-import re
 import sys
 from setuptools import setup
-
-# I don't want to learn reStructuredText right now, so strip Markdown links
-# that make pip barf.
-LONG_DESCRIPTION_MD = __doc__
-LONG_DESCRIPTION = re.sub(r'(?s)\[(.*?)\]\((http.*?)\)', r'\1', LONG_DESCRIPTION_MD)
 
 INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.1.0", "requests-file>=1.4"]
 if (2, 7) > sys.version_info:
@@ -53,7 +47,8 @@ setup(
     url="https://github.com/john-kurkowski/tldextract",
     packages=['tldextract'],
     include_package_data=True,
-    long_description=LONG_DESCRIPTION,
+    long_description=__doc__,
+    long_description_content_type="text/markdown",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",


### PR DESCRIPTION
The good news is now that the new PyPI (aka Warehouse) has been released, Markdown is supported.

More info and examples:

* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
* https://pypi.org/project/markdown-description-example/
