### PR TITLE
Add code to fold domain names to lower case. Turn it on by default.

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -104,13 +104,20 @@ def test_looks_like_ip():
     assert_extract(u'1\xe9', ('', '', u'1\xe9', ''))
 
 
+def test_upper_case_folding():
+    assert_extract('http://www.GOOGLE.com',
+                   ('www.google.com', 'www', 'google', 'com'))
+    assert_extract("http://www.TheRegister.Co.Uk",
+                   ("www.theregister.co.uk", "www", "theregister", "co.uk"))
+
+
 def test_punycode():
     assert_extract('http://xn--h1alffa9f.xn--p1ai',
                    ('xn--h1alffa9f.xn--p1ai', '', 'xn--h1alffa9f', 'xn--p1ai'))
     assert_extract('http://xN--h1alffa9f.xn--p1ai',
-                   ('xN--h1alffa9f.xn--p1ai', '', 'xN--h1alffa9f', 'xn--p1ai'))
+                   ('xn--h1alffa9f.xn--p1ai', '', 'xn--h1alffa9f', 'xn--p1ai'))
     assert_extract('http://XN--h1alffa9f.xn--p1ai',
-                   ('XN--h1alffa9f.xn--p1ai', '', 'XN--h1alffa9f', 'xn--p1ai'))
+                   ('xn--h1alffa9f.xn--p1ai', '', 'xn--h1alffa9f', 'xn--p1ai'))
     # Entries that might generate UnicodeError exception
     # This subdomain generates UnicodeError 'IDNA does not round-trip'
     assert_extract('xn--tub-1m9d15sfkkhsifsbqygyujjrw602gk4li5qqk98aca0w.google.com',

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -147,7 +147,7 @@ class TLDExtract(object):
     # TODO: Agreed with Pylint: too-many-arguments
     def __init__(self, cache_file=CACHE_FILE, suffix_list_urls=PUBLIC_SUFFIX_LIST_URLS,  # pylint: disable=too-many-arguments
                  fallback_to_snapshot=True, include_psl_private_domains=False, extra_suffixes=(),
-                 cache_fetch_timeout=CACHE_TIMEOUT):
+                 fold_case=True, cache_fetch_timeout=CACHE_TIMEOUT):
         """
         Constructs a callable for extracting subdomain, domain, and suffix
         components from a URL.
@@ -202,6 +202,7 @@ class TLDExtract(object):
         self.include_psl_private_domains = include_psl_private_domains
         self.extra_suffixes = extra_suffixes
         self._extractor = None
+        self.fold_case = fold_case
 
         self.cache_fetch_timeout = cache_fetch_timeout
         if isinstance(self.cache_fetch_timeout, STRING_TYPE):
@@ -226,6 +227,9 @@ class TLDExtract(object):
             .partition(":")[0] \
             .strip() \
             .rstrip(".")
+
+        if self.fold_case:
+            netloc = netloc.lower()
 
         labels = netloc.split(".")
 


### PR DESCRIPTION
This change adds an option to fold the output to lower case, and make that the default.

In my view there is no logical reason to preserve the case of input domain names, and it should be considered a bug that the current version of tldextract does that.

Under the current behaviour GOOGLE.COM and google.com are treated as separate domains. This change fixes that.
