### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,6 +9,6 @@ collect_ignore = ('setup.py',)
 # pylint: enable=invalid-name
 
 def pytest_cmdline_preparse(args):
-    is_pylint_compatible = (2, 7) <= sys.version_info < (3, 6)
+    is_pylint_compatible = sys.version_info < (3, 6)
     if not is_pylint_compatible:
         args.remove('--pylint')

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     packages=['tldextract'],
     include_package_data=True,
     long_description=LONG_DESCRIPTION,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Topic :: Utilities",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ You can optionally support the Public Suffix List's private domains as well.
 """
 
 import re
-import sys
 from setuptools import setup
 
 # I don't want to learn reStructuredText right now, so strip Markdown links
@@ -35,8 +34,6 @@ LONG_DESCRIPTION_MD = __doc__
 LONG_DESCRIPTION = re.sub(r'(?s)\[(.*?)\]\((http.*?)\)', r'\1', LONG_DESCRIPTION_MD)
 
 INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.1.0", "requests-file>=1.4"]
-if (2, 7) > sys.version_info:
-    INSTALL_REQUIRES.append("argparse>=1.2.1")
 
 setup(
     name="tldextract",
@@ -59,7 +56,6 @@ setup(
         "Topic :: Utilities",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,13 @@ You can optionally support the Public Suffix List's private domains as well.
 """
 
 import re
+import sys
 from setuptools import setup
+
+if sys.version_info < (2, 7):
+    raise RuntimeError("Python 2.6 is EOL and no longer supported. "
+                       "Please upgrade your Python or use an older "
+                       "version of tldextract.")
 
 # I don't want to learn reStructuredText right now, so strip Markdown links
 # that make pip barf.


### PR DESCRIPTION
Python 2.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

It's also little used.

Here's the pip installs for `tldextract` from PyPI for May 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  65.11% |         76,370 |
| 3.6            |  14.82% |         17,386 |
| 3.5            |  14.82% |         17,378 |
| 3.4            |   5.16% |          6,050 |
| 3.7            |   0.07% |             84 |
| 2.6            |   0.02% |             23 |
| 3.3            |   0.00% |              1 |
| Total          |         |        117,292 |

Source: `pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown tldextract pyversion`