### PR TITLE
Fix ContextualVersionConflict Requirement.parse('idna<2.9,>=2.5'), {'requests'})

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.version_info < (3, 5) and not (
         "version of tldextract." % (sys.version_info[0], sys.version_info[1])
     )
 
-INSTALL_REQUIRES = ["setuptools", "idna", "requests>=2.1.0", "requests-file>=1.4"]
+INSTALL_REQUIRES = ["setuptools", "idna<2.9", "requests>=2.1.0", "requests-file>=1.4"]
 
 setup(
     name="tldextract",


### PR DESCRIPTION
Running python packages via cli enforce correct environment, hence when requiring tldextract, this error occurs:
```
pkg_resources.ContextualVersionConflict: (idna 2.9 (/usr/local/lib/python3.7/site-packages), Requirement.parse('idna<2.9,>=2.5'), {'requests'})
```

So unless tldextract constrains idna, pips greedy algorithm will install idna 2.9 in a fresh environment despite the underlying constraint from requests (ref https://github.com/pypa/pip/issues/988). 

```
$ pipgrip --tree tldextract 'idna<2.9'

tldextract (2.2.2)
├── idna (2.8)
├── requests-file>=1.4 (1.4.3)
│   ├── requests>=1.0.0 (2.22.0)
│   │   ├── certifi>=2017.4.17 (2019.11.28)
│   │   ├── chardet<3.1.0,>=3.0.2 (3.0.4)
│   │   ├── idna<2.9,>=2.5 (2.8)
│   │   └── urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (1.25.8)
│   └── six (1.14.0)
├── requests>=2.1.0 (2.22.0)
│   ├── certifi>=2017.4.17 (2019.11.28)
│   ├── chardet<3.1.0,>=3.0.2 (3.0.4)
│   ├── idna<2.9,>=2.5 (2.8)
│   └── urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 (1.25.8)
└── setuptools (45.2.0)
idna<2.9 (2.8)
```