### PR TITLE
Catch the IndexError caused by the punycode bug.

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -127,6 +127,9 @@ def test_invalid_puny_with_puny():
     assert_extract('http://xn--zckzap6140b352by.blog.so-net.xn--wcvs22d.hk',
                    ('xn--zckzap6140b352by.blog.so-net.xn--wcvs22d.hk',
                     'xn--zckzap6140b352by.blog', 'so-net', 'xn--wcvs22d.hk'))
+    assert_extract('http://xn--&.so-net.com',
+                   ('xn--&.so-net.com',
+                    'xn--&', 'so-net', 'com'))
 
 
 def test_puny_with_non_puny():

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -403,6 +403,6 @@ def _decode_punycode(label):
     if looks_like_puny:
         try:
             return idna.decode(label.encode('ascii')).lower()
-        except UnicodeError:
+        except (UnicodeError, IndexError):
             pass
     return lowered


### PR DESCRIPTION
This fix addresses the punycode decoding bug that was referred to in this issue: https://github.com/john-kurkowski/tldextract/issues/199

i.e. Malformed punycode strings like "xn--&" will be treated as if decoding in idna produced an UnicodeError as it should have been.