### PR TITLE
feature: private tlds can be used at call-time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ tldextract/_version.py
 tldextract_app/tldextract
 tldextract_app/web
 tldextract.egg-info
+tldextract/.suffix_cache/*
 .tox
+.pytest_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 After upgrading, update your cache file by deleting it or via `tldextract
 --update`.
 
+## Unreleased
+
+* Breaking Changes
+    * Rename `cache_file` to `cache_dir` as it is no longer a single file but a directory ([#207](https://github.com/john-kurkowski/tldextract/issues/207))
+    * The CLI arg also changed from `--cache_file` to `--cache_dir`
+* Features
+    * Can pass `include_psl_private_domains` on call, not only on construction
+    * Use filelocking to support multi-processing and multithreading environments
+* Bugfixes
+    * Select public or private suffixes at runtime. Fixes [#66](https://github.com/john-kurkowski/tldextract/issues/66).
+
+
 ## 2.2.3 (2020-08-05)
 
 * Bugfixes

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ when I haven't kept this code up to date.)
 
 To avoid this fetch or control the cache's location, use your own extract
 callable by setting TLDEXTRACT_CACHE environment variable or by setting the
-cache_file path in TLDExtract initialization.
+cache_dir path in TLDExtract initialization.
 
 ```python
 # extract callable that falls back to the included TLD snapshot, no live HTTP fetching
@@ -122,11 +122,11 @@ no_fetch_extract = tldextract.TLDExtract(suffix_list_urls=None)
 no_fetch_extract('http://www.google.com')
 
 # extract callable that reads/writes the updated TLD set to a different path
-custom_cache_extract = tldextract.TLDExtract(cache_file='/path/to/your/cache/file')
+custom_cache_extract = tldextract.TLDExtract(cache_dir='/path/to/your/cache/')
 custom_cache_extract('http://www.google.com')
 
 # extract callable that doesn't use caching
-no_cache_extract = tldextract.TLDExtract(cache_file=False)
+no_cache_extract = tldextract.TLDExtract(cache_dir=False)
 no_cache_extract('http://www.google.com')
 ```
 
@@ -167,10 +167,15 @@ ExtractResult(subdomain='waiterrant', domain='blogspot', suffix='com')
 ```
 
 The following overrides this.
-
 ```python
->>> extract = tldextract.TLDExtract(include_psl_private_domains=True)
->>> extract.update() # necessary until #66 is fixed
+>>> extract = tldextract.TLDExtract()
+>>> extract('waiterrant.blogspot.com', include_psl_private_domains=True)
+ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com')
+```
+
+or to change the default for all extract calls,
+```python
+>>> extract = tldextract.TLDExtract( include_psl_private_domains=True)
 >>> extract('waiterrant.blogspot.com')
 ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com')
 ```
@@ -189,19 +194,19 @@ extract = tldextract.TLDExtract(
     suffix_list_urls=["http://foo.bar.baz"],
     # Recommended: Specify your own cache file, to minimize ambiguities about where
     # tldextract is getting its data, or cached data, from.
-    cache_file='/path/to/your/cache/file',
+    cache_dir='/path/to/your/cache/',
     fallback_to_snapshot=False)
 ```
 
 The above snippet will fetch from the URL *you* specified, upon first need to download the
-suffix list (i.e. if the cache_file doesn't exist).
+suffix list (i.e. if the cached version doesn't exist).
 
 If you want to use input data from your local filesystem, just use the `file://` protocol:
 
 ```python
 extract = tldextract.TLDExtract(
     suffix_list_urls=["file://absolute/path/to/your/local/suffix/list/file"],
-    cache_file='/path/to/your/cache/file',
+    cache_dir='/path/to/your/cache/',
     fallback_to_snapshot=False)
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if sys.version_info < (3, 5) and not (
         "version of tldextract." % (sys.version_info[0], sys.version_info[1])
     )
 
-INSTALL_REQUIRES = ["idna", "requests>=2.1.0", "requests-file>=1.4"]
+INSTALL_REQUIRES = ["idna", "requests>=2.1.0", "requests-file>=1.4", "filelock>=3.0.8"]
 
 setup(
     name="tldextract",

--- a/tests/custom_suffix_test.py
+++ b/tests/custom_suffix_test.py
@@ -3,9 +3,7 @@
 import os
 
 import tldextract
-
-from .helpers import temporary_file
-
+from .helpers import temporary_dir
 
 FAKE_SUFFIX_LIST_URL = "file://" + os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
@@ -15,19 +13,29 @@ EXTRA_SUFFIXES = ['foo1', 'bar1', 'baz1']
 
 # pylint: disable=invalid-name
 extract_using_fake_suffix_list = tldextract.TLDExtract(
-    cache_file=temporary_file(),
+    cache_dir=temporary_dir(),
     suffix_list_urls=[FAKE_SUFFIX_LIST_URL]
 )
 extract_using_fake_suffix_list_no_cache = tldextract.TLDExtract(
-    cache_file=None,
+    cache_dir=None,
     suffix_list_urls=[FAKE_SUFFIX_LIST_URL]
 )
 extract_using_extra_suffixes = tldextract.TLDExtract(
-    cache_file=None,
+    cache_dir=None,
     suffix_list_urls=[FAKE_SUFFIX_LIST_URL],
     extra_suffixes=EXTRA_SUFFIXES
 )
 # pylint: enable=invalid-name
+
+
+def test_private_extraction():
+    tld = tldextract.TLDExtract(
+        cache_dir=temporary_dir(),
+        suffix_list_urls=[]
+    )
+
+    assert tld("foo.blogspot.com") == ('foo', 'blogspot', 'com')
+    assert tld("foo.blogspot.com", include_psl_private_domains=True) == ('', 'foo', 'blogspot.com')
 
 
 def test_suffix_which_is_not_in_custom_list():

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ def check_output(*popenargs, **kwargs):
     return output
 
 
-def temporary_file():
+def temporary_dir():
     """ Make a writable temporary file and return its absolute path.
     """
-    return tempfile.mkstemp()[1]
+    return tempfile.mkdtemp()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -1,33 +1,12 @@
 '''tldextract integration tests.'''
 
-import logging
-import os
-import traceback
-
 import pytest
 
 import tldextract
 
 
-def test_log_snapshot_diff(mocker):
-    mocker.patch.object(logging.getLogger(), 'level', logging.DEBUG)
-    debug_mock = mocker.patch.object(logging.getLogger('tldextract'), 'debug')
-
-    extractor = tldextract.TLDExtract()
-    try:
-        os.remove(extractor.cache_file)
-    except (IOError, OSError):
-        logging.warning(traceback.format_exc())
-
-    extractor('ignore.com')
-
-    assert debug_mock.call_count == 1
-    log_str = debug_mock.call_args[0][0]
-    assert log_str.startswith('computed TLD diff')
-
-
 def test_bad_kwargs():
     with pytest.raises(ValueError):
         tldextract.TLDExtract(
-            cache_file=False, suffix_list_urls=False, fallback_to_snapshot=False
+            cache_dir=False, suffix_list_urls=False, fallback_to_snapshot=False
         )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,18 @@
+"""Test the caching functionality"""
+import pytest
+
+from tldextract.cache import DiskCache
+
+
+def test_disk_cache(tmpdir):
+    cache = DiskCache(tmpdir)
+    cache.set("testing", "foo", "bar")
+    assert cache.get("testing", "foo") == "bar"
+
+    cache.clear()
+
+    with pytest.raises(KeyError):
+        cache.get("testing", "foo")
+
+    cache.set("testing", "foo", "baz")
+    assert cache.get("testing", "foo") == "baz"

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -1,0 +1,59 @@
+"""Test ability to run in parallel with shared cache"""
+import os
+import os.path
+from multiprocessing import Pool
+
+import responses
+
+from tldextract import TLDExtract
+from tldextract.tldextract import PUBLIC_SUFFIX_LIST_URLS
+
+
+def test_multiprocessing_makes_one_request(tmpdir):
+    """Ensure there aren't duplicate download requests"""
+    process_count = 3
+    pool = Pool(processes=process_count)
+
+    http_request_counts = pool.map(_run_extractor, [str(tmpdir)] * process_count)
+    assert sum(http_request_counts) == 1
+
+
+@responses.activate
+def _run_extractor(cache_dir):
+    """run the extractor"""
+    responses.add(
+        responses.GET,
+        PUBLIC_SUFFIX_LIST_URLS[0],
+        status=208,
+        body="uk.co"
+    )
+    extract = TLDExtract(cache_dir=cache_dir)
+
+    extract("bar.uk.com", include_psl_private_domains=True)
+    return len(responses.calls)
+
+
+@responses.activate
+def test_cache_cleared_by_other_process(tmpdir, monkeypatch):
+    """Simulate a file being deleted after we check for existence but before we try to delete it"""
+    responses.add(  # pylint: disable=no-member
+        responses.GET,  # pylint: disable=no-member
+        PUBLIC_SUFFIX_LIST_URLS[0],
+        status=208,
+        body="uk.com"
+    )
+
+    cache_dir = str(tmpdir)
+    extract = TLDExtract(cache_dir=cache_dir)
+    extract("google.com")
+    orig_unlink = os.unlink
+
+    def evil_unlink(filename):
+        """Simulates someone delete the file right before we try to"""
+        if filename.startswith(cache_dir):
+            orig_unlink(filename)
+        orig_unlink(filename)
+
+    monkeypatch.setattr(os, "unlink", evil_unlink)
+
+    extract.update(fetch_now=True)

--- a/tldextract/.tld_set_snapshot
+++ b/tldextract/.tld_set_snapshot
@@ -1,7268 +1,13396 @@
-[
-  "chikuho.fukuoka.jp",
-  "\u0c2d\u0c3e\u0c30\u0c24\u0c4d",
-  "\u516c\u53f8.hk",
-  "pvt.ge",
-  "matsuzaki.shizuoka.jp",
-  "name.eg",
-  "tsuruga.fukui.jp",
-  "\u0627\u062a\u0635\u0627\u0644\u0627\u062a",
-  "in-addr.arpa",
-  "hisayama.fukuoka.jp",
-  "name.et",
-  "botanicalgarden.museum",
-  "union.aero",
-  "dell",
-  "biz.ki",
-  "owani.aomori.jp",
-  "kh.ua",
-  "wallonie.museum",
-  "medical.museum",
-  "imb.br",
-  "vald-aosta.it",
-  "rochester.museum",
-  "hisamitsu",
-  "seto.aichi.jp",
-  "\ud55c\uad6d",
-  "pro.az",
-  "nose.osaka.jp",
-  "ayagawa.kagawa.jp",
-  "esp.br",
-  "orientexpress",
-  "okawa.fukuoka.jp",
-  "dgca.aero",
-  "nesoddtangen.no",
-  "cooking",
-  "s\u00f8gne.no",
-  "maibara.shiga.jp",
-  "aigo",
-  "kashihara.nara.jp",
-  "pd.it",
-  "here",
-  "lgbt",
-  "kmpsp.gov.pl",
-  "omuta.fukuoka.jp",
-  "s\u00f8rfold.no",
-  "naumburg.museum",
-  "association.aero",
-  "\u65b0\u95fb",
-  "sula.no",
-  "nom.fr",
-  "akkeshi.hokkaido.jp",
-  "azumino.nagano.jp",
-  "shiki.saitama.jp",
-  "goldpoint",
-  "dnp",
-  "bristol.museum",
-  "myoko.niigata.jp",
-  "m.se",
-  "yamatotakada.nara.jp",
-  "inzai.chiba.jp",
-  "yahoo",
-  "glass",
-  "mosj\u00f8en.no",
-  "shiranuka.hokkaido.jp",
-  "kudoyama.wakayama.jp",
-  "ashiya.fukuoka.jp",
-  "oyer.no",
-  "locker",
-  "lib.ut.us",
-  "philadelphia.museum",
-  "nakagawa.tokushima.jp",
-  "mytis.ru",
-  "vaksdal.no",
-  "hyatt",
-  "ginan.gifu.jp",
-  "tendo.yamagata.jp",
-  "kita.kyoto.jp",
-  "dell-ogliastra.it",
-  "travel",
-  "vv.it",
-  "how",
-  "hot",
-  "kawachinagano.osaka.jp",
-  "chase",
-  "beauty",
-  "tran\u00f8y.no",
-  "yun",
-  "kiev.ua",
-  "go.ug",
-  "okoppe.hokkaido.jp",
-  "helsinki",
-  "vallee-aoste.it",
-  "wine",
-  "unj\u00e1rga.no",
-  "edu.za",
-  "feedback",
-  "travelersinsurance",
-  "comsec",
-  "asso.re",
-  "barclays",
-  "\u7fa4\u99ac.jp",
-  "fidelity",
-  "ne.us",
-  "fit",
-  "crotone.it",
-  "exeter.museum",
-  "nesseby.no",
-  "coastaldefence.museum",
-  "ne.ug",
-  "wales",
-  "ishikawa.fukushima.jp",
-  "kasahara.gifu.jp",
-  "rendalen.no",
-  "brand.se",
-  "interactive.museum",
-  "id.au",
-  "asahikawa.hokkaido.jp",
-  "africamagic",
-  "uda.nara.jp",
-  "\u0e44\u0e17\u0e22",
-  "karmoy.no",
-  "com.qa",
-  "aero.tt",
-  "mil.ba",
-  "mil.bo",
-  "como.it",
-  "mil.br",
-  "fh.se",
-  "mil.by",
-  "ru",
-  "malbork.pl",
-  "rw",
-  "rs",
-  "hokuryu.hokkaido.jp",
-  "ascolipiceno.it",
-  "asahi.nagano.jp",
-  "re",
-  "susono.shizuoka.jp",
-  "sc.kr",
-  "ro",
-  "foundation",
-  "abbott",
-  "reisen",
-  "california.museum",
-  "ups",
-  "tobetsu.hokkaido.jp",
-  "walmart",
-  "ct.it",
-  "b\u00e1hcavuotna.no",
-  "gyeongbuk.kr",
-  "kagamino.okayama.jp",
-  "palermo.it",
-  "hjelmeland.no",
-  "kfh",
-  "basketball",
-  "gr.jp",
-  "lego",
-  "oppdal.no",
-  "xin",
-  "hikawa.shimane.jp",
-  "funabashi.chiba.jp",
-  "mckinsey",
-  "imari.saga.jp",
-  "niyodogawa.kochi.jp",
-  "tires",
-  "kommune.no",
-  "konsulat.gov.pl",
-  "gives",
-  "\u0633\u0648\u0631\u064a\u0627",
-  "\u0633\u0648\u0631\u064a\u0629",
-  "boston",
-  "kotoura.tottori.jp",
-  "pasadena.museum",
-  "fuchu.hiroshima.jp",
-  "nagasaki.nagasaki.jp",
-  "yamagata.ibaraki.jp",
-  "loabat.no",
-  "university.museum",
-  "\u043e\u0431\u0440.\u0441\u0440\u0431",
-  "\u0642\u0637\u0631",
-  "wake.okayama.jp",
-  "co.ci",
-  "fuchu.tokyo.jp",
-  "co.cl",
-  "co.cm",
-  "arakawa.saitama.jp",
-  "co.cr",
-  "kyonan.chiba.jp",
-  "shonai.yamagata.jp",
-  "nuoro.it",
-  "nebraska.museum",
-  "sd.cn",
-  "brindisi.it",
-  "nakayama.yamagata.jp",
-  "aircraft.aero",
-  "graz.museum",
-  "ina.saitama.jp",
-  "sn.cn",
-  "lpl",
-  "tech",
-  "ullensaker.no",
-  "volgograd.ru",
-  "\u5343\u8449.jp",
-  "eng.pro",
-  "krasnoyarsk.ru",
-  "nichinan.tottori.jp",
-  "vladimir.su",
-  "menu",
-  "supersport",
-  "otobe.hokkaido.jp",
-  "skjak.no",
-  "6.bg",
-  "hammerfest.no",
-  "karelia.ru",
-  "honda",
-  "\u5e83\u5cf6.jp",
-  "museum.no",
-  "new",
-  "tips",
-  "nagareyama.chiba.jp",
-  "jaguar",
-  "org.do",
-  "org.dm",
-  "tamayu.shimane.jp",
-  "com.mk",
-  "org.dz",
-  "med",
-  "saku.nagano.jp",
-  "council.aero",
-  "fail",
-  "archaeological.museum",
-  "goodhands",
-  "gs.fm.no",
-  "group.aero",
-  "\u0639\u0631\u0628",
-  "piw.gov.pl",
-  "sn\u00e5ase.no",
-  "name.cy",
-  "biz.mv",
-  "biz.mw",
-  "heimatunduhren.museum",
-  "bihoro.hokkaido.jp",
-  "natura",
-  "nationwide",
-  "cri.nz",
-  "cards",
-  "rybnik.pl",
-  "qld.gov.au",
-  "kami.miyagi.jp",
-  "\u6559\u80b2.hk",
-  "abruzzo.it",
-  "hita.oita.jp",
-  "nrw.museum",
-  "choshi.chiba.jp",
-  "country",
-  "nowruz",
-  "forli-cesena.it",
-  "atsuma.hokkaido.jp",
-  "frogn.no",
-  "wloclawek.pl",
-  "drangedal.no",
-  "kitagawa.miyazaki.jp",
-  "aviation.museum",
-  "mihama.chiba.jp",
-  "chrome",
-  "cc.va.us",
-  "cc.tx.us",
-  "frl",
-  "heroy.more-og-romsdal.no",
-  "gj\u00f8vik.no",
-  "\u98de\u5229\u6d66",
-  "asakawa.fukushima.jp",
-  "minamioguni.kumamoto.jp",
-  "sydney",
-  "fm.br",
-  "birthplace.museum",
-  "forum.hu",
-  "oketo.hokkaido.jp",
-  "hashimoto.wakayama.jp",
-  "bible.museum",
-  "cc.sc.us",
-  "andria-barletta-trani.it",
-  "hotel.lk",
-  "tsk.ru",
-  "inawashiro.fukushima.jp",
-  "\u0915\u0949\u092e",
-  "pi.it",
-  "bj.cn",
-  "urbinopesaro.it",
-  "memorial",
-  "dhl",
-  "shimabara.nagasaki.jp",
-  "agdenes.no",
-  "\u6c96\u7e04.jp",
-  "odda.no",
-  "k12.ct.us",
-  "\u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0629",
-  "n\u00e5\u00e5mesjevuemie.no",
-  "ebiz.tw",
-  "higashimatsuyama.saitama.jp",
-  "chocolate.museum",
-  "sh.cn",
-  "musashimurayama.tokyo.jp",
-  "\u0441\u0430\u0439\u0442",
-  "web.tj",
-  "oshino.yamanashi.jp",
-  "cranbrook.museum",
-  "web.tr",
-  "\u00f8ystre-slidre.no",
-  "okuizumo.shimane.jp",
-  "nakanoto.ishikawa.jp",
-  "yoshikawa.saitama.jp",
-  "gs.sf.no",
-  "kamakura.kanagawa.jp",
-  "edu.tm",
-  "omasvuotna.no",
-  "echizen.fukui.jp",
-  "mopar",
-  "higashishirakawa.gifu.jp",
-  "awaji.hyogo.jp",
-  "tas.gov.au",
-  "airguard.museum",
-  "hiranai.aomori.jp",
-  "bnl",
-  "edu.tt",
-  "shinjo.okayama.jp",
-  "shiga.jp",
-  "skierva.no",
-  "railroad.museum",
-  "yaese.okinawa.jp",
-  "furudono.fukushima.jp",
-  "taiki.hokkaido.jp",
-  "murmansk.su",
-  "fukuoka.jp",
-  "attorney",
-  "okazaki.aichi.jp",
-  "crown",
-  "valledaosta.it",
-  "tsuiki.fukuoka.jp",
-  "fox",
-  "tcm.museum",
-  "lib.fl.us",
-  "foo",
-  "evenassi.no",
-  "nom.za",
-  "dental",
-  "richardli",
-  "quebec.museum",
-  "na.it",
-  "com.sy",
-  "chino.nagano.jp",
-  "delaware.museum",
-  "com.st",
-  "com.sv",
-  "com.sh",
-  "com.sl",
-  "com.sn",
-  "com.so",
-  "com.sa",
-  "com.sb",
-  "com.sc",
-  "com.sd",
-  "com.sg",
-  "consulting",
-  "cc.md.us",
-  "s\u00e1lat.no",
-  "brescia.it",
-  "mba",
-  "osaka.jp",
-  "fire",
-  "mil.lv",
-  "ivgu.no",
-  "kitagawa.kochi.jp",
-  "estate.museum",
-  "zoology.museum",
-  "stj\u00f8rdal.no",
-  "support",
-  "sandnessj\u00f8en.no",
-  "\u4e00\u53f7\u5e97",
-  "khakassia.su",
-  "call",
-  "ibara.okayama.jp",
-  "modum.no",
-  "asn.au",
-  "msk.ru",
-  "media.pl",
-  "nikko.tochigi.jp",
-  "\u0627\u0628\u0648\u0638\u0628\u064a",
-  "hino.tokyo.jp",
-  "vanguard",
-  "nf.ca",
-  "chosei.chiba.jp",
-  "surgut.ru",
-  "divtasvuodna.no",
-  "q.bg",
-  "dealer",
-  "pp.az",
-  "umig.gov.pl",
-  "sekikawa.niigata.jp",
-  "cyou",
-  "actor",
-  "stuttgart.museum",
-  "ferrari",
-  "naturhistorisches.museum",
-  "jmp",
-  "firm.in",
-  "tn.us",
-  "bando.ibaraki.jp",
-  "britishcolumbia.museum",
-  "sakai.ibaraki.jp",
-  "tom.ru",
-  "lib.mn.us",
-  "moriyama.shiga.jp",
-  "press.se",
-  "cesenaforli.it",
-  "decorativearts.museum",
-  "mykolaiv.ua",
-  "\u05d9\u05e8\u05d5\u05e9\u05dc\u05d9\u05dd.museum",
-  "iruma.saitama.jp",
-  "isshiki.aichi.jp",
-  "khmelnitskiy.ua",
-  "tsuno.miyazaki.jp",
-  "urasoe.okinawa.jp",
-  "bostik",
-  "\u043a\u043e\u043c",
-  "trentino-altoadige.it",
-  "vet",
-  "ikoma.nara.jp",
-  "co.mg",
-  "co.me",
-  "oldnavy",
-  "co.ma",
-  "valley.museum",
-  "yokoze.saitama.jp",
-  "co.mw",
-  "co.mu",
-  "rec.ro",
-  "t.se",
-  "kyotango.kyoto.jp",
-  "komoro.nagano.jp",
-  "exhibition.museum",
-  "tohma.hokkaido.jp",
-  "schoenbrunn.museum",
-  "lardal.no",
-  "team",
-  "banamex",
-  "yoita.niigata.jp",
-  "sandnessjoen.no",
-  "fc.it",
-  "presse.fr",
-  "ito.shizuoka.jp",
-  "med.pro",
-  "y.bg",
-  "rocher",
-  "\u98df\u54c1",
-  "nishio.aichi.jp",
-  "columbia.museum",
-  "\u30d5\u30a1\u30c3\u30b7\u30e7\u30f3",
-  "nx.cn",
-  "l\u00f8renskog.no",
-  "\u043e\u0440\u0433",
-  "sorfold.no",
-  "balestrand.no",
-  "logistics.aero",
-  "skedsmokorset.no",
-  "bw",
-  "marumori.miyagi.jp",
-  "love",
-  "gov.dm",
-  "gov.do",
-  "ug",
-  "smola.no",
-  "yamamoto.miyagi.jp",
-  "gov.dz",
-  "rc.it",
-  "bifuka.hokkaido.jp",
-  "name.az",
-  "gok.pk",
-  "chijiwa.nagasaki.jp",
-  "nl.ca",
-  "nnov.ru",
-  "pc.pl",
-  "miki.hyogo.jp",
-  "cc.al.us",
-  "k12.oh.us",
-  "alessandria.it",
-  "andoy.no",
-  "tv.tz",
-  "friuli-vegiulia.it",
-  "fresenius",
-  "space.museum",
-  "tv.tr",
-  "tuscany.it",
-  "sklep.pl",
-  "mari.ru",
-  "ac.ru",
-  "\u09ac\u09be\u0982\u09b2\u09be",
-  "ac.rw",
-  "ac.rs",
-  "ge.it",
-  "ne.jp",
-  "omura.nagasaki.jp",
-  "hurum.no",
-  "mutuelle",
-  "misato.saitama.jp",
-  "kikuchi.kumamoto.jp",
-  "takaoka.toyama.jp",
-  "date",
-  "elvendrell.museum",
-  "meiwa.gunma.jp",
-  "epost",
-  "sz",
-  "sy",
-  "sx",
-  "sr",
-  "cbn",
-  "sv",
-  "su",
-  "st",
-  "sk",
-  "hitachinaka.ibaraki.jp",
-  "si",
-  "sh",
-  "so",
-  "sn",
-  "sm",
-  "sl",
-  "sc",
-  "sb",
-  "sa",
-  "\u4e09\u91cd.jp",
-  "sg",
-  "se",
-  "sd",
-  "leasing.aero",
-  "chernigov.ua",
-  "trana.no",
-  "brunel.museum",
-  "showa.fukushima.jp",
-  "aero.mv",
-  "frankfurt.museum",
-  "jio",
-  "copenhagen.museum",
-  "\u00f8rland.no",
-  "\u0441\u0440\u0431",
-  "cc.ca.us",
-  "nowaruda.pl",
-  "naka.hiroshima.jp",
-  "midori.chiba.jp",
-  "showa.gunma.jp",
-  "geisei.kochi.jp",
-  "web.ve",
-  "rg.it",
-  "gokase.miyazaki.jp",
-  "okuma.fukushima.jp",
-  "lib.az.us",
-  "minamiaiki.nagano.jp",
-  "ogi.saga.jp",
-  "ashikaga.tochigi.jp",
-  "ichinomiya.aichi.jp",
-  "nobeoka.miyazaki.jp",
-  "matsue.shimane.jp",
-  "shimonoseki.yamaguchi.jp",
-  "mantova.it",
-  "ohda.shimane.jp",
-  "d\u00f8nna.no",
-  "air.museum",
-  "omitama.ibaraki.jp",
-  "basel.museum",
-  "shibecha.hokkaido.jp",
-  "training",
-  "gouv.km",
-  "cc.ok.us",
-  "vestv\u00e5g\u00f8y.no",
-  "laakesvuemie.no",
-  "cc.la.us",
-  "nakasatsunai.hokkaido.jp",
-  "iveco",
-  "onl",
-  "ong",
-  "one",
-  "voto",
-  "vote",
-  "ogliastra.it",
-  "open",
-  "tec.ve",
-  "city",
-  "toyama.toyama.jp",
-  "fujikawa.shizuoka.jp",
-  "kvalsund.no",
-  "castle.museum",
-  "citi",
-  "ak.us",
-  "tgory.pl",
-  "com.ua",
-  "com.ug",
-  "lerdal.no",
-  "tranby.no",
-  "iwata.shizuoka.jp",
-  "com.uz",
-  "com.uy",
-  "kitahiroshima.hokkaido.jp",
-  "fl\u00e5.no",
-  "jolster.no",
-  "rehab",
-  "kanra.gunma.jp",
-  "hadano.kanagawa.jp",
-  "college",
-  "sukumo.kochi.jp",
-  "town.museum",
-  "mil.no",
-  "\u4e16\u754c",
-  "mil.ng",
-  "dominic.ua",
-  "mil.nz",
-  "takinoue.hokkaido.jp",
-  "vlog.br",
-  "sas",
-  "suisse.museum",
-  "kashiwazaki.niigata.jp",
-  "vikna.no",
-  "miyashiro.saitama.jp",
-  "meloy.no",
-  "onga.fukuoka.jp",
-  "joso.ibaraki.jp",
-  "tsuruta.aomori.jp",
-  "sor-varanger.no",
-  "rightathome",
-  "sanda.hyogo.jp",
-  "archi",
-  "kamijima.ehime.jp",
-  "kitaura.miyazaki.jp",
-  "krym.ua",
-  "*.zw",
-  "nagiso.nagano.jp",
-  "axa",
-  "hakodate.hokkaido.jp",
-  "*.zm",
-  "yasuda.kochi.jp",
-  "soma.fukushima.jp",
-  "org.vn",
-  "b\u00e6rum.no",
-  "mil.km",
-  "muika.niigata.jp",
-  "jpmorgan",
-  "shop.pl",
-  "hockey",
-  "tado.mie.jp",
-  "pruszkow.pl",
-  "trentino.it",
-  "konyvelo.hu",
-  "turin.it",
-  "swinoujscie.pl",
-  "kamikawa.hokkaido.jp",
-  "kuban.ru",
-  "prime",
-  "\u7d44\u7ec7.hk",
-  "uz",
-  "hamada.shimane.jp",
-  "vision",
-  "unbi.ba",
-  "tomsk.ru",
-  "biev\u00e1t.no",
-  "surgery",
-  "futsu.nagasaki.jp",
-  "yahiko.niigata.jp",
-  "weibo",
-  "gamvik.no",
-  "co.om",
-  "misawa.aomori.jp",
-  "tjome.no",
-  "jobs",
-  "preservation.museum",
-  "kragero.no",
-  "ariake.saga.jp",
-  "friuli-v-giulia.it",
-  "mesaverde.museum",
-  "\u9759\u5ca1.jp",
-  "yoshimi.saitama.jp",
-  "kuroishi.aomori.jp",
-  "urayasu.chiba.jp",
-  "mashiko.tochigi.jp",
-  "coldwar.museum",
-  "eigersund.no",
-  "uzs.gov.pl",
-  "wa.edu.au",
-  "g\u00e1\u014bgaviika.no",
-  "\u5c71\u53e3.jp",
-  "riik.ee",
-  "photos",
-  "mobi.tz",
-  "theguardian",
-  "ggee",
-  "mobi.tt",
-  "\u0b87\u0ba8\u0bcd\u0ba4\u0bbf\u0baf\u0bbe",
-  "schmidt",
-  "org.ht",
-  "org.hu",
-  "engineering",
-  "org.hn",
-  "org.hk",
-  "uol",
-  "tjeldsund.no",
-  "gov.jo",
-  "yokkaichi.mie.jp",
-  "canon",
-  "yahaba.iwate.jp",
-  "r\u00e5de.no",
-  "tysvar.no",
-  "technology",
-  "marylhurst.museum",
-  "noshiro.akita.jp",
-  "wang",
-  "shinshinotsu.hokkaido.jp",
-  "honeywell",
-  "taiki.mie.jp",
-  "joshkar-ola.ru",
-  "saintlouis.museum",
-  "dc.us",
-  "tome.miyagi.jp",
-  "k12.va.us",
-  "jcp",
-  "tm.mc",
-  "amagasaki.hyogo.jp",
-  "tm.mg",
-  "tempio-olbia.it",
-  "nango.fukushima.jp",
-  "ballooning.aero",
-  "va.no",
-  "oirm.gov.pl",
-  "yokaichiba.chiba.jp",
-  "ac.pa",
-  "fosnes.no",
-  "rest",
-  "starostwo.gov.pl",
-  "durham.museum",
-  "\u00f8yer.no",
-  "sic.it",
-  "ac.pr",
-  "photography.museum",
-  "gdn",
-  "numata.hokkaido.jp",
-  "ogawa.nagano.jp",
-  "winb.gov.pl",
-  "eidfjord.no",
-  "med.pa",
-  "swatch",
-  "soka.saitama.jp",
-  "furubira.hokkaido.jp",
-  "kawaue.gifu.jp",
-  "world",
-  "cam.it",
-  "intel",
-  "iida.nagano.jp",
-  "mosvik.no",
-  "aisai.aichi.jp",
-  "tvs",
-  "hotel.hu",
-  "net.vn",
-  "net.vi",
-  "bergen.no",
-  "benevento.it",
-  "scholarships",
-  "joboji.iwate.jp",
-  "nis.za",
-  "tube",
-  "fukushima.fukushima.jp",
-  "kimitsu.chiba.jp",
-  "net.ve",
-  "bjerkreim.no",
-  "tiffany",
-  "info.bb",
-  "hachinohe.aomori.jp",
-  "shouji",
-  "origins",
-  "aco",
-  "baths.museum",
-  "isa.kagoshima.jp",
-  "net.za",
-  "her\u00f8y.m\u00f8re-og-romsdal.no",
-  "north.museum",
-  "oh.us",
-  "os.hedmark.no",
-  "financial",
-  "miyawaka.fukuoka.jp",
-  "ethnology.museum",
-  "hirosaki.aomori.jp",
-  "kita.tokyo.jp",
-  "verran.no",
-  "media",
-  "shriram",
-  "val-daosta.it",
-  "iwc",
-  "b\u00e5d\u00e5ddj\u00e5.no",
-  "barletta-trani-andria.it",
-  "mining.museum",
-  "sayama.osaka.jp",
-  "mallorca.museum",
-  "ushiku.ibaraki.jp",
-  "yachiyo.ibaraki.jp",
-  "video.hu",
-  "ac",
-  "ae",
-  "ad",
-  "ag",
-  "af",
-  "ai",
-  "edu.dz",
-  "am",
-  "al",
-  "ao",
-  "aq",
-  "lenug.su",
-  "as",
-  "ar",
-  "au",
-  "at",
-  "tateshina.nagano.jp",
-  "ax",
-  "az",
-  "edu.dm",
-  "edu.do",
-  "olsztyn.pl",
-  "yoga",
-  "radio.br",
-  "higashiomi.shiga.jp",
-  "co.tm",
-  "co.th",
-  "suifu.ibaraki.jp",
-  "co.tt",
-  "co.tz",
-  "r\u00f8yken.no",
-  "gifts",
-  "com.ws",
-  "ogori.fukuoka.jp",
-  "eastcoast.museum",
-  "tr.no",
-  "aurland.no",
-  "hemsedal.no",
-  "adac",
-  "alipay",
-  "sca",
-  "scb",
-  "tours",
-  "kurate.fukuoka.jp",
-  "mil.hn",
-  "\u0928\u0947\u091f",
-  "rockart.museum",
-  "tz",
-  "gs.aa.no",
-  "tv",
-  "tw",
-  "tt",
-  "immobilien",
-  "tr",
-  "tn",
-  "to",
-  "tl",
-  "tm",
-  "tj",
-  "tk",
-  "th",
-  "tf",
-  "tg",
-  "td",
-  "tsuruoka.yamagata.jp",
-  "tc",
-  "voagat.no",
-  "suedtirol.it",
-  "kyiv.ua",
-  "chikujo.fukuoka.jp",
-  "casa",
-  "abbvie",
-  "wroclaw.pl",
-  "ed.jp",
-  "publ.pt",
-  "corporation.museum",
-  "nagasu.kumamoto.jp",
-  "kawamata.fukushima.jp",
-  "itami.hyogo.jp",
-  "legnica.pl",
-  "tokorozawa.saitama.jp",
-  "hikone.shiga.jp",
-  "minamiizu.shizuoka.jp",
-  "samnanger.no",
-  "kashima.kumamoto.jp",
-  "cash",
-  "choyo.kumamoto.jp",
-  "kartuzy.pl",
-  "michigan.museum",
-  "nuremberg.museum",
-  "marnardal.no",
-  "luroy.no",
-  "kasumigaura.ibaraki.jp",
-  "otoineppu.hokkaido.jp",
-  "machida.tokyo.jp",
-  "bronnoy.no",
-  "v\u00e5gs\u00f8y.no",
-  "sand\u00f8y.no",
-  "uonuma.niigata.jp",
-  "shingu.wakayama.jp",
-  "nayoro.hokkaido.jp",
-  "tydal.no",
-  "jewelry.museum",
-  "frosinone.it",
-  "nakagawa.hokkaido.jp",
-  "pics",
-  "pb.ao",
-  "cc.wa.us",
-  "va.us",
-  "social",
-  "rec.ve",
-  "monza-e-della-brianza.it",
-  "botanical.museum",
-  "ichinohe.iwate.jp",
-  "friuli-veneziagiulia.it",
-  "vip",
-  "pro.vn",
-  "select",
-  "co.ir",
-  "asker.no",
-  "ukiha.fukuoka.jp",
-  "co.it",
-  "history.museum",
-  "furukawa.miyagi.jp",
-  "haebaru.okinawa.jp",
-  "gyokuto.kumamoto.jp",
-  "etnedal.no",
-  "co.id",
-  "co.in",
-  "co.il",
-  "co.im",
-  "casino.hu",
-  "kamisu.ibaraki.jp",
-  "company",
-  "tur.ar",
-  "tosa.kochi.jp",
-  "bielawa.pl",
-  "mad.museum",
-  "giske.no",
-  "science",
-  "s\u00f8r-aurdal.no",
-  "labour.museum",
-  "ve.it",
-  "rennes\u00f8y.no",
-  "edunet.tn",
-  "abb",
-  "kawara.fukuoka.jp",
-  "gamo.shiga.jp",
-  "s\u00f8mna.no",
-  "sigdal.no",
-  "ube.yamaguchi.jp",
-  "morimachi.shizuoka.jp",
-  "yoshino.nara.jp",
-  "shikokuchuo.ehime.jp",
-  "lesja.no",
-  "svizzera.museum",
-  "br\u00f8nn\u00f8ysund.no",
-  "annefrank.museum",
-  "limanowa.pl",
-  "oppegard.no",
-  "org.jo",
-  "org.je",
-  "starhub",
-  "gov.hk",
-  "gwangju.kr",
-  "akaiwa.okayama.jp",
-  "k12.ut.us",
-  "matsushima.miyagi.jp",
-  "higashi.fukuoka.jp",
-  "trade",
-  "nanbu.tottori.jp",
-  "yandex",
-  "itv",
-  "broadway",
-  "name.my",
-  "or.pw",
-  "troitsk.su",
-  "tanabe.wakayama.jp",
-  "name.mv",
-  "kchr.ru",
-  "sa.gov.pl",
-  "ally",
-  "\u653f\u52a1",
-  "cartoonart.museum",
-  "s\u00f8ndre-land.no",
-  "kppsp.gov.pl",
-  "events",
-  "busan.kr",
-  "courses",
-  "otsuki.kochi.jp",
-  "tm.km",
-  "e.bg",
-  "iglesiascarbonia.it",
-  "lea\u014bgaviika.no",
-  "osaka",
-  "nittedal.no",
-  "ohira.miyagi.jp",
-  "perso.ht",
-  "ac.vn",
-  "hyogo.jp",
-  "ftr",
-  "in.na",
-  "ichikawamisato.yamanashi.jp",
-  "numazu.shizuoka.jp",
-  "in.ni",
-  "astrakhan.ru",
-  "creditunion",
-  "obninsk.su",
-  "kushiro.hokkaido.jp",
-  "geelvinck.museum",
-  "ecn.br",
-  "nishimera.miyazaki.jp",
-  "arboretum.museum",
-  "yono.saitama.jp",
-  "hirado.nagasaki.jp",
-  "gorge.museum",
-  "nanjo.okinawa.jp",
-  "mil.uy",
-  "basilicata.it",
-  "\u7db2\u7d61.hk",
-  "vrn.ru",
-  "tokigawa.saitama.jp",
-  "niikappu.hokkaido.jp",
-  "heritage.museum",
-  "kitchen",
-  "agrigento.it",
-  "le.it",
-  "iraq.museum",
-  "kobierzyce.pl",
-  "aaa",
-  "database.museum",
-  "ibestad.no",
-  "cc.wy.us",
-  "sel.no",
-  "assabu.hokkaido.jp",
-  "ohira.tochigi.jp",
-  "folkebibl.no",
-  "psse.gov.pl",
-  "olayangroup",
-  "somna.no",
-  "dagestan.su",
-  "hirata.fukushima.jp",
-  "tysfjord.no",
-  "takatsuki.shiga.jp",
-  "play",
-  "rel.ht",
-  "c.bg",
-  "singles",
-  "health.museum",
-  "bmd.br",
-  "chiyoda.gunma.jp",
-  "augustow.pl",
-  "matsuno.ehime.jp",
-  "\u00e5mli.no",
-  "0.bg",
-  "software.aero",
-  "can.museum",
-  "microsoft",
-  "edu.bz",
-  "taxi",
-  "kaisei.kanagawa.jp",
-  "golf",
-  "gold",
-  "cruises",
-  "edu.br",
-  "edu.bs",
-  "kg.kr",
-  "\u0440\u0443\u0441",
-  "edu.bt",
-  "edu.bh",
-  "edu.bi",
-  "edu.bo",
-  "guernsey.museum",
-  "vb.it",
-  "edu.ba",
-  "minoh.osaka.jp",
-  "wzmiuw.gov.pl",
-  "co.ve",
-  "condos",
-  "co.vi",
-  "okagaki.fukuoka.jp",
-  "barclaycard",
-  "marugame.kagawa.jp",
-  "kitakami.iwate.jp",
-  "veterinaire.km",
-  "com.is",
-  "gratis",
-  "com.iq",
-  "farsund.no",
-  "masuda.shimane.jp",
-  "ulm.museum",
-  "amur.ru",
-  "com.io",
-  "com.im",
-  "\u9e7f\u5150\u5cf6.jp",
-  "progressive",
-  "pilots.museum",
-  "shiksha",
-  "seirou.niigata.jp",
-  "psp.gov.pl",
-  "tondabayashi.osaka.jp",
-  "sew",
-  "esan.hokkaido.jp",
-  "ses",
-  "k12.id.us",
-  "nesodden.no",
-  "ibigawa.gifu.jp",
-  "sarufutsu.hokkaido.jp",
-  "valle-aosta.it",
-  "sex",
-  "mil.jo",
-  "uw.gov.pl",
-  "hachirogata.akita.jp",
-  "uvic.museum",
-  "so.gov.pl",
-  "slattum.no",
-  "other.nf",
-  "yamato.kanagawa.jp",
-  "leangaviika.no",
-  "ltd.gi",
-  "com.kz",
-  "cc.nd.us",
-  "vs.it",
-  "\u00e5krehamn.no",
-  "lib.dc.us",
-  "mol.it",
-  "comunica\u00e7\u00f5es.museum",
-  "act.edu.au",
-  "magazine.aero",
-  "ollo",
-  "celtic.museum",
-  "loan",
-  "flight.aero",
-  "community",
-  "com.ki",
-  "kids.museum",
-  "otago.museum",
-  "kashiwa.chiba.jp",
-  "laz.it",
-  "shiroishi.miyagi.jp",
-  "hiroshima.jp",
-  "nra",
-  "notteroy.no",
-  "fund",
-  "vda.it",
-  "pila.pl",
-  "contemporary.museum",
-  "national.museum",
-  "nrw",
-  "mlb",
-  "environmentalconservation.museum",
-  "mls",
-  "omaezaki.shizuoka.jp",
-  "pittsburgh.museum",
-  "hino.tottori.jp",
-  "moto",
-  "ac.kr",
-  "j.bg",
-  "aurskog-holand.no",
-  "audi",
-  "miasta.pl",
-  "seek",
-  "co.kr",
-  "nabari.mie.jp",
-  "ikeda.fukui.jp",
-  "namerikawa.toyama.jp",
-  "engerdal.no",
-  "read",
-  "ind.tn",
-  "nagi.okayama.jp",
-  "ltda",
-  "maori.nz",
-  "yamagata.jp",
-  "\u6de1\u9a6c\u9521",
-  "minamiawaji.hyogo.jp",
-  "sandvik",
-  "caa.aero",
-  "utashinai.hokkaido.jp",
-  "rodoy.no",
-  "tsushima.nagasaki.jp",
-  "altai.ru",
-  "vaapste.no",
-  "lavagis.no",
-  "assisi.museum",
-  "ugim.gov.pl",
-  "koga.fukuoka.jp",
-  "gripe",
-  "iwade.wakayama.jp",
-  "coop.br",
-  "turystyka.pl",
-  "bl.it",
-  "tsuga.tochigi.jp",
-  "soo.kagoshima.jp",
-  "openair.museum",
-  "horokanai.hokkaido.jp",
-  "\u0627\u0644\u0633\u0639\u0648\u062f\u064a\u0647",
-  "grosseto.it",
-  "poltava.ua",
-  "toho.fukuoka.jp",
-  "oppeg\u00e5rd.no",
-  "org.lb",
-  "org.lc",
-  "org.la",
-  "stange.no",
-  "org.lk",
-  "olbiatempio.it",
-  "intuit",
-  "rexroth",
-  "org.lr",
-  "org.ls",
-  "quest",
-  "org.lv",
-  "og.ao",
-  "\u0627\u064a\u0631\u0627\u0646.ir",
-  "org.ly",
-  "williamsburg.museum",
-  "k12.ky.us",
-  "handson.museum",
-  "takanabe.miyazaki.jp",
-  "pro.tt",
-  "sunndal.no",
-  "gov.nr",
-  "gov.ng",
-  "satx.museum",
-  "kitagata.gifu.jp",
-  "redstone",
-  "hidaka.saitama.jp",
-  "\u00f8rsta.no",
-  "*.nom.br",
-  "tas.au",
-  "ohtawara.tochigi.jp",
-  "ishikawa.okinawa.jp",
-  "torahime.shiga.jp",
-  "hob\u00f8l.no",
-  "noda.iwate.jp",
-  "geek.nz",
-  "dating",
-  "be",
-  "bf",
-  "bg",
-  "ba",
-  "bb",
-  "carbonia-iglesias.it",
-  "bm",
-  "bo",
-  "bh",
-  "bi",
-  "bj",
-  "bt",
-  "bv",
-  "kunstunddesign.museum",
-  "br",
-  "bs",
-  "by",
-  "bz",
-  "austin.museum",
-  "netflix",
-  "karuizawa.nagano.jp",
-  "melbourne",
-  "fin.ec",
-  "higashi.okinawa.jp",
-  "ruhr",
-  "eid.no",
-  "gouv.rw",
-  "ga.us",
-  "repair",
-  "dielddanuorri.no",
-  "ac.tz",
-  "locus",
-  "ac.tj",
-  "ac.th",
-  "timekeeping.museum",
-  "yurihonjo.akita.jp",
-  "ns.ca",
-  "author.aero",
-  "nichinan.miyazaki.jp",
-  "exposed",
-  "cadaques.museum",
-  "narita.chiba.jp",
-  "kurashiki.okayama.jp",
-  "yamanobe.yamagata.jp",
-  "karpacz.pl",
-  "nishikatsura.yamanashi.jp",
-  "bryansk.su",
-  "pinb.gov.pl",
-  "ogawa.ibaraki.jp",
-  "seiyo.ehime.jp",
-  "link",
-  "perugia.it",
-  "uy",
-  "aioi.hyogo.jp",
-  "us",
-  "uk",
-  "kahoku.yamagata.jp",
-  "sdn.gov.pl",
-  "higashiura.aichi.jp",
-  "ip6.arpa",
-  "ua",
-  "camp",
-  "georgia.museum",
-  "nextdirect",
-  "showtime",
-  "motegi.tochigi.jp",
-  "\u7db2\u7d61.cn",
-  "vik.no",
-  "esashi.hokkaido.jp",
-  "chat",
-  "chelyabinsk.ru",
-  "pharmacien.fr",
-  "codes",
-  "kirkenes.no",
-  "inashiki.ibaraki.jp",
-  "kurobe.toyama.jp",
-  "jcb",
-  "minamiboso.chiba.jp",
-  "habmer.no",
-  "fribourg.museum",
-  "cymru.museum",
-  "nalchik.ru",
-  "bato.tochigi.jp",
-  "yufu.oita.jp",
-  "info.nr",
-  "net.vc",
-  "larvik.no",
-  "info.ni",
-  "net.vu",
-  "info.nf",
-  "friulivgiulia.it",
-  "wolomin.pl",
-  "info.na",
-  "songdalen.no",
-  "land",
-  "web.lk",
-  "tn.it",
-  "oracle",
-  "kisarazu.chiba.jp",
-  "priv.pl",
-  "qvc",
-  "luster.no",
-  "fujikawaguchiko.yamanashi.jp",
-  "terni.it",
-  "stathelle.no",
-  "tabayama.yamanashi.jp",
-  "garden",
-  "natuurwetenschappen.museum",
-  "zgora.pl",
-  "medecin.fr",
-  "\u798f\u5ca1.jp",
-  "ehime.jp",
-  "fareast.ru",
-  "calabria.it",
-  "taobao",
-  "narviika.no",
-  "zhitomir.ua",
-  "asso.dz",
-  "video",
-  "napoli.it",
-  "b\u00e5tsfjord.no",
-  "k12.wa.us",
-  "saitama.saitama.jp",
-  "vic.gov.au",
-  "kawakita.ishikawa.jp",
-  "co.pn",
-  "kosai.shizuoka.jp",
-  "b\u00f8.telemark.no",
-  "cambridge.museum",
-  "citic",
-  "vet.br",
-  "co.pw",
-  "com.kp",
-  "tranibarlettaandria.it",
-  "com.ky",
-  "virginia.museum",
-  "foodnetwork",
-  "com.kg",
-  "flakstad.no",
-  "aaa.pro",
-  "com.km",
-  "fujisawa.kanagawa.jp",
-  "kasamatsu.gifu.jp",
-  "nishigo.fukushima.jp",
-  "casino",
-  "koto.tokyo.jp",
-  "k12.tr",
-  "monzaedellabrianza.it",
-  "\u0628\u064a\u062a\u0643",
-  "hm.no",
-  "zaporizhzhia.ua",
-  "kamiizumi.saitama.jp",
-  "hatsukaichi.hiroshima.jp",
-  "fitjar.no",
-  "cbre",
-  "tools",
-  "tree.museum",
-  "zip",
-  "deatnu.no",
-  "sc.us",
-  "auto.pl",
-  "textile.museum",
-  "next",
-  "fortworth.museum",
-  "s.bg",
-  "vgs.no",
-  "incheon.kr",
-  "pt.it",
-  "sc.ug",
-  "media.hu",
-  "sp.it",
-  "rich",
-  "tamamura.gunma.jp",
-  "williamhill",
-  "nishinomiya.hyogo.jp",
-  "baby",
-  "embaixada.st",
-  "lebesby.no",
-  "hara.nagano.jp",
-  "nagato.yamaguchi.jp",
-  "ogawa.saitama.jp",
-  "athleta",
-  "jeep",
-  "emerson",
-  "sauherad.no",
-  "schlesisches.museum",
-  "yomitan.okinawa.jp",
-  "gov.sd",
-  "gov.sg",
-  "gov.sa",
-  "gov.sc",
-  "gov.sb",
-  "gov.sl",
-  "gov.sh",
-  "entertainment.aero",
-  "gov.st",
-  "srl",
-  "gov.sy",
-  "gov.sx",
-  "akdn",
-  "bashkiria.su",
-  "\u043c\u043e\u0441\u043a\u0432\u0430",
-  "uhren.museum",
-  "rakkestad.no",
-  "malatvuopmi.no",
-  "kvam.no",
-  "kamoenai.hokkaido.jp",
-  "srt",
-  "agrar.hu",
-  "culturalcenter.museum",
-  "bar.pro",
-  "int.la",
-  "praxi",
-  "int.lk",
-  "cl.it",
-  "store.st",
-  "ac.il",
-  "ac.im",
-  "ac.in",
-  "barcelona.museum",
-  "ac.id",
-  "yoka.hyogo.jp",
-  "higashimurayama.tokyo.jp",
-  "daigo.ibaraki.jp",
-  "communications.museum",
-  "grp.lk",
-  "mukawa.hokkaido.jp",
-  "sokndal.no",
-  "kv.ua",
-  "kizu.kyoto.jp",
-  "yame.fukuoka.jp",
-  "dep.no",
-  "docs",
-  "suzu.ishikawa.jp",
-  "tempioolbia.it",
-  "koshimizu.hokkaido.jp",
-  "pol.tr",
-  "living.museum",
-  "\u5927\u5206.jp",
-  "bardu.no",
-  "burghof.museum",
-  "br.it",
-  "samukawa.kanagawa.jp",
-  "vibovalentia.it",
-  "matera.it",
-  "kpn",
-  "av.it",
-  "osen.no",
-  "lanxess",
-  "motosu.gifu.jp",
-  "pmn.it",
-  "cci.fr",
-  "lur\u00f8y.no",
-  "\u66f8\u7c4d",
-  "boutique",
-  "hadsel.no",
-  "wegrow.pl",
-  "corsica",
-  "correios-e-telecomunica\u00e7\u00f5es.museum",
-  "org.ni",
-  "durban",
-  "org.ng",
-  "org.na",
-  "yoshioka.gunma.jp",
-  "org.nz",
-  "red.sv",
-  "org.nr",
-  "tawaramoto.nara.jp",
-  "lib.ok.us",
-  "bir.ru",
-  "cc.ny.us",
-  "belau.pw",
-  "gov.ly",
-  "gov.lt",
-  "or.th",
-  "vestre-toten.no",
-  "abiko.chiba.jp",
-  "anthropology.museum",
-  "gov.lk",
-  "or.tz",
-  "gov.la",
-  "gov.lb",
-  "gov.lc",
-  "trentino-stirol.it",
-  "not.br",
-  "izhevsk.ru",
-  "mitou.yamaguchi.jp",
-  "farmequipment.museum",
-  "norton",
-  "nationalfirearms.museum",
-  "nm.cn",
-  "imamat",
-  "nishikata.tochigi.jp",
-  "namsskogan.no",
-  "kyoto.jp",
-  "jan-mayen.no",
-  "hitachiomiya.ibaraki.jp",
-  "morotsuka.miyazaki.jp",
-  "lib.tn.us",
-  "ot.it",
-  "ozu.ehime.jp",
-  "makinohara.shizuoka.jp",
-  "\u0431\u0435\u043b",
-  "lib.il.us",
-  "mibu.tochigi.jp",
-  "higashikagura.hokkaido.jp",
-  "omigawa.chiba.jp",
-  "perso.tn",
-  "gob.sv",
-  "blockbuster",
-  "natori.miyagi.jp",
-  "culture.museum",
-  "kunitachi.tokyo.jp",
-  "oyabe.toyama.jp",
-  "wakasa.fukui.jp",
-  "best",
-  "rmit",
-  "lib.gu.us",
-  "latino",
-  "linde",
-  "rennebu.no",
-  "toyo.kochi.jp",
-  "k12.ak.us",
-  "jobs.tt",
-  "aq.it",
-  "visa",
-  "minnesota.museum",
-  "miyoshi.hiroshima.jp",
-  "kurgan.ru",
-  "bio.br",
-  "tomioka.gunma.jp",
-  "mil.qa",
-  "landes.museum",
-  "honbetsu.hokkaido.jp",
-  "lc.it",
-  "\u9ce5\u53d6.jp",
-  "corvette.museum",
-  "k12.md.us",
-  "\u5bb6\u96fb",
-  "kozaki.chiba.jp",
-  "matsusaka.mie.jp",
-  "brandywinevalley.museum",
-  "net.tw",
-  "web.nf",
-  "holt\u00e5len.no",
-  "net.tr",
-  "web.ni",
-  "campidano-medio.it",
-  "autos",
-  "reggiocalabria.it",
-  "newjersey.museum",
-  "net.tn",
-  "net.tm",
-  "luzern.museum",
-  "net.th",
-  "reit",
-  "intl.tn",
-  "romskog.no",
-  "itano.tokushima.jp",
-  "aeg",
-  "gran.no",
-  "haugesund.no",
-  "v\u00e5g\u00e5.no",
-  "swiftcover",
-  "greta.fr",
-  "kishiwada.osaka.jp",
-  "rennesoy.no",
-  "nes.akershus.no",
-  "virtuel.museum",
-  "shimosuwa.nagano.jp",
-  "vistaprint",
-  "gs.cn",
-  "ac.ir",
-  "koge.tottori.jp",
-  "email",
-  "judaica.museum",
-  "inagawa.hyogo.jp",
-  "sor-aurdal.no",
-  "experts-comptables.fr",
-  "\u5fae\u535a",
-  "mielec.pl",
-  "komatsu",
-  "e-burg.ru",
-  "safety.aero",
-  "ci",
-  "ch",
-  "shishikui.tokushima.jp",
-  "cn",
-  "cm",
-  "cl",
-  "cc",
-  "ca",
-  "watari.miyagi.jp",
-  "cf",
-  "cd",
-  "cz",
-  "cx",
-  "cr",
-  "cw",
-  "cv",
-  "cu",
-  "co.rw",
-  "venice.it",
-  "co.rs",
-  "shimogo.fukushima.jp",
-  "h.se",
-  "lindesnes.no",
-  "com.mx",
-  "com.my",
-  "lib.id.us",
-  "satte.saitama.jp",
-  "com.ms",
-  "com.mv",
-  "com.mw",
-  "com.mt",
-  "com.mu",
-  "nordkapp.no",
-  "com.mo",
-  "com.ml",
-  "graphics",
-  "toyono.osaka.jp",
-  "com.mg",
-  "froland.no",
-  "gs.oslo.no",
-  "eus",
-  "teo.br",
-  "rindal.no",
-  "vc",
-  "juedisches.museum",
-  "ve",
-  "vg",
-  "vi",
-  "bjark\u00f8y.no",
-  "site",
-  "vn",
-  "trentinosuedtirol.it",
-  "mihama.wakayama.jp",
-  "ltd.cy",
-  "tattoo",
-  "yamada.iwate.jp",
-  "tula.su",
-  "karlsoy.no",
-  "cc.ak.us",
-  "trust.museum",
-  "android",
-  "chuo.osaka.jp",
-  "chuvashia.ru",
-  "posts-and-telecommunications.museum",
-  "infiniti",
-  "*.bd",
-  "toshiba",
-  "*.bn",
-  "asso.fr",
-  "off",
-  "principe.st",
-  "edu.ni",
-  "edu.ng",
-  "*.jm",
-  "kanzaki.saga.jp",
-  "audio",
-  "edu.nr",
-  "tomisato.chiba.jp",
-  "gov.qa",
-  "gs.rl.no",
-  "madrid.museum",
-  "fj.cn",
-  "lib.mi.us",
-  "fet.no",
-  "wed",
-  "komae.tokyo.jp",
-  "parliament.cy",
-  "tsunan.niigata.jp",
-  "\u00e5snes.no",
-  "ddr.museum",
-  "museum.tt",
-  "shobara.hiroshima.jp",
-  "aya.miyazaki.jp",
-  "\u653f\u5e9c",
-  "kharkiv.ua",
-  "tm.ro",
-  "int.ni",
-  "kadena.okinawa.jp",
-  "ven.it",
-  "amot.no",
-  "liguria.it",
-  "omachi.saga.jp",
-  "shikabe.hokkaido.jp",
-  "boston.museum",
-  "iijima.nagano.jp",
-  "emergency.aero",
-  "futaba.fukushima.jp",
-  "omi.niigata.jp",
-  "witd.gov.pl",
-  "hidaka.hokkaido.jp",
-  "in.us",
-  "ikeda.hokkaido.jp",
-  "inf.mk",
-  "minano.saitama.jp",
-  "mill.museum",
-  "in.ua",
-  "ostre-toten.no",
-  "rauma.no",
-  "tosu.saga.jp",
-  "consulting.aero",
-  "unsa.ba",
-  "shimane.jp",
-  "civilisation.museum",
-  "birdart.museum",
-  "ichikai.tochigi.jp",
-  "loans",
-  "voss.no",
-  "\u5c71\u5f62.jp",
-  "lifestyle",
-  "klodzko.pl",
-  "k12.as.us",
-  "holdings",
-  "stavropol.ru",
-  "minamitane.kagoshima.jp",
-  "krd",
-  "software",
-  "noheji.aomori.jp",
-  "kaminoyama.yamagata.jp",
-  "ismaili",
-  "ichihara.chiba.jp",
-  "dyroy.no",
-  "org.pt",
-  "taishi.hyogo.jp",
-  "org.pr",
-  "org.ps",
-  "net.om",
-  "org.py",
-  "org.pf",
-  "org.pe",
-  "org.pa",
-  "org.pn",
-  "org.pl",
-  "org.pk",
-  "org.ph",
-  "hongo.hiroshima.jp",
-  "akagi.shimane.jp",
-  "volvo",
-  "tp.it",
-  "pro.pr",
-  "s\u00f8r-varanger.no",
-  "irish",
-  "kiyokawa.kanagawa.jp",
-  "vadso.no",
-  "int",
-  "life",
-  "!city.nagoya.jp",
-  "kanazawa.ishikawa.jp",
-  "kerrylogistics",
-  "skanit.no",
-  "ink",
-  "namsos.no",
-  "ing",
-  "g\u00e1ls\u00e1.no",
-  "starnberg.museum",
-  "k12.il.us",
-  "sykkylven.no",
-  "kami.kochi.jp",
-  "satsumasendai.kagoshima.jp",
-  "hirakata.osaka.jp",
-  "osoyro.no",
-  "\u798f\u4e95.jp",
-  "omi.nagano.jp",
-  "aetna",
-  "from.hr",
-  "genting",
-  "ina.ibaraki.jp",
-  "med.ht",
-  "namegata.ibaraki.jp",
-  "takayama.gifu.jp",
-  "maniwa.okayama.jp",
-  "oki.fukuoka.jp",
-  "takatsuki.osaka.jp",
-  "idv.tw",
-  "nsw.au",
-  "bike",
-  "n.se",
-  "mp.br",
-  "bomlo.no",
-  "grane.no",
-  "inami.toyama.jp",
-  "rahkkeravju.no",
-  "casadelamoneda.museum",
-  "\u500b\u4eba.hk",
-  "\u6ecb\u8cc0.jp",
-  "\u5ca1\u5c71.jp",
-  "lib.co.us",
-  "tickets",
-  "oizumi.gunma.jp",
-  "gs.vf.no",
-  "tamakawa.fukushima.jp",
-  "portlligat.museum",
-  "ikeda.nagano.jp",
-  "yoro.gifu.jp",
-  "mil.st",
-  "sasebo.nagasaki.jp",
-  "kita.osaka.jp",
-  "mil.sy",
-  "dish",
-  "*.sapporo.jp",
-  "guge",
-  "eurovision",
-  "\u0633\u0648\u062f\u0627\u0646",
-  "mil.sh",
-  "km.ua",
-  "discovery.museum",
-  "\u043f\u0440.\u0441\u0440\u0431",
-  "nomi.ishikawa.jp",
-  "ono.hyogo.jp",
-  "test.tj",
-  "net.ru",
-  "catering.aero",
-  "net.rw",
-  "\u6771\u4eac.jp",
-  "hyundai",
-  "protection",
-  "\u5948\u826f.jp",
-  "sakuragawa.ibaraki.jp",
-  "study",
-  "gle",
-  "bnpparibas",
-  "alaska.museum",
-  "messina.it",
-  "tabuse.yamaguchi.jp",
-  "fot.br",
-  "kouhoku.saga.jp",
-  "total",
-  "\u7d44\u7e54.tw",
-  "tonosho.kagawa.jp",
-  "comcast",
-  "tj\u00f8me.no",
-  "\u0627\u06cc\u0631\u0627\u0646",
-  "roma.museum",
-  "fed.us",
-  "takasaki.gunma.jp",
-  "verbania.it",
-  "archaeology.museum",
-  "\u0627\u0631\u0627\u0645\u0643\u0648",
-  "honefoss.no",
-  "\u5bae\u57ce.jp",
-  "arkhangelsk.ru",
-  "il.us",
-  "work",
-  "aeroclub.aero",
-  "ichikawa.hyogo.jp",
-  "tsukui.kanagawa.jp",
-  "ouda.nara.jp",
-  "bunkyo.tokyo.jp",
-  "cc.ky.us",
-  "kawagoe.saitama.jp",
-  "lg.jp",
-  "dellogliastra.it",
-  "arteducation.museum",
-  "kosaka.akita.jp",
-  "macys",
-  "com.om",
-  "brasil.museum",
-  "re.kr",
-  "boats",
-  "pizza",
-  "uri.arpa",
-  "itayanagi.aomori.jp",
-  "manno.kagawa.jp",
-  "kr.it",
-  "lat",
-  "law",
-  "naroy.no",
-  "airtraffic.aero",
-  "chernihiv.ua",
-  "smolensk.ru",
-  "green",
-  "salon",
-  "shiraoka.saitama.jp",
-  "isla.pr",
-  "office",
-  "forsand.no",
-  "gop.pk",
-  "ogano.saitama.jp",
-  "gausdal.no",
-  "gjesdal.no",
-  "porsangu.no",
-  "adm.br",
-  "vladivostok.ru",
-  "gov.lv",
-  "coffee",
-  "safe",
-  "band",
-  "gov.lr",
-  "kostroma.ru",
-  "lg.ua",
-  "bank",
-  "edu.lk",
-  "edu.la",
-  "edu.lb",
-  "edu.lc",
-  "rocks",
-  "edu.ly",
-  "movistar",
-  "edu.lr",
-  "edu.lv",
-  "ck.ua",
-  "nv.us",
-  "md.ci",
-  "kamikawa.hyogo.jp",
-  "minamimaki.nagano.jp",
-  "\u0434\u0435\u0442\u0438",
-  "building.museum",
-  "gov.ws",
-  "ggf.br",
-  "lucania.it",
-  "veneto.it",
-  "\u9999\u6e2f",
-  "glass.museum",
-  "badajoz.museum",
-  "ro.it",
-  "seika.kyoto.jp",
-  "minamifurano.hokkaido.jp",
-  "ntt",
-  "gs.jan-mayen.no",
-  "jetzt",
-  "mizumaki.fukuoka.jp",
-  "tiaa",
-  "hanawa.fukushima.jp",
-  "honai.ehime.jp",
-  "kaneyama.yamagata.jp",
-  "frosta.no",
-  "kiyosato.hokkaido.jp",
-  "campania.it",
-  "sa.edu.au",
-  "k-uralsk.ru",
-  "miners.museum",
-  "tm.pl",
-  "ac.mu",
-  "ac.mw",
-  "toga.toyama.jp",
-  "veg\u00e5rshei.no",
-  "kiso.nagano.jp",
-  "ac.ma",
-  "trentinos-tirol.it",
-  "ac.me",
-  "kamitonda.wakayama.jp",
-  "\u7f51\u7edc.cn",
-  "kitaaiki.nagano.jp",
-  "nishiaizu.fukushima.jp",
-  "kiwi",
-  "pv.it",
-  "sande.more-og-romsdal.no",
-  "ulan-ude.ru",
-  "royrvik.no",
-  "edu.az",
-  "reklam.hu",
-  "lib.pa.us",
-  "cc.ks.us",
-  "takehara.hiroshima.jp",
-  "target",
-  "gmina.pl",
-  "sasayama.hyogo.jp",
-  "nhs.uk",
-  "denmark.museum",
-  "yamanouchi.nagano.jp",
-  "shimoichi.nara.jp",
-  "lib.ga.us",
-  "luxury",
-  "\u0627\u0645\u0627\u0631\u0627\u062a",
-  "*.nagoya.jp",
-  "net.ma",
-  "avocat.fr",
-  "net.me",
-  "k12.mi.us",
-  "net.mk",
-  "net.ml",
-  "l\u00e1hppi.no",
-  "net.mo",
-  "ptz.ru",
-  "net.ms",
-  "net.mt",
-  "net.mu",
-  "net.mv",
-  "net.mw",
-  "net.mx",
-  "net.my",
-  "sb.ua",
-  "mediocampidano.it",
-  "org.ro",
-  "webcam",
-  "yuki.ibaraki.jp",
-  "lefrak",
-  "ass.km",
-  "lib.ar.us",
-  "pro.na",
-  "karumai.iwate.jp",
-  "cn.it",
-  "voting",
-  "kvits\u00f8y.no",
-  "film.museum",
-  "trentino-sudtirol.it",
-  "arts.nf",
-  "r\u00f8yrvik.no",
-  "zaporizhzhe.ua",
-  "us.na",
-  "atami.shizuoka.jp",
-  "meeres.museum",
-  "latina.it",
-  "sakaiminato.tottori.jp",
-  "planetarium.museum",
-  "neustar",
-  "malselv.no",
-  "lviv.ua",
-  "\u0645\u0644\u064a\u0633\u064a\u0627",
-  "stv.ru",
-  "minami.tokushima.jp",
-  "do",
-  "dm",
-  "dj",
-  "dk",
-  "plc.co.im",
-  "de",
-  "dz",
-  "accident-prevention.aero",
-  "extraspace",
-  "chanel",
-  "spy.museum",
-  "delmenhorst.museum",
-  "slupsk.pl",
-  "dupont",
-  "vologda.ru",
-  "klepp.no",
-  "aibetsu.hokkaido.jp",
-  "lom.it",
-  "coop.ht",
-  "!city.kawasaki.jp",
-  "observer",
-  "bearalvahki.no",
-  "fukushima.jp",
-  "sc.cn",
-  "kamiamakusa.kumamoto.jp",
-  "analytics",
-  "mo-i-rana.no",
-  "\u624b\u673a",
-  "salem.museum",
-  "abira.hokkaido.jp",
-  "yotsukaido.chiba.jp",
-  "ar.it",
-  "newmexico.museum",
-  "mizuho.tokyo.jp",
-  "kawai.iwate.jp",
-  "lv.ua",
-  "2.bg",
-  "\u9999\u5ddd.jp",
-  "wf",
-  "tonaki.okinawa.jp",
-  "r\u00e5holt.no",
-  "mobara.chiba.jp",
-  "uryu.hokkaido.jp",
-  "kherson.ua",
-  "ws",
-  "newyork.museum",
-  "ms.us",
-  "plc.ly",
-  "fage",
-  "com",
-  "org.ec",
-  "birkenes.no",
-  "nakai.kanagawa.jp",
-  "\u30af\u30e9\u30a6\u30c9",
-  "yamaga.kumamoto.jp",
-  "hofu.yamaguchi.jp",
-  "k12.ms.us",
-  "varese.it",
-  "g12.br",
-  "yuu.yamaguchi.jp",
-  "info.hu",
-  "info.ht",
-  "futtsu.chiba.jp",
-  "net.py",
-  "muroran.hokkaido.jp",
-  "test.ru",
-  "net.ps",
-  "net.pr",
-  "karatsu.saga.jp",
-  "pesarourbino.it",
-  "net.pk",
-  "net.ph",
-  "net.pn",
-  "hanamigawa.chiba.jp",
-  "net.pl",
-  "net.pa",
-  "isa.us",
-  "net.pe",
-  "h\u00e5.no",
-  "\u00f8stre-toten.no",
-  "takatori.nara.jp",
-  "balat.no",
-  "vf.no",
-  "alabama.museum",
-  "lib.de.us",
-  "az.us",
-  "aig",
-  "property",
-  "olayan",
-  "\u9752\u68ee.jp",
-  "priv.no",
-  "wios.gov.pl",
-  "l\u00f8dingen.no",
-  "sakura",
-  "komatsu.ishikawa.jp",
-  "k12.gu.us",
-  "matsumoto.nagano.jp",
-  "raid",
-  "\u5728\u7ebf",
-  "juniper",
-  "vagsoy.no",
-  "dr\u00f8bak.no",
-  "oirase.aomori.jp",
-  "yokote.akita.jp",
-  "mx.na",
-  "sasaguri.fukuoka.jp",
-  "contact",
-  "kyowa.hokkaido.jp",
-  "nagano.jp",
-  "masaki.ehime.jp",
-  "thd",
-  "juegos",
-  "rec.co",
-  "stjordalshalsen.no",
-  "kudamatsu.yamaguchi.jp",
-  "sebastopol.ua",
-  "photo",
-  "mincom.tn",
-  "wildlife.museum",
-  "kanonji.kagawa.jp",
-  "nsw.edu.au",
-  "minato.tokyo.jp",
-  "health.nz",
-  "com.al",
-  "family",
-  "com.ai",
-  "com.af",
-  "com.ag",
-  "tatarstan.ru",
-  "toei.aichi.jp",
-  "com.ac",
-  "blackfriday",
-  "com.az",
-  "com.aw",
-  "com.au",
-  "com.ar",
-  "viking",
-  "sumy.ua",
-  "ppg.br",
-  "hvaler.no",
-  "leksvik.no",
-  "\u307f\u3093\u306a",
-  "xbox",
-  "toda.saitama.jp",
-  "kep.tr",
-  "yasugi.shimane.jp",
-  "productions",
-  "cieszyn.pl",
-  "udono.mie.jp",
-  "ci.it",
-  "matsudo.chiba.jp",
-  "cancerresearch",
-  "tranoy.no",
-  "*.fj",
-  "*.fk",
-  "gotemba.shizuoka.jp",
-  "rissa.no",
-  "powiat.pl",
-  "marketing",
-  "asso.bj",
-  "laquila.it",
-  "lixil",
-  "post",
-  "saxo",
-  "properties",
-  "obi",
-  "astronomy.museum",
-  "akune.kagoshima.jp",
-  "edu.jo",
-  "hattfjelldal.no",
-  "plaza.museum",
-  "nowtv",
-  "xyz",
-  "beppu.oita.jp",
-  "\u81fa\u7063",
-  "gov.ua",
-  "jelenia-gora.pl",
-  "gov.uk",
-  "nakadomari.aomori.jp",
-  "vercelli.it",
-  "antiques.museum",
-  "kitagata.saga.jp",
-  "sakuho.nagano.jp",
-  "melhus.no",
-  "farmers.museum",
-  "higashikawa.hokkaido.jp",
-  "mk.ua",
-  "monza-brianza.it",
-  "kazuno.akita.jp",
-  "alsace",
-  "ustka.pl",
-  "\u65b0\u6f5f.jp",
-  "b\u00e1id\u00e1r.no",
-  "vads\u00f8.no",
-  "sch.lk",
-  "mtr",
-  "unazuki.toyama.jp",
-  "kibichuo.okayama.jp",
-  "mtn",
-  "sch.ly",
-  "tel.tr",
-  "ac.cy",
-  "ac.cr",
-  "ac.cn",
-  "ac.ci",
-  "lecce.it",
-  "izumiotsu.osaka.jp",
-  "takaharu.miyazaki.jp",
-  "shakotan.hokkaido.jp",
-  "kamimine.saga.jp",
-  "histoire.museum",
-  "moareke.no",
-  "lib.ee",
-  "nom.km",
-  "sor-odal.no",
-  "roma.it",
-  "weatherchannel",
-  "omega",
-  "stordal.no",
-  "anan.tokushima.jp",
-  "muni.il",
-  "gniezno.pl",
-  "pp.se",
-  "tsu.mie.jp",
-  "steiermark.museum",
-  "kanna.gunma.jp",
-  "dance",
-  "pro.ht",
-  "oslo.no",
-  "iwi.nz",
-  "otsuchi.iwate.jp",
-  "zone",
-  "\u09ad\u09be\u09b0\u09a4",
-  "nh.us",
-  "assassination.museum",
-  "og.it",
-  "zgrad.ru",
-  "uscountryestate.museum",
-  "net.ki",
-  "net.kn",
-  "izumozaki.niigata.jp",
-  "zp.ua",
-  "org.tr",
-  "net.kg",
-  "org.tt",
-  "net.kz",
-  "\u7ec4\u7ec7\u673a\u6784",
-  "net.ky",
-  "org.tn",
-  "org.to",
-  "org.tm",
-  "cc.ri.us",
-  "wa.gov.au",
-  "obama.nagasaki.jp",
-  "guitars",
-  "indian.museum",
-  "hida.gifu.jp",
-  "htc",
-  "kiho.mie.jp",
-  "or.jp",
-  "discover",
-  "hl.cn",
-  "detroit.museum",
-  "mitane.akita.jp",
-  "\u0b87\u0bb2\u0b99\u0bcd\u0b95\u0bc8",
-  "go.jp",
-  "higashiyodogawa.osaka.jp",
-  "hdfc",
-  "architecture.museum",
-  "vard\u00f8.no",
-  "tv.br",
-  "porsanger.no",
-  "i.ng",
-  "tv.bb",
-  "kikonai.hokkaido.jp",
-  "tv.bo",
-  "nj.us",
-  "nogata.fukuoka.jp",
-  "\u043e\u043d\u043b\u0430\u0439\u043d",
-  "l.bg",
-  "domains",
-  "vantaa.museum",
-  "med.ly",
-  "gob.mx",
-  "automotive.museum",
-  "yura.wakayama.jp",
-  "baghdad.museum",
-  "market",
-  "anthro.museum",
-  "tonami.toyama.jp",
-  "hekinan.aichi.jp",
-  "ojiya.niigata.jp",
-  "u.bg",
-  "live",
-  "ba.it",
-  "artsandcrafts.museum",
-  "club",
-  "lib.in.us",
-  "flekkefjord.no",
-  "isen.kagoshima.jp",
-  "massa-carrara.it",
-  "zarow.pl",
-  "ibm",
-  "car",
-  "fujixerox",
-  "cat",
-  "cc.nc.us",
-  "cal",
-  "cab",
-  "idrett.no",
-  "sm\u00f8la.no",
-  "matsukawa.nagano.jp",
-  "swidnica.pl",
-  "net.tt",
-  "hamar.no",
-  "nakhodka.ru",
-  "clothing",
-  "kurume.fukuoka.jp",
-  "asn.lv",
-  "spb.ru",
-  "kamogawa.chiba.jp",
-  "kawakami.nagano.jp",
-  "info.ve",
-  "info.vn",
-  "nagahama.shiga.jp",
-  "aol",
-  "fuoisku.no",
-  "web.do",
-  "jar.ru",
-  "higashiyama.kyoto.jp",
-  "aquarium.museum",
-  "iiyama.nagano.jp",
-  "ol.no",
-  "edu.ws",
-  "gd.cn",
-  "karate.museum",
-  "priv.hu",
-  "info.la",
-  "ieee",
-  "\u5de5\u884c",
-  "wv.us",
-  "flsmidth",
-  "net.tj",
-  "\u96c6\u56e2",
-  "est.pr",
-  "fnd.br",
-  "vi.it",
-  "aso.kumamoto.jp",
-  "medizinhistorisches.museum",
-  "r\u00f8st.no",
-  "chiba.jp",
-  "tjx",
-  "now",
-  "nome.pt",
-  "huissier-justice.fr",
-  "piacenza.it",
-  "minamiminowa.nagano.jp",
-  "tottori.jp",
-  "oceanographic.museum",
-  "salzburg.museum",
-  "moriya.ibaraki.jp",
-  "ee",
-  "eg",
-  "ec",
-  "soy",
-  "amsterdam",
-  "eu",
-  "et",
-  "ryazan.ru",
-  "es",
-  "com.ci",
-  "com.cm",
-  "com.cn",
-  "com.co",
-  "com.cy",
-  "trentino-s-tirol.it",
-  "com.cu",
-  "com.cw",
-  "sumita.iwate.jp",
-  "cars",
-  "school.nz",
-  "school.na",
-  "novara.it",
-  "kr.ua",
-  "mamurogawa.yamagata.jp",
-  "murayama.yamagata.jp",
-  "care",
-  "bern.museum",
-  "ks.us",
-  "shimamaki.hokkaido.jp",
-  "ks.ua",
-  "pamperedchef",
-  "gx.cn",
-  "odessa.ua",
-  "*.kobe.jp",
-  "pu.it",
-  "production.aero",
-  "shika.ishikawa.jp",
-  "tokamachi.niigata.jp",
-  "tsukigata.hokkaido.jp",
-  "lapy.pl",
-  "spreadbetting",
-  "katsuura.chiba.jp",
-  "pnc",
-  "flowers",
-  "yonaguni.okinawa.jp",
-  "narashino.chiba.jp",
-  "edu.ht",
-  "hsbc",
-  "edu.hn",
-  "edu.hk",
-  "hawaii.museum",
-  "hirokawa.fukuoka.jp",
-  "gs.bu.no",
-  "davvesiida.no",
-  "lib.mo.us",
-  "far.br",
-  "\u062a\u0648\u0646\u0633",
-  "bungoono.oita.jp",
-  "equipment",
-  "davvenj\u00e1rga.no",
-  "k12.al.us",
-  "online",
-  "fhv.se",
-  "sakaki.nagano.jp",
-  "oyamazaki.kyoto.jp",
-  "uslivinghistory.museum",
-  "yamagata.nagano.jp",
-  "teshikaga.hokkaido.jp",
-  "com.dm",
-  "lincoln.museum",
-  "sch.ng",
-  "afjord.no",
-  "com.do",
-  "yuzhno-sakhalinsk.ru",
-  "sue.fukuoka.jp",
-  "mifune.kumamoto.jp",
-  "ranzan.saitama.jp",
-  "szex.hu",
-  "fm.it",
-  "chofu.tokyo.jp",
-  "tsuwano.shimane.jp",
-  "sogne.no",
-  "koza.wakayama.jp",
-  "tsuru.yamanashi.jp",
-  "shirahama.wakayama.jp",
-  "bs.it",
-  "k12.co.us",
-  "nom.mg",
-  "consultant.aero",
-  "jamison.museum",
-  "catering",
-  "obuse.nagano.jp",
-  "yamato.kumamoto.jp",
-  "shirakawa.fukushima.jp",
-  "suzaka.nagano.jp",
-  "loten.no",
-  "fi.it",
-  "nanmoku.gunma.jp",
-  "org.ve",
-  "firestone",
-  "kariwa.niigata.jp",
-  "org.vc",
-  "suginami.tokyo.jp",
-  "org.vi",
-  "org.vu",
-  "harima.hyogo.jp",
-  "cc.vt.us",
-  "airline.aero",
-  "*.sendai.jp",
-  "net.iq",
-  "net.ir",
-  "net.is",
-  "style",
-  "nishiarita.saga.jp",
-  "miyakonojo.miyazaki.jp",
-  "net.id",
-  "onojo.fukuoka.jp",
-  "net.il",
-  "net.im",
-  "net.in",
-  "ac.ae",
-  "nov.ru",
-  "deals",
-  "ac.at",
-  "figueres.museum",
-  "moriguchi.osaka.jp",
-  "ama.shimane.jp",
-  "kitashiobara.fukushima.jp",
-  "fiat",
-  "kumenan.okayama.jp",
-  "ta.it",
-  "muenster.museum",
-  "minakami.gunma.jp",
-  "higashichichibu.saitama.jp",
-  "wien",
-  "miyama.fukuoka.jp",
-  "leg.br",
-  "cymru",
-  "shikama.miyagi.jp",
-  "katagami.akita.jp",
-  "hoyanger.no",
-  "nord-aurdal.no",
-  "aero",
-  "nikon",
-  "c.se",
-  "mulhouse.museum",
-  "hirara.okinawa.jp",
-  "western.museum",
-  "andasuolo.no",
-  "carrara-massa.it",
-  "\u79fb\u52a8",
-  "cc.ar.us",
-  "rwe",
-  "hanyu.saitama.jp",
-  "cc.as.us",
-  "ericsson",
-  "hiroo.hokkaido.jp",
-  "ichiba.tokushima.jp",
-  "narvik.no",
-  "plantation.museum",
-  "\u05e7\u05d5\u05dd",
-  "england.museum",
-  "scor",
-  "la.us",
-  "name.qa",
-  "otsuka",
-  "akabira.hokkaido.jp",
-  "www.ro",
-  "pulawy.pl",
-  "palmsprings.museum",
-  "brussel.museum",
-  "genoa.it",
-  "daiwa.hiroshima.jp",
-  "chiryu.aichi.jp",
-  "kashima.saga.jp",
-  "\u0443\u043a\u0440",
-  "info.tr",
-  "gov.nc.tr",
-  "info.tt",
-  "design.museum",
-  "kunisaki.oita.jp",
-  "info.tz",
-  "lyngen.no",
-  "hashima.gifu.jp",
-  "miyazu.kyoto.jp",
-  "info.tn",
-  "shimizu.hokkaido.jp",
-  "siljan.no",
-  "\u9ad8\u77e5.jp",
-  "lt.it",
-  "cg",
-  "mashiki.kumamoto.jp",
-  "mt.it",
-  "maebashi.gunma.jp",
-  "edu.ua",
-  "enterprises",
-  "balsan.it",
-  "edu.uy",
-  "gub.uy",
-  "technology.museum",
-  "cisco",
-  "apartments",
-  "spydeberg.no",
-  "hn.cn",
-  "sardegna.it",
-  "k12.az.us",
-  "nanao.ishikawa.jp",
-  "iheya.okinawa.jp",
-  "me.tz",
-  "trentinoalto-adige.it",
-  "hasami.nagasaki.jp",
-  "tdk",
-  "matsushige.tokushima.jp",
-  "epson",
-  "h\u00f8yanger.no",
-  "business",
-  "club.aero",
-  "volkswagen",
-  "kainan.wakayama.jp",
-  "saltdal.no",
-  "niigata.jp",
-  "otsu.shiga.jp",
-  "shimizu.shizuoka.jp",
-  "glade",
-  "miyake.nara.jp",
-  "selbu.no",
-  "gangwon.kr",
-  "aip.ee",
-  "toyonaka.osaka.jp",
-  "house.museum",
-  "on.ca",
-  "co.za",
-  "\u77f3\u5ddd.jp",
-  "pl.ua",
-  "daito.osaka.jp",
-  "umbria.it",
-  "com.es",
-  "fujisato.akita.jp",
-  "aerodrome.aero",
-  "com.et",
-  "yekaterinburg.ru",
-  "lol",
-  "holmestrand.no",
-  "com.ec",
-  "com.eg",
-  "com.ee",
-  "lombardia.it",
-  "te.it",
-  "\u00e1k\u014boluokta.no",
-  "monticello.museum",
-  "roan.no",
-  "children.museum",
-  "luxembourg.museum",
-  "prochowice.pl",
-  "eti.br",
-  "yawara.ibaraki.jp",
-  "citadel",
-  "builders",
-  "futbol",
-  "shinichi.hiroshima.jp",
-  "s\u00e1l\u00e1t.no",
-  "sicilia.it",
-  "lundbeck",
-  "maserati",
-  "kutchan.hokkaido.jp",
-  "fukuyama.hiroshima.jp",
-  "stokke.no",
-  "misugi.mie.jp",
-  "storage",
-  "sakai.osaka.jp",
-  "bandai.fukushima.jp",
-  "ilawa.pl",
-  "k12.sc.us",
-  "nagara.chiba.jp",
-  "ayabe.kyoto.jp",
-  "asso.nc",
-  "al.it",
-  "indiana.museum",
-  "iitate.fukushima.jp",
-  "ueno.gunma.jp",
-  "genova.it",
-  "shisui.chiba.jp",
-  "kembuchi.hokkaido.jp",
-  "stryn.no",
-  "wif.gov.pl",
-  "kunigami.okinawa.jp",
-  "risor.no",
-  "biz.bb",
-  "southcarolina.museum",
-  "kounosu.saitama.jp",
-  "meraker.no",
-  "caseih",
-  "sa.cr",
-  "omotego.fukushima.jp",
-  "algard.no",
-  "safety",
-  "wme",
-  "dp.ua",
-  "tm.za",
-  "epilepsy.museum",
-  "dr.tr",
-  "sydney.museum",
-  "k12.vi",
-  "musashino.tokyo.jp",
-  "\u7f51\u7ad9",
-  "sevastopol.ua",
-  "presse.km",
-  "toyosato.shiga.jp",
-  "cr.ua",
-  "mizunami.gifu.jp",
-  "control.aero",
-  "muroto.kochi.jp",
-  "akrehamn.no",
-  "\u5609\u91cc\u5927\u9152\u5e97",
-  "suli.hu",
-  "cookingchannel",
-  "nc.tr",
-  "cbg.ru",
-  "kalmykia.su",
-  "aver\u00f8y.no",
-  "prd.fr",
-  "shimokawa.hokkaido.jp",
-  "museumvereniging.museum",
-  "jevnaker.no",
-  "tsukumi.oita.jp",
-  "misaki.osaka.jp",
-  "oryol.ru",
-  "syzran.ru",
-  "shari.hokkaido.jp",
-  "imperia.it",
-  "niki.hokkaido.jp",
-  "zagan.pl",
-  "savona.it",
-  "ny.us",
-  "va",
-  "toys",
-  "tra.kp",
-  "namegawa.saitama.jp",
-  "polkowice.pl",
-  "hayashima.okayama.jp",
-  "sv.it",
-  "uchihara.ibaraki.jp",
-  "shingo.aomori.jp",
-  "\u5bcc\u5c71.jp",
-  "berlev\u00e5g.no",
-  "udine.it",
-  "vao.it",
-  "net.gy",
-  "net.gt",
-  "net.gr",
-  "net.gp",
-  "net.gn",
-  "net.gl",
-  "ryuoh.shiga.jp",
-  "valle-d-aosta.it",
-  "net.gg",
-  "kesennuma.miyagi.jp",
-  "net.ge",
-  "gbiz",
-  "anquan",
-  "cc.ma.us",
-  "ac.gn",
-  "etc.br",
-  "vu",
-  "kuriyama.hokkaido.jp",
-  "kagoshima.kagoshima.jp",
-  "lib.or.us",
-  "yakumo.shimane.jp",
-  "york.museum",
-  "lib.al.us",
-  "sr.it",
-  "edu.sy",
-  "izumisano.osaka.jp",
-  "kiwi.nz",
-  "fr",
-  "odate.akita.jp",
-  "mitsuke.niigata.jp",
-  "bod\u00f8.no",
-  "fi",
-  "heguri.nara.jp",
-  "fm",
-  "fo",
-  "sayama.saitama.jp",
-  "montblanc",
-  "lezajsk.pl",
-  "fukuchi.fukuoka.jp",
-  "nagaoka.niigata.jp",
-  "ishikawa.jp",
-  "szkola.pl",
-  "circus.museum",
-  "help",
-  "bahn.museum",
-  "gloppen.no",
-  "icbc",
-  "mcdonalds",
-  "verm\u00f6gensberatung",
-  "akiruno.tokyo.jp",
-  "mansion.museum",
-  "systems",
-  "trentinoaadige.it",
-  "kure.hiroshima.jp",
-  "ceb",
-  "hembygdsforbund.museum",
-  "ceo",
-  "tamba.hyogo.jp",
-  "ninja",
-  "bodo.no",
-  "research.museum",
-  "yt",
-  "staples",
-  "tuva.ru",
-  "or.na",
-  "ichinomiya.chiba.jp",
-  "misato.akita.jp",
-  "wajima.ishikawa.jp",
-  "railway.museum",
-  "kuzumaki.iwate.jp",
-  "ifm",
-  "nakaniikawa.toyama.jp",
-  "educator.aero",
-  "fam.pk",
-  "cc.ga.us",
-  "numata.gunma.jp",
-  "engineer.aero",
-  "shingu.fukuoka.jp",
-  "mikasa.hokkaido.jp",
-  "hachioji.tokyo.jp",
-  "steinkjer.no",
-  "catania.it",
-  "info.ro",
-  "nasu.tochigi.jp",
-  "art.br",
-  "pub",
-  "arts.co",
-  "avellino.it",
-  "johana.toyama.jp",
-  "duns",
-  "k12.de.us",
-  "lier.no",
-  "agrinet.tn",
-  "norddal.no",
-  "edu.sl",
-  "academy.museum",
-  "edu.sn",
-  "edu.sa",
-  "edu.sc",
-  "edu.sb",
-  "edu.sd",
-  "edu.sg",
-  "shimofusa.chiba.jp",
-  "liaison",
-  "oto.fukuoka.jp",
-  "edu.st",
-  "edu.sv",
-  "cc.de.us",
-  "m\u00e5s\u00f8y.no",
-  "\u00e5mot.no",
-  "horse",
-  "*.sch.uk",
-  "khabarovsk.ru",
-  "k12.ok.us",
-  "flor\u00f8.no",
-  "stc",
-  "tokashiki.okinawa.jp",
-  "hanno.saitama.jp",
-  "kindle",
-  "dtv",
-  "cmw.ru",
-  "chikusei.ibaraki.jp",
-  "sk.ca",
-  "salat.no",
-  "aosta-valley.it",
-  "telekommunikation.museum",
-  "biz.vn",
-  "aknoluokta.no",
-  "com.gy",
-  "zama.kanagawa.jp",
-  "\u7f51\u5740",
-  "com.gt",
-  "com.gp",
-  "com.gr",
-  "snoasa.no",
-  "com.gl",
-  "nannestad.no",
-  "com.gn",
-  "com.gh",
-  "com.gi",
-  "com.ge",
-  "g.bg",
-  "oe.yamagata.jp",
-  "vang.no",
-  "hikimi.shimane.jp",
-  "zachpomor.pl",
-  "agric.za",
-  "fuossko.no",
-  "mobily",
-  "komagane.nagano.jp",
-  "bzh",
-  "notaires.km",
-  "kuki.saitama.jp",
-  "lucca.it",
-  "ulsan.kr",
-  "nsk.ru",
-  "conf.lv",
-  "matsuda.kanagawa.jp",
-  "kameyama.mie.jp",
-  "nishiazai.shiga.jp",
-  "gunma.jp",
-  "tokyo.jp",
-  "flights",
-  "circle",
-  "kuji.iwate.jp",
-  "alfaromeo",
-  "asso.ht",
-  "nishi.osaka.jp",
-  "\u6803\u6728.jp",
-  "l\u00f8ten.no",
-  "\u7ec4\u7e54.hk",
-  "net.sb",
-  "res.in",
-  "komi.ru",
-  "niimi.okayama.jp",
-  "\u7f51\u7edc",
-  "arendal.no",
-  "kemerovo.ru",
-  "ris\u00f8r.no",
-  "settsu.osaka.jp",
-  "hagi.yamaguchi.jp",
-  "uz.ua",
-  "joetsu.niigata.jp",
-  "emr.it",
-  "bykle.no",
-  "pc.it",
-  "lib.nd.us",
-  "ashiya.hyogo.jp",
-  "\u0570\u0561\u0575",
-  "\u673a\u6784",
-  "sa.au",
-  "wow",
-  "teva",
-  "pr.us",
-  "\u9910\u5385",
-  "4.bg",
-  "rn.it",
-  "sakawa.kochi.jp",
-  "piedmont.it",
-  "makeup",
-  "sfr",
-  "fin.tn",
-  "owariasahi.aichi.jp",
-  "biratori.hokkaido.jp",
-  "agro.pl",
-  "presse.ml",
-  "wanouchi.gifu.jp",
-  "cc.pa.us",
-  "imakane.hokkaido.jp",
-  "sch.jo",
-  "misato.miyagi.jp",
-  "eisenbahn.museum",
-  "rost.no",
-  "shibuya.tokyo.jp",
-  "sd.us",
-  "\u4fe1\u606f",
-  "bievat.no",
-  "inf.cu",
-  "ferrero",
-  "ostrowwlkp.pl",
-  "nom.ag",
-  "naha.okinawa.jp",
-  "gs.svalbard.no",
-  "kiyose.tokyo.jp",
-  "salerno.it",
-  "kiyama.saga.jp",
-  "kasama.ibaraki.jp",
-  "design.aero",
-  "naples.it",
-  "macerata.it",
-  "k12.me.us",
-  "grajewo.pl",
-  "akita.jp",
-  "yamatsuri.fukushima.jp",
-  "langevag.no",
-  "oxford.museum",
-  "cc.gu.us",
-  "caltanissetta.it",
-  "guide",
-  "ina.nagano.jp",
-  "hapmir.no",
-  "kids.us",
-  "skype",
-  "shaw",
-  "org.za",
-  "urausu.hokkaido.jp",
-  "ivanovo.su",
-  "miyazaki.miyazaki.jp",
-  "microlight.aero",
-  "gol.no",
-  "net.et",
-  "haus",
-  "gobo.wakayama.jp",
-  "net.ec",
-  "zoological.museum",
-  "net.eg",
-  "mobi",
-  "rokunohe.aomori.jp",
-  "naoshima.kagawa.jp",
-  "marker.no",
-  "usa.oita.jp",
-  "desi",
-  "go.pw",
-  "toyooka.hyogo.jp",
-  "museum.mv",
-  "oshima.tokyo.jp",
-  "lunner.no",
-  "koshu.yamanashi.jp",
-  "toscana.it",
-  "tako.chiba.jp",
-  "jefferson.museum",
-  "takikawa.hokkaido.jp",
-  "irkutsk.ru",
-  "vestnes.no",
-  "lubin.pl",
-  "dubai",
-  "game",
-  "web.pk",
-  "leikanger.no",
-  "floro.no",
-  "itoigawa.niigata.jp",
-  "larsson.museum",
-  "toyota",
-  "hitachi.ibaraki.jp",
-  "himeji.hyogo.jp",
-  "science-fiction.museum",
-  "undersea.museum",
-  "\u0639\u0645\u0627\u0646",
-  "rade.no",
-  "sandiego.museum",
-  "versailles.museum",
-  "togura.nagano.jp",
-  "kagoshima.jp",
-  "shibata.niigata.jp",
-  "costume.museum",
-  "koeln",
-  "veterinaire.fr",
-  "jprs",
-  "run",
-  "force.museum",
-  "kursk.ru",
-  "iide.yamagata.jp",
-  "oguni.yamagata.jp",
-  "kurotaki.nara.jp",
-  "sanofi",
-  "faith",
-  "plants.museum",
-  "nd.us",
-  "chikuma.nagano.jp",
-  "cody.museum",
-  "sejny.pl",
-  "mobi.gp",
-  "chattanooga.museum",
-  "kitadaito.okinawa.jp",
-  "nb.ca",
-  "info.pl",
-  "info.pk",
-  "krasnodar.su",
-  "\u5609\u91cc",
-  "info.pr",
-  "stalowa-wola.pl",
-  "fortmissoula.museum",
-  "rl.no",
-  "takamori.kumamoto.jp",
-  "mn.us",
-  "esurance",
-  "ragusa.it",
-  "agr.br",
-  "noto.ishikawa.jp",
-  "art.dz",
-  "mt.us",
-  "hgtv",
-  "koori.fukushima.jp",
-  "pwc",
-  "art.do",
-  "no.it",
-  "j\u00f8lster.no",
-  "info",
-  "shiiba.miyazaki.jp",
-  "shimada.shizuoka.jp",
-  "edu.qa",
-  "politie",
-  "gob.gt",
-  "jessheim.no",
-  "kawanishi.yamagata.jp",
-  "americana.museum",
-  "sande.vestfold.no",
-  "sn\u00e5sa.no",
-  "yodobashi",
-  "makurazaki.kagoshima.jp",
-  "nab",
-  "fetsund.no",
-  "doshi.yamanashi.jp",
-  "abarth",
-  "firm.nf",
-  "fr\u00e6na.no",
-  "lplfinancial",
-  "yokawa.hyogo.jp",
-  "\u5546\u696d.tw",
-  "stcgroup",
-  "yamanakako.yamanashi.jp",
-  "games.hu",
-  "aquila.it",
-  "missoula.museum",
-  "youtube",
-  "mil.eg",
-  "k12.pa.us",
-  "mil.ec",
-  "starachowice.pl",
-  "gs.st.no",
-  "gw",
-  "\u5175\u5eab.jp",
-  "soeda.fukuoka.jp",
-  "mordovia.ru",
-  "ap.gov.pl",
-  "gr",
-  "gq",
-  "gp",
-  "vladikavkaz.su",
-  "gy",
-  "nanto.toyama.jp",
-  "gf",
-  "ge",
-  "gd",
-  "gb",
-  "ga",
-  "lib.wy.us",
-  "gn",
-  "oshu.iwate.jp",
-  "gl",
-  "\u0627\u06cc\u0631\u0627\u0646.ir",
-  "gi",
-  "gh",
-  "\u4f5b\u5c71",
-  "assedic.fr",
-  "lib.nh.us",
-  "\u0643\u0648\u0645",
-  "oyodo.nara.jp",
-  "kddi",
-  "tsuyama.okayama.jp",
-  "contemporaryart.museum",
-  "repbody.aero",
-  "\u03b5\u03bb",
-  "izumi.kagoshima.jp",
-  "kr\u00f8dsherad.no",
-  "tozawa.yamagata.jp",
-  "mod.gi",
-  "kota.aichi.jp",
-  "malopolska.pl",
-  "tomari.hokkaido.jp",
-  "\u0440\u0444",
-  "boots",
-  "ln.cn",
-  "vestby.no",
-  "download",
-  "oji.nara.jp",
-  "sapo",
-  "xz.cn",
-  "\u30dd\u30a4\u30f3\u30c8",
-  "*.np",
-  "warszawa.pl",
-  "adygeya.su",
-  "\u0643\u0627\u062b\u0648\u0644\u064a\u0643",
-  "rzeszow.pl",
-  "lib.nj.us",
-  "usculture.museum",
-  "ullensvang.no",
-  "airport.aero",
-  "gent",
-  "ono.fukui.jp",
-  "k12.nh.us",
-  "oystre-slidre.no",
-  "tmall",
-  "yamagata.yamagata.jp",
-  "win",
-  "yoshida.saitama.jp",
-  "takamatsu.kagawa.jp",
-  "gos.pk",
-  "moskenes.no",
-  "cloud",
-  "commbank",
-  "jgora.pl",
-  "kumiyama.kyoto.jp",
-  "press.aero",
-  "camera",
-  "gulen.no",
-  "tm.fr",
-  "yachiyo.chiba.jp",
-  "solund.no",
-  "shiriuchi.hokkaido.jp",
-  "caserta.it",
-  "\u0627\u0644\u0633\u0639\u0648\u062f\u06cc\u0629",
-  "bz.it",
-  "meet",
-  "cc.ne.us",
-  "sund.no",
-  "n.bg",
-  "woodside",
-  "hotmail",
-  "us.gov.pl",
-  "\u0627\u0644\u0633\u0639\u0648\u062f\u06cc\u06c3",
-  "bialystok.pl",
-  "ryokami.saitama.jp",
-  "cz.it",
-  "pink",
-  "loppa.no",
-  "creation.museum",
-  "lib.sc.us",
-  "biei.hokkaido.jp",
-  "aland.fi",
-  "monmouth.museum",
-  "mus.br",
-  "donna.no",
-  "simbirsk.ru",
-  "nord-odal.no",
-  "kamaishi.iwate.jp",
-  "ogawara.miyagi.jp",
-  "jl.cn",
-  "v.bg",
-  "ntr.br",
-  "scjohnson",
-  "healthcare",
-  "taxi.br",
-  "com.ly",
-  "ping",
-  "otaki.saitama.jp",
-  "onomichi.hiroshima.jp",
-  "cruise",
-  "jnj",
-  "fuefuki.yamanashi.jp",
-  "net.ci",
-  "net.cn",
-  "net.co",
-  "suwa.nagano.jp",
-  "net.cm",
-  "net.cw",
-  "net.cu",
-  "agano.niigata.jp",
-  "wodzislaw.pl",
-  "net.cy",
-  "com.lr",
-  "ab.ca",
-  "auto",
-  "kira.aichi.jp",
-  "bbva",
-  "rishiri.hokkaido.jp",
-  "himi.toyama.jp",
-  "beeldengeluid.museum",
-  "nyc",
-  "motobu.okinawa.jp",
-  "fusa.no",
-  "university",
-  "moda",
-  "toya.hokkaido.jp",
-  "katori.chiba.jp",
-  "verona.it",
-  "d.se",
-  "globo",
-  "yamagata.gifu.jp",
-  "lidl",
-  "ishinomaki.miyagi.jp",
-  "bedzin.pl",
-  "saiki.oita.jp",
-  "media.museum",
-  "sandoy.no",
-  "averoy.no",
-  "czeladz.pl",
-  "manchester.museum",
-  "krokstadelva.no",
-  "giehtavuoatna.no",
-  "spot",
-  "tsaritsyn.ru",
-  "gouv.bj",
-  "calvinklein",
-  "higashimatsushima.miyagi.jp",
-  "!city.sapporo.jp",
-  "kumano.mie.jp",
-  "wada.nagano.jp",
-  "sugito.saitama.jp",
-  "baltimore.museum",
-  "czest.pl",
-  "!www.ck",
-  "kamigori.hyogo.jp",
-  "nantan.kyoto.jp",
-  "id.ly",
-  "id.lv",
-  "tx.us",
-  "pescara.it",
-  "ikawa.akita.jp",
-  "tsushima.aichi.jp",
-  "art.museum",
-  "final",
-  "nesset.no",
-  "pictet",
-  "kvinnherad.no",
-  "yoshida.shizuoka.jp",
-  "insurance.aero",
-  "fukui.fukui.jp",
-  "sandnes.no",
-  "ngo.za",
-  "kg",
-  "lamborghini",
-  "friuli-vgiulia.it",
-  "bibai.hokkaido.jp",
-  "urakawa.hokkaido.jp",
-  "whaling.museum",
-  "or.bi",
-  "bet",
-  "sobetsu.hokkaido.jp",
-  "tadotsu.kagawa.jp",
-  "edeka",
-  "buy",
-  "belluno.it",
-  "jur.pro",
-  "kuromatsunai.hokkaido.jp",
-  "sj",
-  "able",
-  "amli.no",
-  "mango",
-  "vt.it",
-  "reggio-calabria.it",
-  "localhistory.museum",
-  "penza.ru",
-  "aws",
-  "matta-varjjat.no",
-  "hiphop",
-  "sciencecenters.museum",
-  "gallery",
-  "kitahata.saga.jp",
-  "delivery",
-  "gob.es",
-  "nt.edu.au",
-  "sunagawa.hokkaido.jp",
-  "nakagawa.fukuoka.jp",
-  "jx.cn",
-  "geometre-expert.fr",
-  "gob.ec",
-  "pictures",
-  "ne.pw",
-  "karasjok.no",
-  "tokuyama.yamaguchi.jp",
-  "edu.py",
-  "kani.gifu.jp",
-  "sanuki.kagawa.jp",
-  "arao.kumamoto.jp",
-  "miyagi.jp",
-  "partners",
-  "artcenter.museum",
-  "forex",
-  "e.se",
-  "nesna.no",
-  "ngo",
-  "chichibu.saitama.jp",
-  "cremona.it",
-  "dodge",
-  "\u611b\u77e5.jp",
-  "iwakura.aichi.jp",
-  "wajiki.tokushima.jp",
-  "flanders.museum",
-  "trentinosued-tirol.it",
-  "muos\u00e1t.no",
-  "potenza.it",
-  "rieti.it",
-  "sch.qa",
-  "mil.gt",
-  "sagae.yamagata.jp",
-  "mil.gh",
-  "tunes",
-  "mil.ge",
-  "tank.museum",
-  "uenohara.yamanashi.jp",
-  "\u30b9\u30c8\u30a2",
-  "km",
-  "computer",
-  "brussels.museum",
-  "mr.no",
-  "r\u00e1isa.no",
-  "\u00f8vre-eiker.no",
-  "org.kn",
-  "skj\u00e5k.no",
-  "pokrovsk.su",
-  "farm.museum",
-  "unzen.nagasaki.jp",
-  "flickr",
-  "and\u00f8y.no",
-  "utazas.hu",
-  "padova.it",
-  "labor.museum",
-  "samegawa.fukushima.jp",
-  "group",
-  "konin.pl",
-  "wtc",
-  "museum.om",
-  "columbus.museum",
-  "oishida.yamagata.jp",
-  "arna.no",
-  "gr.it",
-  "fredrikstad.no",
-  "obira.hokkaido.jp",
-  "oi.kanagawa.jp",
-  "dudinka.ru",
-  "org.ae",
-  "org.ag",
-  "palace.museum",
-  "pin",
-  "tagawa.fukuoka.jp",
-  "org.al",
-  "nakanojo.gunma.jp",
-  "org.ai",
-  "org.au",
-  "org.ar",
-  "h\u00e1bmer.no",
-  "org.az",
-  "wtf",
-  "shiroi.chiba.jp",
-  "mo.cn",
-  "childrensgarden.museum",
-  "ha.cn",
-  "hamburg",
-  "trading.aero",
-  "ott",
-  "gucci",
-  "moma.museum",
-  "aguni.okinawa.jp",
-  "dali.museum",
-  "*.ck",
-  "jeju.kr",
-  "tomi.nagano.jp",
-  "pubol.museum",
-  "dlugoleka.pl",
-  "finance",
-  "pr.it",
-  "homesense",
-  "lajolla.museum",
-  "parts",
-  "fido",
-  "idf.il",
-  "party",
-  "tateyama.chiba.jp",
-  "hurdal.no",
-  "hjartdal.no",
-  "buzz",
-  "valer.ostfold.no",
-  "erotika.hu",
-  "sm.ua",
-  "abashiri.hokkaido.jp",
-  "oygarden.no",
-  "metlife",
-  "yuasa.wakayama.jp",
-  "cc.sd.us",
-  "shinyoshitomi.fukuoka.jp",
-  "philadelphiaarea.museum",
-  "fukaya.saitama.jp",
-  "\u0938\u0902\u0917\u0920\u0928",
-  "audnedaln.no",
-  "fujinomiya.shizuoka.jp",
-  "de.us",
-  "yugawa.fukushima.jp",
-  "act.au",
-  "nom.es",
-  "pol.dz",
-  "nagawa.nagano.jp",
-  "pa.us",
-  "higashiizumo.shimane.jp",
-  "gifu.jp",
-  "ushuaia.museum",
-  "otsuki.yamanashi.jp",
-  "kannami.shizuoka.jp",
-  "gov.cu",
-  "lincoln",
-  "foggia.it",
-  "kasukabe.saitama.jp",
-  "gov.cy",
-  "gov.cx",
-  "gov.cd",
-  "gov.cm",
-  "gov.cl",
-  "gov.co",
-  "bajddar.no",
-  "page",
-  "inf.br",
-  "shichinohe.aomori.jp",
-  "*.kitakyushu.jp",
-  "grozny.ru",
-  "jlc",
-  "jll",
-  "net.al",
-  "romsa.no",
-  "kaizuka.osaka.jp",
-  "net.af",
-  "net.ag",
-  "net.ac",
-  "net.az",
-  "net.au",
-  "net.ar",
-  "pro.br",
-  "shimodate.ibaraki.jp",
-  "anan.nagano.jp",
-  "miasa.nagano.jp",
-  "yaizu.shizuoka.jp",
-  "bjugn.no",
-  "uozu.toyama.jp",
-  "minamisanriku.miyagi.jp",
-  "lib.va.us",
-  "american.museum",
-  "yamada.toyama.jp",
-  "kamikoani.akita.jp",
-  "tottori.tottori.jp",
-  "rodeo",
-  "nom.ad",
-  "gangaviika.no",
-  "av.tr",
-  "ringerike.no",
-  "ca.na",
-  "arts.museum",
-  "miyazaki.jp",
-  "skien.no",
-  "go.th",
-  "amursk.ru",
-  "szczecin.pl",
-  "museum",
-  "museum.mw",
-  "accountant",
-  "chuo.chiba.jp",
-  "suzuki",
-  "sera.hiroshima.jp",
-  "iki.nagasaki.jp",
-  "cricket",
-  "hr",
-  "nyny.museum",
-  "iveland.no",
-  "xerox",
-  "ht",
-  "hu",
-  "hk",
-  "chizu.tottori.jp",
-  "hn",
-  "mil.do",
-  "hk.cn",
-  "eat",
-  "bushey.museum",
-  "yabuki.fukushima.jp",
-  "hosting",
-  "bialowieza.pl",
-  "lipsy",
-  "shinonsen.hyogo.jp",
-  "warmia.pl",
-  "handa.aichi.jp",
-  "beats",
-  "soja.okayama.jp",
-  "education",
-  "kunstsammlung.museum",
-  "kimobetsu.hokkaido.jp",
-  "eiheiji.fukui.jp",
-  "star",
-  "living",
-  "gs.of.no",
-  "express.aero",
-  "bcn",
-  "samsung",
-  "bcg",
-  "yazu.tottori.jp",
-  "hitra.no",
-  "mugi.tokushima.jp",
-  "mzansimagic",
-  "naustdal.no",
-  "toyako.hokkaido.jp",
-  "takarazuka.hyogo.jp",
-  "seiro.niigata.jp",
-  "com.vn",
-  "hyuga.miyazaki.jp",
-  "art.ht",
-  "podlasie.pl",
-  "friulivegiulia.it",
-  "ando.nara.jp",
-  "kakuda.miyagi.jp",
-  "workshop.museum",
-  "v\u00e6r\u00f8y.no",
-  "org.gh",
-  "erimo.hokkaido.jp",
-  "olecko.pl",
-  "americanantiques.museum",
-  "mutsuzawa.chiba.jp",
-  "hamburg.museum",
-  "sagamihara.kanagawa.jp",
-  "fineart.museum",
-  "finnoy.no",
-  "gob.cl",
-  "karasjohka.no",
-  "chikushino.fukuoka.jp",
-  "nishikawa.yamagata.jp",
-  "freiburg.museum",
-  "chonan.chiba.jp",
-  "abogado",
-  "community.museum",
-  "nec",
-  "asia",
-  "parma.it",
-  "youth.museum",
-  "net",
-  "farmstead.museum",
-  "usarts.museum",
-  "izumizaki.fukushima.jp",
-  "meo",
-  "men",
-  "nakagyo.kyoto.jp",
-  "and.museum",
-  "nagasaki.jp",
-  "carrier.museum",
-  "st.no",
-  "otake.hiroshima.jp",
-  "active",
-  "yk.ca",
-  "motoyama.kochi.jp",
-  "mil.az",
-  "iwama.ibaraki.jp",
-  "mil.ar",
-  "r.se",
-  "credit",
-  "sch.sa",
-  "mil.al",
-  "chrysler",
-  "mil.ac",
-  "mil.ae",
-  "city.hu",
-  "shinanomachi.nagano.jp",
-  "alto-adige.it",
-  "passenger-association.aero",
-  "agriculture.museum",
-  "pa.gov.pl",
-  "realestate.pl",
-  "re.it",
-  "murakami.niigata.jp",
-  "ing.pa",
-  "kadoma.osaka.jp",
-  "army",
-  "ic.gov.pl",
-  "yokoshibahikari.chiba.jp",
-  "media.aero",
-  "lib.ky.us",
-  "miura.kanagawa.jp",
-  "eastafrica.museum",
-  "z.se",
-  "ss.it",
-  "gs.hm.no",
-  "cc.me.us",
-  "berlin",
-  "adult",
-  "stjordal.no",
-  "room",
-  "tanagura.fukushima.jp",
-  "vodka",
-  "taketomi.okinawa.jp",
-  "ogata.akita.jp",
-  "karelia.su",
-  "tynset.no",
-  "bi.it",
-  "muenchen.museum",
-  "piaget",
-  "org.co",
-  "org.cn",
-  "resistance.museum",
-  "\u4e2d\u4fe1",
-  "ed.pw",
-  "org.ci",
-  "iwaizumi.iwate.jp",
-  "ct.us",
-  "ichikawa.chiba.jp",
-  "\u5927\u62ff",
-  "org.cy",
-  "org.cw",
-  "org.cu",
-  "asuke.aichi.jp",
-  "koriyama.fukushima.jp",
-  "yusuhara.kochi.jp",
-  "stpetersburg.museum",
-  "flatanger.no",
-  "ovh",
-  "aoste.it",
-  "m\u0101ori.nz",
-  "riodejaneiro.museum",
-  "gliding.aero",
-  "cv.ua",
-  "co.bb",
-  "co.ba",
-  "snasa.no",
-  "gs.ah.no",
-  "co.bi",
-  "co.bw",
-  "rv.ua",
-  "koshigaya.saitama.jp",
-  "pug.it",
-  "kongsvinger.no",
-  "vinnytsia.ua",
-  "shiwa.iwate.jp",
-  "togo.aichi.jp",
-  "steam.museum",
-  "association.museum",
-  "nemuro.hokkaido.jp",
-  "tolga.no",
-  "askoy.no",
-  "nachikatsuura.wakayama.jp",
-  "toyota.aichi.jp",
-  "b\u00e1l\u00e1t.no",
-  "fujimino.saitama.jp",
-  "presse.ci",
-  "fe.it",
-  "bolt.hu",
-  "eidskog.no",
-  "sakae.nagano.jp",
-  "urawa.saitama.jp",
-  "vladimir.ru",
-  "udm.ru",
-  "asmatart.museum",
-  "oumu.hokkaido.jp",
-  "minami-alps.yamanashi.jp",
-  "mikawa.yamagata.jp",
-  "bond",
-  "u.se",
-  "nakatombetsu.hokkaido.jp",
-  "trading",
-  "hatogaya.saitama.jp",
-  "navy",
-  "tw.cn",
-  "nord-fron.no",
-  "saito.miyazaki.jp",
-  "bauhaus",
-  "\u010d\u00e1hcesuolo.no",
-  "hm",
-  "online.museum",
-  "furniture.museum",
-  "yasu.shiga.jp",
-  "iris.arpa",
-  "salangen.no",
-  "\u4eac\u90fd.jp",
-  "onagawa.miyagi.jp",
-  "katowice.pl",
-  "gov.az",
-  "gov.au",
-  "gov.as",
-  "gov.ar",
-  "ist",
-  "gov.al",
-  "okaya.nagano.jp",
-  "gov.af",
-  "gov.ae",
-  "gov.ac",
-  "cleaning",
-  "contractors",
-  "arida.wakayama.jp",
-  "sciencehistory.museum",
-  "my.id",
-  "cc.dc.us",
-  "brussels",
-  "sassari.it",
-  "bieszczady.pl",
-  "takazaki.miyazaki.jp",
-  "direct",
-  "bel.tr",
-  "svalbard.no",
-  "savannahga.museum",
-  "mattel",
-  "realestate",
-  "kawahara.tottori.jp",
-  "takayama.gunma.jp",
-  "verdal.no",
-  "yachts",
-  "mail.pl",
-  "mint",
-  "gjovik.no",
-  "lancome",
-  "gouv.fr",
-  "ricoh",
-  "i.bg",
-  "friuli-ve-giulia.it",
-  "murmansk.ru",
-  "od.ua",
-  "tv.na",
-  "hitachiota.ibaraki.jp",
-  "gushikami.okinawa.jp",
-  "indianapolis.museum",
-  "marine.ru",
-  "t\u00f8nsberg.no",
-  "tananger.no",
-  "fundacio.museum",
-  "meme",
-  "cargo.aero",
-  "uji.kyoto.jp",
-  "7.bg",
-  "fi.cr",
-  "khmelnytskyi.ua",
-  "takamori.nagano.jp",
-  "kusatsu.gunma.jp",
-  "francaise.museum",
-  "lancia",
-  "chernivtsi.ua",
-  "dot",
-  "tenkawa.nara.jp",
-  "illustration.museum",
-  "koenig.ru",
-  "suzuka.mie.jp",
-  "chitose.hokkaido.jp",
-  "com.py",
-  "com.pt",
-  "arpa",
-  "com.ps",
-  "com.pr",
-  "com.pl",
-  "historical.museum",
-  "com.ph",
-  "com.pk",
-  "com.pe",
-  "com.pf",
-  "com.pa",
-  "dstv",
-  "kuokgroup",
-  "bar",
-  "abr.it",
-  "\u00e5l.no",
-  "playstation",
-  "msk.su",
-  "khakassia.ru",
-  "fuji.shizuoka.jp",
-  "kamikawa.saitama.jp",
-  "kanagawa.jp",
-  "taira.toyama.jp",
-  "lancaster",
-  "voyage",
-  "vt.us",
-  "ogimi.okinawa.jp",
-  "shibukawa.gunma.jp",
-  "capetown",
-  "harvestcelebration.museum",
-  "taka.hyogo.jp",
-  "tozsde.hu",
-  "nysa.pl",
-  "bungotakada.oita.jp",
-  "toyotomi.hokkaido.jp",
-  "prudential",
-  "ne.tz",
-  "gob.ar",
-  "\u00e5s.no",
-  "soc.lk",
-  "tochio.niigata.jp",
-  "uno",
-  "lib.wa.us",
-  "hobol.no",
-  "kayabe.hokkaido.jp",
-  "ikaruga.nara.jp",
-  "ami.ibaraki.jp",
-  "firm.ht",
-  "county.museum",
-  "parliament.nz",
-  "k12.ia.us",
-  "mragowo.pl",
-  "temasek",
-  "fg.it",
-  "website",
-  "mcd",
-  "mil.co",
-  "mil.cn",
-  "mil.cl",
-  "k12.vi.us",
-  "koryo.nara.jp",
-  "pisz.pl",
-  "vn.ua",
-  "uppo.gov.pl",
-  "osteroy.no",
-  "ventures",
-  "lib.ks.us",
-  "iz.hr",
-  "seven",
-  "kamishihoro.hokkaido.jp",
-  "doha",
-  "iq",
-  "is",
-  "ir",
-  "it",
-  "gaular.no",
-  "katsushika.tokyo.jp",
-  "im",
-  "il",
-  "io",
-  "in",
-  "batsfjord.no",
-  "ie",
-  "id",
-  "\u5546\u57ce",
-  "sap",
-  "mie.jp",
-  "naturbruksgymn.se",
-  "siellak.no",
-  "cuneo.it",
-  "bloomberg",
-  "fr.it",
-  "bc.ca",
-  "kia",
-  "lib.hi.us",
-  "trader.aero",
-  "gen.in",
-  "claims",
-  "ulvik.no",
-  "investments",
-  "wakayama.wakayama.jp",
-  "\u5927\u962a.jp",
-  "\u00e5lesund.no",
-  "fujisawa.iwate.jp",
-  "prato.it",
-  "weber",
-  "secure",
-  "\u8bfa\u57fa\u4e9a",
-  "k12.dc.us",
-  "matsubushi.saitama.jp",
-  "org.ee",
-  "org.eg",
-  "state.museum",
-  "its.me",
-  "statebank",
-  "org.es",
-  "save",
-  "org.et",
-  "dovre.no",
-  "divttasvuotna.no",
-  "shirataka.yamagata.jp",
-  "akita.akita.jp",
-  "lillesand.no",
-  "kiyosu.aichi.jp",
-  "co.lc",
-  "govt.nz",
-  "uchinomi.kagawa.jp",
-  "name.mk",
-  "medio-campidano.it",
-  "\u9999\u683c\u91cc\u62c9",
-  "org.qa",
-  "niiza.saitama.jp",
-  "co.ls",
-  "sa.it",
-  "ah.cn",
-  "\u7db2\u8def.tw",
-  "deal",
-  "inagi.tokyo.jp",
-  "ryugasaki.ibaraki.jp",
-  "asahi.toyama.jp",
-  "cityeats",
-  "gov.ee",
-  "tv.sd",
-  "\u0aad\u0abe\u0ab0\u0aa4",
-  "dr.na",
-  "taiji.wakayama.jp",
-  "louvre.museum",
-  "l.se",
-  "services.aero",
-  "kyotamba.kyoto.jp",
-  "berlevag.no",
-  "itoman.okinawa.jp",
-  "lecco.it",
-  "azure",
-  "isehara.kanagawa.jp",
-  "tachikawa.tokyo.jp",
-  "minokamo.gifu.jp",
-  "odesa.ua",
-  "americanart.museum",
-  "sorum.no",
-  "aeroport.fr",
-  "!city.kitakyushu.jp",
-  "per.nf",
-  "viajes",
-  "abeno.osaka.jp",
-  "tennis",
-  "kharkov.ua",
-  "ostroleka.pl",
-  "!city.sendai.jp",
-  "togane.chiba.jp",
-  "settlement.museum",
-  "ford",
-  "katsuyama.fukui.jp",
-  "cc.ia.us",
-  "scienceandhistory.museum",
-  "askvoll.no",
-  "gov.gy",
-  "rawa-maz.pl",
-  "gov.gr",
-  "gov.gi",
-  "gov.gh",
-  "gov.gn",
-  "zara",
-  "windmill.museum",
-  "ota.tokyo.jp",
-  "gov.ge",
-  "warman",
-  "bharti",
-  "volyn.ua",
-  "shia",
-  "akashi.hyogo.jp",
-  "drive",
-  "mobi.na",
-  "mobi.ng",
-  "tokai.ibaraki.jp",
-  "vista",
-  "vossevangen.no",
-  "research.aero",
-  "lib.as.us",
-  "honjo.akita.jp",
-  "digital",
-  "historyofscience.museum",
-  "friulivenezia-giulia.it",
-  "sling",
-  "diet",
-  "kui.hiroshima.jp",
-  "losangeles.museum",
-  "ind.br",
-  "gs.nt.no",
-  "ne.kr",
-  "perm.ru",
-  "paragliding.aero",
-  "takko.aomori.jp",
-  "news.hu",
-  "tomigusuku.okinawa.jp",
-  "tienda",
-  "skin",
-  "kuwana.mie.jp",
-  "yachimata.chiba.jp",
-  "cc.mn.us",
-  "hirogawa.wakayama.jp",
-  "gouv.ht",
-  "mihama.aichi.jp",
-  "construction",
-  "mg",
-  "info.ec",
-  "kameoka.kyoto.jp",
-  "yalta.ua",
-  "mc",
-  "coop.tt",
-  "democrat",
-  "abu.yamaguchi.jp",
-  "diy",
-  "seljord.no",
-  "com.re",
-  "com.ro",
-  "show.aero",
-  "com.rw",
-  "qh.cn",
-  "com.ru",
-  "kimino.wakayama.jp",
-  "oseto.nagasaki.jp",
-  "ainan.ehime.jp",
-  "noboribetsu.hokkaido.jp",
-  "yatsushiro.kumamoto.jp",
-  "p.bg",
-  "ascoli-piceno.it",
-  "higashiagatsuma.gunma.jp",
-  "tingvoll.no",
-  "mv",
-  "vindafjord.no",
-  "international",
-  "fussa.tokyo.jp",
-  "guardian",
-  "alesund.no",
-  "okinawa",
-  "ca.it",
-  "tomiya.miyagi.jp",
-  "seaport.museum",
-  "bugatti",
-  "box",
-  "hbo",
-  "biella.it",
-  "institute",
-  "bot",
-  "bom",
-  "n\u00f8tter\u00f8y.no",
-  "boo",
-  "taipei",
-  "yonabaru.okinawa.jp",
-  "yatomi.aichi.jp",
-  "environment.museum",
-  "v\u00e5gan.no",
-  "bayern",
-  "leirfjord.no",
-  "lewismiller.museum",
-  "kazimierz-dolny.pl",
-  "*.ye",
-  "po.gov.pl",
-  "ooo",
-  "kunimi.fukushima.jp",
-  "bygland.no",
-  "shingu.hyogo.jp",
-  "realty",
-  "fly",
-  "tokyo",
-  "reviews",
-  "kisosaki.mie.jp",
-  "ookuwa.nagano.jp",
-  "sowa.ibaraki.jp",
-  "shimoda.shizuoka.jp",
-  "firm.ve",
-  "monash",
-  "saigawa.fukuoka.jp",
-  "kochi.kochi.jp",
-  "kumagaya.saitama.jp",
-  "aizuwakamatsu.fukushima.jp",
-  "trentino-alto-adige.it",
-  "orsta.no",
-  "mil.mg",
-  "rikubetsu.hokkaido.jp",
-  "mil.my",
-  "mil.mv",
-  "pistoia.it",
-  "nagano.nagano.jp",
-  "man",
-  "iwanuma.miyagi.jp",
-  "x.bg",
-  "hioki.kagoshima.jp",
-  "talk",
-  "izu.shizuoka.jp",
-  "shoes",
-  "morioka.iwate.jp",
-  "valle.no",
-  "shibata.miyagi.jp",
-  "jamal.ru",
-  "air-surveillance.aero",
-  "okinoshima.shimane.jp",
-  "lib.ak.us",
-  "maif",
-  "asaminami.hiroshima.jp",
-  "js.cn",
-  "yoshinogari.saga.jp",
-  "shinagawa.tokyo.jp",
-  "pn.it",
-  "brumunddal.no",
-  "voronezh.ru",
-  "ws.na",
-  "coloradoplateau.museum",
-  "lib.ct.us",
-  "togliatti.su",
-  "bus.museum",
-  "shunan.yamaguchi.jp",
-  "noda.chiba.jp",
-  "haram.no",
-  "aizubange.fukushima.jp",
-  "aizumi.tokushima.jp",
-  "shirako.chiba.jp",
-  "org.gr",
-  "org.gp",
-  "sabae.fukui.jp",
-  "bari.it",
-  "org.gt",
-  "org.gy",
-  "krager\u00f8.no",
-  "iwanai.hokkaido.jp",
-  "org.gg",
-  "org.ge",
-  "org.gi",
-  "vc.it",
-  "org.gn",
-  "org.gl",
-  "monster",
-  "cuisinella",
-  "ishikari.hokkaido.jp",
-  "nozawaonsen.nagano.jp",
-  "toyota.yamaguchi.jp",
-  "malvik.no",
-  "org",
-  "gotv",
-  "co.ni",
-  "kisofukushima.nagano.jp",
-  "co.na",
-  "zushi.kanagawa.jp",
-  "isleofman.museum",
-  "co.nz",
-  "kommunalforbund.se",
-  "kashiwara.osaka.jp",
-  "forsale",
-  "fudai.iwate.jp",
-  "wiki",
-  "obu.aichi.jp",
-  "tver.ru",
-  "\u0627\u064a\u0631\u0627\u0646",
-  "saroma.hokkaido.jp",
-  "ritto.shiga.jp",
-  "kumakogen.ehime.jp",
-  "\u10d2\u10d4",
-  "tm.no",
-  "ud.it",
-  "chicago.museum",
-  "fujieda.shizuoka.jp",
-  "rana.no",
-  "tinn.no",
-  "moscow",
-  "\u043e\u0440\u0433.\u0441\u0440\u0431",
-  "cr.it",
-  "kristiansund.no",
-  "naganohara.gunma.jp",
-  "co",
-  "sf.no",
-  "alstom",
-  "khv.ru",
-  "asago.hyogo.jp",
-  "etisalat",
-  "wy.us",
-  "historicalsociety.museum",
-  "bokn.no",
-  "panama.museum",
-  "tobe.ehime.jp",
-  "lib.nc.us",
-  "kawanishi.nara.jp",
-  "amfam",
-  "hasama.oita.jp",
-  "jaworzno.pl",
-  "gemological.museum",
-  "law.pro",
-  "konan.shiga.jp",
-  "channel",
-  "gov.ec",
-  "gov.eg",
-  "donostia.museum",
-  "shell.museum",
-  "meiwa.mie.jp",
-  "gov.et",
-  "\u0b9a\u0bbf\u0b99\u0bcd\u0b95\u0baa\u0bcd\u0baa\u0bc2\u0bb0\u0bcd",
-  "biz.ni",
-  "itakura.gunma.jp",
-  "hamaroy.no",
-  "capebreton.museum",
-  "ino.kochi.jp",
-  "biz.nr",
-  "encyclopedic.museum",
-  "klabu.no",
-  "horten.no",
-  "show",
-  "bozen.it",
-  "takahama.fukui.jp",
-  "\u4e2d\u6587\u7f51",
-  "sk\u00e1nit.no",
-  "info.et",
-  "livorno.it",
-  "iwate.jp",
-  "art.sn",
-  "black",
-  "ac.se",
-  "sakurai.nara.jp",
-  "shikatsu.aichi.jp",
-  "gea",
-  "ac.sz",
-  "museumcenter.museum",
-  "versicherung",
-  "lukow.pl",
-  "per.la",
-  "pup.gov.pl",
-  "atm.pl",
-  "\u0639\u0631\u0627\u0642",
-  "yorii.saitama.jp",
-  "l\u00e4ns.museum",
-  "seat",
-  "cologne",
-  "ibaraki.ibaraki.jp",
-  "torino.museum",
-  "medecin.km",
-  "diamonds",
-  "herad.no",
-  "ontario.museum",
-  "\u5546\u5e97",
-  "olkusz.pl",
-  "jp",
-  "tui",
-  "jo",
-  "moriyoshi.akita.jp",
-  "je",
-  "med.br",
-  "coupons",
-  "\u7ec4\u7ec7.hk",
-  "chungbuk.kr",
-  "koebenhavn.museum",
-  "novosibirsk.ru",
-  "ralingen.no",
-  "ens.tn",
-  "bas.it",
-  "g.se",
-  "com.tj",
-  "com.tm",
-  "com.to",
-  "com.tn",
-  "com.tr",
-  "com.tt",
-  "aostavalley.it",
-  "ladbrokes",
-  "arte",
-  "military.museum",
-  "fujioka.gunma.jp",
-  "snaase.no",
-  "m\u00e5lselv.no",
-  "nosegawa.nara.jp",
-  "bms",
-  "bo.it",
-  "enebakk.no",
-  "bmw",
-  "grong.no",
-  "austrheim.no",
-  "fedex",
-  "or.it",
-  "aichi.jp",
-  "chuo.yamanashi.jp",
-  "to.it",
-  "inderoy.no",
-  "cc.vi.us",
-  "pay",
-  "\u0a2d\u0a3e\u0a30\u0a24",
-  "nore-og-uvdal.no",
-  "matsumae.hokkaido.jp",
-  "miyako.iwate.jp",
-  "edu.gt",
-  "edu.gp",
-  "edu.gr",
-  "edu.gy",
-  "edu.ge",
-  "berg.no",
-  "edu.gl",
-  "mar.it",
-  "fukui.jp",
-  "edu.gh",
-  "kosei.shiga.jp",
-  "higashiyoshino.nara.jp",
-  "okinawa.jp",
-  "cs.it",
-  "\u0647\u0645\u0631\u0627\u0647",
-  "bill.museum",
-  "katsuragi.wakayama.jp",
-  "tokke.no",
-  "bjarkoy.no",
-  "money",
-  "bergamo.it",
-  "yuzawa.niigata.jp",
-  "tarnobrzeg.pl",
-  "bn.it",
-  "mutsu.aomori.jp",
-  "nahari.kochi.jp",
-  "minowa.nagano.jp",
-  "sado.niigata.jp",
-  "karm\u00f8y.no",
-  "friuliv-giulia.it",
-  "miyama.mie.jp",
-  "yuza.yamagata.jp",
-  "careers",
-  "sarl",
-  "sakae.chiba.jp",
-  "otaru.hokkaido.jp",
-  "ginowan.okinawa.jp",
-  "mov",
-  "spjelkavik.no",
-  "moi",
-  "mom",
-  "guovdageaidnu.no",
-  "moe",
-  "beardu.no",
-  "gaivuotna.no",
-  "iwakuni.yamaguchi.jp",
-  "tahara.aichi.jp",
-  "nishihara.kumamoto.jp",
-  "air-traffic-control.aero",
-  "tur.br",
-  "rovno.ua",
-  "com.tw",
-  "ujitawara.kyoto.jp",
-  "castres.museum",
-  "telecity",
-  "lotte",
-  "giessen.museum",
-  "ryukyu",
-  "v\u00e5ler.\u00f8stfold.no",
-  "yakumo.hokkaido.jp",
-  "lotto",
-  "kr\u00e5anghke.no",
-  "takahata.yamagata.jp",
-  "pioneer",
-  "strand.no",
-  "homedepot",
-  "nom.pe",
-  "nom.pa",
-  "goto.nagasaki.jp",
-  "kyoto",
-  "fitness",
-  "broker",
-  "qld.edu.au",
-  "oum.gov.pl",
-  "\u7d44\u7e54.hk",
-  "k\u00e1r\u00e1\u0161johka.no",
-  "tara.saga.jp",
-  "keisen.fukuoka.jp",
-  "res.aero",
-  "marriott",
-  "izunokuni.shizuoka.jp",
-  "coupon",
-  "hachijo.tokyo.jp",
-  "tajimi.gifu.jp",
-  "ouchi.saga.jp",
-  "kosa.kumamoto.jp",
-  "org.iq",
-  "org.is",
-  "org.ir",
-  "org.im",
-  "org.il",
-  "org.in",
-  "cincinnati.museum",
-  "namie.fukushima.jp",
-  "wskr.gov.pl",
-  "iselect",
-  "andria-trani-barletta.it",
-  "ujiie.tochigi.jp",
-  "tamatsukuri.ibaraki.jp",
-  "langev\u00e5g.no",
-  "co.hu",
-  "fylkesbibl.no",
-  "tsukuba.ibaraki.jp",
-  "\u7f51\u7edc.hk",
-  "fla.no",
-  "axis.museum",
-  "shimonita.gunma.jp",
-  "cc.nv.us",
-  "nu.it",
-  "nl.no",
-  "grainger",
-  "lib.vt.us",
-  "onjuku.chiba.jp",
-  "sr.gov.pl",
-  "film",
-  "soccer",
-  "va.it",
-  "istanbul",
-  "nt.au",
-  "finn\u00f8y.no",
-  "ashibetsu.hokkaido.jp",
-  "creditcard",
-  "lib.md.us",
-  "gjerdrum.no",
-  "int.tt",
-  "fst.br",
-  "barreau.bj",
-  "halsa.no",
-  "suldal.no",
-  "shinshiro.aichi.jp",
-  "network",
-  "\u0645\u0648\u0628\u0627\u064a\u0644\u064a",
-  "bananarepublic",
-  "nativeamerican.museum",
-  "andebu.no",
-  "aramco",
-  "tr\u00e6na.no",
-  "gt",
-  "gs",
-  "kosuge.yamanashi.jp",
-  "game.tw",
-  "k12.wi.us",
-  "chesapeakebay.museum",
-  "\u516c\u53f8.cn",
-  "komono.mie.jp",
-  "marche.it",
-  "coal.museum",
-  "gov.km",
-  "gov.kn",
-  "gov.ki",
-  "gov.kg",
-  "maryland.museum",
-  "ostroda.pl",
-  "gov.ky",
-  "gov.kz",
-  "aisho.shiga.jp",
-  "oster\u00f8y.no",
-  "gov.kp",
-  "gg",
-  "hakusan.ishikawa.jp",
-  "minamiuonuma.niigata.jp",
-  "stor-elvdal.no",
-  "asahi.yamagata.jp",
-  "biz.pl",
-  "name.ng",
-  "name.na",
-  "biz.pk",
-  "kanuma.tochigi.jp",
-  "info.co",
-  "ambulance.aero",
-  "hitachi",
-  "zero",
-  "quebec",
-  "kuju.oita.jp",
-  "gm",
-  "shizukuishi.iwate.jp",
-  "abc",
-  "kanan.osaka.jp",
-  "hakata.fukuoka.jp",
-  "web.id",
-  "lel.br",
-  "kinko.kagoshima.jp",
-  "iwafune.tochigi.jp",
-  "modelling.aero",
-  "vic.edu.au",
-  "journal.aero",
-  "jor.br",
-  "satosho.okayama.jp",
-  "ringebu.no",
-  "bible",
-  "trogstad.no",
-  "barlettatraniandria.it",
-  "tenri.nara.jp",
-  "mihama.fukui.jp",
-  "gob.ve",
-  "cpa.pro",
-  "!city.yokohama.jp",
-  "civilwar.museum",
-  "television.museum",
-  "caravan",
-  "heroy.nordland.no",
-  "annaka.gunma.jp",
-  "funagata.yamagata.jp",
-  "kawanehon.shizuoka.jp",
-  "sosnowiec.pl",
-  "minamiise.mie.jp",
-  "*.kawasaki.jp",
-  "oarai.ibaraki.jp",
-  "lib.mt.us",
-  "cc.hi.us",
-  "aikawa.kanagawa.jp",
-  "hirono.iwate.jp",
-  "mb.ca",
-  "mil.to",
-  "mil.tm",
-  "mil.tj",
-  "asakuchi.okayama.jp",
-  "mil.tw",
-  "g\u00e1ivuotna.no",
-  "mil.tr",
-  "itau",
-  "sko.gov.pl",
-  "mil.tz",
-  "town",
-  "higashiyamato.tokyo.jp",
-  "sucks",
-  "dev",
-  "hannan.osaka.jp",
-  "wiki.br",
-  "\u73e0\u5b9d",
-  "avocat.pro",
-  "bergbau.museum",
-  "ayase.kanagawa.jp",
-  "com.vi",
-  "shinjo.nara.jp",
-  "agakhan",
-  "mansions.museum",
-  "com.vc",
-  "com.ve",
-  "dn.ua",
-  "firmdale",
-  "dabur",
-  "shimamoto.osaka.jp",
-  "com.vu",
-  "audible",
-  "family.museum",
-  "bydgoszcz.pl",
-  "csc",
-  "uzhgorod.ua",
-  "sukagawa.fukushima.jp",
-  "stjohn.museum",
-  "hokksund.no",
-  "torino.it",
-  "alibaba",
-  "targi.pl",
-  "frog.museum",
-  "hakuba.nagano.jp",
-  "volda.no",
-  "kaufen",
-  "tatsuno.nagano.jp",
-  "samara.ru",
-  "tourism.tn",
-  "\u5c71\u68a8.jp",
-  "obihiro.hokkaido.jp",
-  "kariya.aichi.jp",
-  "higashi.fukushima.jp",
-  "midtre-gauldal.no",
-  "lund.no",
-  "yn.cn",
-  "emiliaromagna.it",
-  "goog",
-  "roros.no",
-  "edu.et",
-  "edu.es",
-  "historichouses.museum",
-  "hellas.museum",
-  "edu.eg",
-  "edu.ee",
-  "edu.ec",
-  "wa.au",
-  "co.ug",
-  "cagliari.it",
-  "aki.kochi.jp",
-  "botanicgarden.museum",
-  "co.uk",
-  "mj\u00f8ndalen.no",
-  "ap.it",
-  "co.uz",
-  "joburg",
-  "house",
-  "energy",
-  "r\u00f8mskog.no",
-  "kanmaki.nara.jp",
-  "higashikagawa.kagawa.jp",
-  "firm.ro",
-  "\u00f8rskog.no",
-  "americanexpress",
-  "jewishart.museum",
-  "dni.us",
-  "adult.ht",
-  "store.ve",
-  "ballangen.no",
-  "nsn.us",
-  "is.gov.pl",
-  "taketa.oita.jp",
-  "mil.iq",
-  "sbs",
-  "\u5c90\u961c.jp",
-  "abudhabi",
-  "wolterskluwer",
-  "mil.id",
-  "beauxarts.museum",
-  "sbi",
-  "1.bg",
-  "mil.in",
-  "okinawa.okinawa.jp",
-  "rebun.hokkaido.jp",
-  "uchinada.ishikawa.jp",
-  "cosenza.it",
-  "mn.it",
-  "takahagi.ibaraki.jp",
-  "top",
-  "kakegawa.shizuoka.jp",
-  "baseball.museum",
-  "tatar",
-  "valleeaoste.it",
-  "hoylandet.no",
-  "a.se",
-  "aure.no",
-  "sondre-land.no",
-  "edu.gn",
-  "kinder",
-  "edu.gi",
-  "waw.pl",
-  "education.museum",
-  "tychy.pl",
-  "nom.ro",
-  "nom.re",
-  "lease",
-  "mini",
-  "gratangen.no",
-  "\u00f8ygarden.no",
-  "n\u00e6r\u00f8y.no",
-  "wa.us",
-  "bytom.pl",
-  "skole.museum",
-  "hammarfeasta.no",
-  "tsubetsu.hokkaido.jp",
-  "cfa",
-  "berkeley.museum",
-  "\u901a\u8ca9",
-  "sochi.su",
-  "gosen.niigata.jp",
-  "forlicesena.it",
-  "toyotsu.fukuoka.jp",
-  "zlg.br",
-  "trysil.no",
-  "org.kg",
-  "takayama.nagano.jp",
-  "at.it",
-  "org.km",
-  "org.ki",
-  "seki.gifu.jp",
-  "namdalseid.no",
-  "org.kp",
-  "takaishi.osaka.jp",
-  "assn.lk",
-  "org.kz",
-  "org.ky",
-  "blanco",
-  "friulive-giulia.it",
-  "mo.it",
-  "build",
-  "e12.ve",
-  "lavangen.no",
-  "dunlop",
-  "achi.nagano.jp",
-  "d.bg",
-  "wlocl.pl",
-  "ac.jp",
-  "services",
-  "osaki.miyagi.jp",
-  "travel.pl",
-  "tas.edu.au",
-  "kamiichi.toyama.jp",
-  "ki",
-  "kn",
-  "babia-gora.pl",
-  "co.jp",
-  "kr",
-  "kp",
-  "in.rs",
-  "kz",
-  "co.je",
-  "sosa.chiba.jp",
-  "museet.museum",
-  "miyoshi.saitama.jp",
-  "\u79cb\u7530.jp",
-  "b.br",
-  "sogndal.no",
-  "budejju.no",
-  "frei.no",
-  "gouv.sn",
-  "yorkshire.museum",
-  "int.ve",
-  "nt.ca",
-  "setagaya.tokyo.jp",
-  "arakawa.tokyo.jp",
-  "express",
-  "nanporo.hokkaido.jp",
-  "bofa",
-  "lom.no",
-  "silk",
-  "motorcycles",
-  "tirol",
-  "chintai",
-  "uruma.okinawa.jp",
-  "\u611b\u5a9b.jp",
-  "takahashi.okayama.jp",
-  "xfinity",
-  "ferrara.it",
-  "minamiyamashiro.kyoto.jp",
-  "expert",
-  "fans",
-  "gov.it",
-  "gov.is",
-  "gov.ir",
-  "gov.iq",
-  "accident-investigation.aero",
-  "press.museum",
-  "gov.ie",
-  "hkt",
-  "gov.in",
-  "gov.il",
-  "lind\u00e5s.no",
-  "slg.br",
-  "restaurant",
-  "nishinoomote.kagoshima.jp",
-  "aukra.no",
-  "oceanographique.museum",
-  "aid.pl",
-  "prof.pr",
-  "info.au",
-  "info.az",
-  "chita.aichi.jp",
-  "stavern.no",
-  "ebetsu.hokkaido.jp",
-  "finearts.museum",
-  "rikuzentakata.iwate.jp",
-  "iwate.iwate.jp",
-  "net.ws",
-  "shizuoka.shizuoka.jp",
-  "miyota.nagano.jp",
-  "orenburg.ru",
-  "whoswho",
-  "med.sd",
-  "med.sa",
-  "sport.hu",
-  "vestre-slidre.no",
-  "iyo.ehime.jp",
-  "\u70b9\u770b",
-  "gap",
-  "vana",
-  "gal",
-  "kopervik.no",
-  "jorpeland.no",
-  "xihuan",
-  "kusatsu.shiga.jp",
-  "convent.museum",
-  "sar.it",
-  "hanggliding.aero",
-  "fun",
-  "bryansk.ru",
-  "unjarga.no",
-  "wakkanai.hokkaido.jp",
-  "viterbo.it",
-  "hasuda.saitama.jp",
-  "shinjo.yamagata.jp",
-  "hidaka.wakayama.jp",
-  "\u00f8ksnes.no",
-  "vanylven.no",
-  "\u548c\u6b4c\u5c71.jp",
-  "utsira.no",
-  "ia.us",
-  "hole.no",
-  "mil.vc",
-  "arita.saga.jp",
-  "mil.ve",
-  "yanaizu.fukushima.jp",
-  "saitama.jp",
-  "taki.mie.jp",
-  "atsugi.kanagawa.jp",
-  "sld.pa",
-  "\u516b\u5366",
-  "\u043a\u0430\u0442\u043e\u043b\u0438\u043a",
-  "swiss",
-  "s\u00f8rreisa.no",
-  "mc.it",
-  "com.ht",
-  "com.hr",
-  "lds",
-  "hamamatsu.shizuoka.jp",
-  "com.hn",
-  "alstahaug.no",
-  "com.hk",
-  "apple",
-  "tjmaxx",
-  "tainai.niigata.jp",
-  "tr.it",
-  "cim.br",
-  "f\u00f8rde.no",
-  "bio",
-  "tkmaxx",
-  "tamano.okayama.jp",
-  "ginoza.okinawa.jp",
-  "bid",
-  "shiojiri.nagano.jp",
-  "hi.us",
-  "fedje.no",
-  "bale.museum",
-  "biz",
-  "taranto.it",
-  "fujiyoshida.yamanashi.jp",
-  "gose.nara.jp",
-  "miyoshi.aichi.jp",
-  "onyourside",
-  "dagestan.ru",
-  "br\u00f8nn\u00f8y.no",
-  "ohi.fukui.jp",
-  "volkenkunde.museum",
-  "okayama.jp",
-  "google",
-  "belgorod.ru",
-  "trentino-aadige.it",
-  "org.rs",
-  "org.ru",
-  "b\u00f8.nordland.no",
-  "recreation.aero",
-  "jewelry",
-  "nishinoshima.shimane.jp",
-  "pet",
-  "bamble.no",
-  "vlaanderen",
-  "fhsk.se",
-  "kaluga.ru",
-  "communication.museum",
-  "of.no",
-  "presidio.museum",
-  "umi.fukuoka.jp",
-  "santabarbara.museum",
-  "edu.cu",
-  "edu.cw",
-  "maritime.museum",
-  "edu.ci",
-  "edu.co",
-  "edu.cn",
-  "pfizer",
-  "kiryu.gunma.jp",
-  "eu.int",
-  "\u0634\u0628\u0643\u0629",
-  "\ub2f7\ucef4",
-  "vicenza.it",
-  "oga.akita.jp",
-  "florida.museum",
-  "linz.museum",
-  "yakutia.ru",
-  "uchiko.ehime.jp",
-  "tajiri.osaka.jp",
-  "odawara.kanagawa.jp",
-  "rad\u00f8y.no",
-  "field.museum",
-  "lugansk.ua",
-  "int.mv",
-  "int.mw",
-  "hamatama.saga.jp",
-  "zgorzelec.pl",
-  "wi.us",
-  "ako.hyogo.jp",
-  "fuchu.toyama.jp",
-  "pacific.museum",
-  "mil.kz",
-  "trentinosudtirol.it",
-  "mil.kr",
-  "higashisumiyoshi.osaka.jp",
-  "depot.museum",
-  "shiroishi.saga.jp",
-  "kijo.miyazaki.jp",
-  "government.aero",
-  "mil.kg",
-  "oskol.ru",
-  "lancashire.museum",
-  "sc.tz",
-  "lib.ri.us",
-  "\u7b87\u4eba.hk",
-  "helsinki.museum",
-  "os.hordaland.no",
-  "yaotsu.gifu.jp",
-  "security",
-  "kodaira.tokyo.jp",
-  "o.bg",
-  "nom.tm",
-  "livinghistory.museum",
-  "prd.km",
-  "int.bo",
-  "cafe",
-  "school.za",
-  "tarui.gifu.jp",
-  "turen.tn",
-  "sennan.osaka.jp",
-  "kustanai.ru",
-  "k.bg",
-  "tsurugashima.saitama.jp",
-  "hayakawa.yamanashi.jp",
-  "jeonbuk.kr",
-  "oita.jp",
-  "toyoake.aichi.jp",
-  "laspezia.it",
-  "gov.rw",
-  "gov.ru",
-  "hiratsuka.kanagawa.jp",
-  "gov.rs",
-  "\u6e38\u620f",
-  "funahashi.toyama.jp",
-  "kinokawa.wakayama.jp",
-  "k12.or.us",
-  "wielun.pl",
-  "kawazu.shizuoka.jp",
-  "bashkiria.ru",
-  "h\u00f8nefoss.no",
-  "dds",
-  "yokohama",
-  "namikata.ehime.jp",
-  "statefarm",
-  "lindas.no",
-  "vi.us",
-  "org.ma",
-  "org.me",
-  "org.mg",
-  "pomorze.pl",
-  "amber.museum",
-  "org.mk",
-  "org.ml",
-  "org.mo",
-  "org.mn",
-  "org.ms",
-  "org.mu",
-  "org.mt",
-  "org.mw",
-  "org.mv",
-  "org.my",
-  "org.mx",
-  "mitsubishi",
-  "haibara.shizuoka.jp",
-  "nom.pl",
-  "davvenjarga.no",
-  "gs.tr.no",
-  "weather",
-  "lilly",
-  "evje-og-hornnes.no",
-  "hichiso.gifu.jp",
-  "traniandriabarletta.it",
-  "tono.iwate.jp",
-  "mino.gifu.jp",
-  "wassamu.hokkaido.jp",
-  "childrens.museum",
-  "org.ac",
-  "taku.saga.jp",
-  "mel\u00f8y.no",
-  "civilaviation.aero",
-  "fukudomi.saga.jp",
-  "surgeonshall.museum",
-  "goodyear",
-  "hanamaki.iwate.jp",
-  "naruto.tokushima.jp",
-  "ide.kyoto.jp",
-  "uki.kumamoto.jp",
-  "shijonawate.osaka.jp",
-  "sex.pl",
-  "int.pt",
-  "giving",
-  "tm.hu",
-  "nieruchomosci.pl",
-  "\u4e2d\u56fd",
-  "\u96fb\u8a0a\u76c8\u79d1",
-  "h\u00e6gebostad.no",
-  "exchange",
-  "gs.ol.no",
-  "mazury.pl",
-  "b\u00f8mlo.no",
-  "shinto.gunma.jp",
-  "sauda.no",
-  "chikuhoku.nagano.jp",
-  "sina",
-  "lib.ny.us",
-  "schweiz.museum",
-  "cern",
-  "hirono.fukushima.jp",
-  "koto.shiga.jp",
-  "kvinesdal.no",
-  "stada",
-  "pramerica",
-  "bauern.museum",
-  "pol.ht",
-  "touch.museum",
-  "k12.wy.us",
-  "limo",
-  "amusement.aero",
-  "yamaguchi.jp",
-  "fukuchiyama.kyoto.jp",
-  "valer.hedmark.no",
-  "kitayama.wakayama.jp",
-  "trentino-sued-tirol.it",
-  "mimata.miyazaki.jp",
-  "tsuno.kochi.jp",
-  "shioya.tochigi.jp",
-  "trentino-suedtirol.it",
-  "bradesco",
-  "or.ug",
-  "kim",
-  "\u4e2d\u570b",
-  "name.jo",
-  "or.us",
-  "settlers.museum",
-  "stranda.no",
-  "gov.om",
-  "yokosuka.kanagawa.jp",
-  "go.ci",
-  "kikugawa.shizuoka.jp",
-  "baikal.ru",
-  "cc.wi.us",
-  "biz.tr",
-  "biz.tt",
-  "biz.tj",
-  "aremark.no",
-  "broker.aero",
-  "go.cr",
-  "sortland.no",
-  "nalchik.su",
-  "\u0e04\u0e2d\u0e21",
-  "net.uk",
-  "tab",
-  "i.ph",
-  "chigasaki.kanagawa.jp",
-  "net.ua",
-  "sango.nara.jp",
-  "net.uy",
-  "net.uz",
-  "afl",
-  "kongsberg.no",
-  "loyalist.museum",
-  "shimokitayama.nara.jp",
-  "cc.mi.us",
-  "\u653f\u5e9c.hk",
-  "goshiki.hyogo.jp",
-  "valleaosta.it",
-  "gc.ca",
-  "physio",
-  "ac.uk",
-  "trieste.it",
-  "ac.ug",
-  "collection.museum",
-  "bing",
-  "chihayaakasaka.osaka.jp",
-  "walbrzych.pl",
-  "marshalls",
-  "\u9577\u5d0e.jp",
-  "leka.no",
-  "wazuka.kyoto.jp",
-  "sk\u00e5nland.no",
-  "industries",
-  "lb",
-  "lc",
-  "la",
-  "bryne.no",
-  "lk",
-  "li",
-  "lv",
-  "lt",
-  "lu",
-  "lr",
-  "ls",
-  "ozora.hokkaido.jp",
-  "ly",
-  "dad",
-  "mil.ph",
-  "tr\u00f8gstad.no",
-  "mil.pl",
-  "yamazoe.nara.jp",
-  "piemonte.it",
-  "mil.pe",
-  "nom.co",
-  "mil.py",
-  "sweden.museum",
-  "day",
-  "shimane.shimane.jp",
-  "travel.tt",
-  "project.museum",
-  "kumamoto.kumamoto.jp",
-  "gallo",
-  "cc.il.us",
-  "kagawa.jp",
-  "garden.museum",
-  "r.bg",
-  "\u795e\u5948\u5ddd.jp",
-  "aurskog-h\u00f8land.no",
-  "z.bg",
-  "com.jo",
-  "trd.br",
-  "aga.niigata.jp",
-  "*.yokohama.jp",
-  "masfjorden.no",
-  "sncf",
-  "farm",
-  "ren",
-  "donetsk.ua",
-  "arq.br",
-  "shimotsuke.tochigi.jp",
-  "red",
-  "tourism.pl",
-  "radom.pl",
-  "computerhistory.museum",
-  "susaki.kochi.jp",
-  "crew.aero",
-  "w.se",
-  "narusawa.yamanashi.jp",
-  "emp.br",
-  "nakatsugawa.gifu.jp",
-  "recipes",
-  "hokkaido.jp",
-  "h\u00e1pmir.no",
-  "nishiwaki.hyogo.jp",
-  "time.no",
-  "ed.ao",
-  "ar.us",
-  "skiptvet.no",
-  "kraanghke.no",
-  "loab\u00e1t.no",
-  "edu.ac",
-  "kaszuby.pl",
-  "k.se",
-  "edu.af",
-  "gsm.pl",
-  "lib.ca.us",
-  "kirov.ru",
-  "edu.al",
-  "edu.ar",
-  "edu.au",
-  "mihara.hiroshima.jp",
-  "as.us",
-  "bosch",
-  "skedsmo.no",
-  "k12.in.us",
-  "\u5ca9\u624b.jp",
-  "yanagawa.fukuoka.jp",
-  "spiegel",
-  "nkz.ru",
-  "vennesla.no",
-  "s\u00f8r-odal.no",
-  "omihachiman.shiga.jp",
-  "k12.ri.us",
-  "paderborn.museum",
-  "o.se",
-  "kamo.niigata.jp",
-  "newhampshire.museum",
-  "airforce",
-  "skoczow.pl",
-  "wanggou",
-  "cc.na",
-  "tatsuno.hyogo.jp",
-  "mil",
-  "journalism.museum",
-  "store.ro",
-  "tm.se",
-  "arezzo.it",
-  "lib.nm.us",
-  "sciencesnaturelles.museum",
-  "mit",
-  "zhytomyr.ua",
-  "balsfjord.no",
-  "kms.ru",
-  "kitakata.fukushima.jp",
-  "yaita.tochigi.jp",
-  "midatlantic.museum",
-  "tula.ru",
-  "vagan.no",
-  "ipiranga",
-  "cc.in.us",
-  "po.it",
-  "shimotsuma.ibaraki.jp",
-  "suita.osaka.jp",
-  "fhs.no",
-  "asnes.no",
-  "te.ua",
-  "\ub2f7\ub137",
-  "freight.aero",
-  "chiropractic.museum",
-  "haboro.hokkaido.jp",
-  "prd.mg",
-  "evenes.no",
-  "realtor",
-  "muncie.museum",
-  "yoichi.hokkaido.jp",
-  "nankoku.kochi.jp",
-  "usui.fukuoka.jp",
-  "gov.ph",
-  "photography",
-  "gov.pk",
-  "gov.pl",
-  "orkanger.no",
-  "gov.pn",
-  "gov.pr",
-  "gov.ps",
-  "gov.pt",
-  "gov.py",
-  "\u6148\u5584",
-  "nerima.tokyo.jp",
-  "svelvik.no",
-  "elverum.no",
-  "org.om",
-  "skaun.no",
-  "\u5fb3\u5cf6.jp",
-  "ac.ni",
-  "showa.yamanashi.jp",
-  "daisen.akita.jp",
-  "skanland.no",
-  "ac.nz",
-  "lowicz.pl",
-  "mordovia.su",
-  "kosher",
-  "bizen.okayama.jp",
-  "gouv.ml",
-  "health.vn",
-  "yamal.ru",
-  "rel.pl",
-  "tama.tokyo.jp",
-  "i.se",
-  "theater",
-  "hidaka.kochi.jp",
-  "\u0627\u0644\u0639\u0644\u064a\u0627\u0646",
-  "lebork.pl",
-  "overhalla.no",
-  "int.rw",
-  "int.ru",
-  "kunohe.iwate.jp",
-  "kin.okinawa.jp",
-  "ch.it",
-  "moscow.museum",
-  "yamanashi.yamanashi.jp",
-  "nyuzen.toyama.jp",
-  "kuchinotsu.nagasaki.jp",
-  "orange",
-  "ma.us",
-  "manx.museum",
-  "sekigahara.gifu.jp",
-  "homes",
-  "trentinoaltoadige.it",
-  "os\u00f8yro.no",
-  "kalisz.pl",
-  "minamiashigara.kanagawa.jp",
-  "money.museum",
-  "sibenik.museum",
-  "aw",
-  "rotorcraft.aero",
-  "kunitomi.miyazaki.jp",
-  "katsuragi.nara.jp",
-  "dolls.museum",
-  "beskidy.pl",
-  "ad.jp",
-  "kurgan.su",
-  "afamilycompany",
-  "jerusalem.museum",
-  "tokushima.jp",
-  "przeworsk.pl",
-  "gov.my",
-  "nokia",
-  "kokonoe.oita.jp",
-  "gov.ms",
-  "gov.mr",
-  "gov.mw",
-  "gov.mv",
-  "gov.mu",
-  "gov.mk",
-  "gov.mo",
-  "gov.mn",
-  "gov.ml",
-  "name.hr",
-  "qld.au",
-  "gov.ma",
-  "gov.mg",
-  "adachi.tokyo.jp",
-  "gov.me",
-  "insure",
-  "center",
-  "int.tj",
-  "watarai.mie.jp",
-  "naklo.pl",
-  "oregon.museum",
-  "nuernberg.museum",
-  "shichikashuku.miyagi.jp",
-  "gallup",
-  "shirosato.ibaraki.jp",
-  "net.st",
-  "works.aero",
-  "net.sy",
-  "exchange.aero",
-  "hagebostad.no",
-  "net.sc",
-  "clinic",
-  "net.sa",
-  "net.sg",
-  "net.sd",
-  "net.sh",
-  "co.tj",
-  "bilbao.museum",
-  "net.so",
-  "net.sl",
-  "hitoyoshi.kumamoto.jp",
-  "nagaokakyo.kyoto.jp",
-  "gmo",
-  "ads",
-  "mitaka.tokyo.jp",
-  "ngo.lk",
-  "vr.it",
-  "lupin",
-  "tenei.fukushima.jp",
-  "gmx",
-  "lib.ne.us",
-  "smart",
-  "gob.pk",
-  "gob.pe",
-  "fyi",
-  "gob.pa",
-  "ogaki.gifu.jp",
-  "yonago.tottori.jp",
-  "even\u00e1\u0161\u0161i.no",
-  "k\u00e5fjord.no",
-  "like",
-  "works",
-  "miho.ibaraki.jp",
-  "off.ai",
-  "cc.nh.us",
-  "hair",
-  "ninohe.iwate.jp",
-  "boleslawiec.pl",
-  "misasa.tottori.jp",
-  "workinggroup.aero",
-  "esq",
-  "arkhangelsk.su",
-  "tagajo.miyagi.jp",
-  "kristiansand.no",
-  "kumano.hiroshima.jp",
-  "press.ma",
-  "\u516c\u53f8",
-  "mil.ru",
-  "mil.rw",
-  "molise.it",
-  "lipetsk.ru",
-  "\u0430\u043a.\u0441\u0440\u0431",
-  "host",
-  "saotome.st",
-  "tsugaru.aomori.jp",
-  "saskatchewan.museum",
-  "chuo.fukuoka.jp",
-  "nishiizu.shizuoka.jp",
-  "\u0627\u0644\u064a\u0645\u0646",
-  "togitsu.nagasaki.jp",
-  "lodingen.no",
-  "info.mv",
-  "isumi.chiba.jp",
-  "you",
-  "cc.wv.us",
-  "fujikawa.yamanashi.jp",
-  "ms.kr",
-  "historisches.museum",
-  "asti.it",
-  "com.lv",
-  "com.lk",
-  "ringsaker.no",
-  "com.la",
-  "nagoya",
-  "com.lc",
-  "com.lb",
-  "pors\u00e1\u014bgu.no",
-  "\u00e1laheadju.no",
-  "ski.no",
-  "dnepropetrovsk.ua",
-  "cc.nj.us",
-  "essex.museum",
-  "komforb.se",
-  "kumamoto.jp",
-  "kvafjord.no",
-  "asahi.ibaraki.jp",
-  "cc.id.us",
-  "priv.me",
-  "finland.museum",
-  "utazu.kagawa.jp",
-  "buryatia.ru",
-  "otama.fukushima.jp",
-  "flir",
-  "k12.nj.us",
-  "ed.ci",
-  "pid",
-  "ri.us",
-  "accenture",
-  "halden.no",
-  "ed.cr",
-  "nationalheritage.museum",
-  "edu.om",
-  "\u092d\u093e\u0930\u0924",
-  "honjo.saitama.jp",
-  "sakura.chiba.jp",
-  "seranishi.hiroshima.jp",
-  "chieti.it",
-  "asso.gp",
-  "moseushi.hokkaido.jp",
-  "lt.ua",
-  "ubs",
-  "nakamura.kochi.jp",
-  "semine.miyagi.jp",
-  "ravenna.it",
-  "chuo.tokyo.jp",
-  "monzaebrianza.it",
-  "net.pt",
-  "philips",
-  "lenvik.no",
-  "co.st",
-  "ask\u00f8y.no",
-  "co.sz",
-  "k12.ga.us",
-  "ishigaki.okinawa.jp",
-  "pz.it",
-  "limited",
-  "\u4f50\u8cc0.jp",
-  "carraramassa.it",
-  "imizu.toyama.jp",
-  "chirurgiens-dentistes.fr",
-  "munakata.fukuoka.jp",
-  "philately.museum",
-  "elburg.museum",
-  "gov.to",
-  "nyc.museum",
-  "sveio.no",
-  "paris",
-  "gov.tj",
-  "tvedestrand.no",
-  "int.is",
-  "emerck",
-  "ski.museum",
-  "cultural.museum",
-  "lillehammer.no",
-  "kotohira.kagawa.jp",
-  "nishihara.okinawa.jp",
-  "sch.ae",
-  "school",
-  "karasuyama.tochigi.jp",
-  "saarland",
-  "higashine.yamagata.jp",
-  "itabashi.tokyo.jp",
-  "grimstad.no",
-  "aosta.it",
-  "bu.no",
-  "wiw.gov.pl",
-  "misato.wakayama.jp",
-  "edogawa.tokyo.jp",
-  "magadan.ru",
-  "blue",
-  "galsa.no",
-  "hemnes.no",
-  "holtalen.no",
-  "statoil",
-  "\u718a\u672c.jp",
-  "misaki.okayama.jp",
-  "supplies",
-  "gov.vn",
-  "gov.vc",
-  "gov.ve",
-  "gs.hl.no",
-  "studio",
-  "iglesias-carbonia.it",
-  "co.gl",
-  "saijo.ehime.jp",
-  "immo",
-  "forum",
-  "auction",
-  "saratov.ru",
-  "kakogawa.hyogo.jp",
-  "nakamichi.yamanashi.jp",
-  "net.ng",
-  "net.nf",
-  "avianca",
-  "net.ni",
-  "kasuya.fukuoka.jp",
-  "cc.ct.us",
-  "bolzano.it",
-  "xperia",
-  "net.nr",
-  "alvdal.no",
-  "net.nz",
-  "sandvikcoromant",
-  "k12.nv.us",
-  "groundhandling.aero",
-  "shiso.hyogo.jp",
-  "pro.om",
-  "massacarrara.it",
-  "monzabrianza.it",
-  "tsumagoi.gunma.jp",
-  "smile",
-  "kashiba.nara.jp",
-  "seoul.kr",
-  "ac.lk",
-  "sos.pl",
-  "me",
-  "md",
-  "psc.br",
-  "ma",
-  "trentinostirol.it",
-  "yasuoka.nagano.jp",
-  "ml",
-  "mo",
-  "mn",
-  "mh",
-  "mk",
-  "mu",
-  "mt",
-  "mw",
-  "kaminokawa.tochigi.jp",
-  "mq",
-  "mp",
-  "ms",
-  "mr",
-  "in.th",
-  "my",
-  "mx",
-  "baidu",
-  "grandrapids.museum",
-  "estate",
-  "odo.br",
-  "monza.it",
-  "otaki.nagano.jp",
-  "\u53f0\u6e7e",
-  "org.sb",
-  "poker",
-  "hyllestad.no",
-  "russia.museum",
-  "swiebodzin.pl",
-  "hareid.no",
-  "nike",
-  "k12.nc.us",
-  "port.fr",
-  "kanie.aichi.jp",
-  "plumbing",
-  "rubtsovsk.ru",
-  "pro.ec",
-  "london",
-  "mtpc",
-  "troandin.no",
-  "takasu.hokkaido.jp",
-  "ochi.kochi.jp",
-  "vinnica.ua",
-  "or.id",
-  "kyowa.akita.jp",
-  "name.vn",
-  "harstad.no",
-  "shizuoka.jp",
-  "b\u00e1hccavuotna.no",
-  "biz.pr",
-  "trani-barletta-andria.it",
-  "rnd.ru",
-  "mishima.fukushima.jp",
-  "komatsushima.tokushima.jp",
-  "taiwa.miyagi.jp",
-  "miyoshi.tokushima.jp",
-  "rishirifuji.hokkaido.jp",
-  "net.qa",
-  "goo",
-  "theater.museum",
-  "komaki.aichi.jp",
-  "berlin.museum",
-  "got",
-  "gov",
-  "chernovtsy.ua",
-  "gop",
-  "\u7db2\u7edc.hk",
-  "free",
-  "dvag",
-  "lib.ma.us",
-  "management",
-  "clubmed",
-  "gob.ni",
-  "gildeskal.no",
-  "mari-el.ru",
-  "sarpsborg.no",
-  "nhk",
-  "kamitsue.oita.jp",
-  "nissedal.no",
-  "hof.no",
-  "shintoku.hokkaido.jp",
-  "ohkura.yamagata.jp",
-  "\u043c\u043e\u043d",
-  "stat.no",
-  "paroch.k12.ma.us",
-  "press.cy",
-  "buzen.fukuoka.jp",
-  "\u8d2d\u7269",
-  "nanbu.yamanashi.jp",
-  "cheltenham.museum",
-  "qsl.br",
-  "hangout",
-  "reggioemilia.it",
-  "umb.it",
-  "otaki.chiba.jp",
-  "trentino-sud-tirol.it",
-  "info.ki",
-  "katano.osaka.jp",
-  "bg.it",
-  "hiraizumi.iwate.jp",
-  "utsunomiya.tochigi.jp",
-  "fashion",
-  "freemasonry.museum",
-  "lakas.hu",
-  "eidsberg.no",
-  "ms.it",
-  "marburg.museum",
-  "broadcast.museum",
-  "catanzaro.it",
-  "pavia.it",
-  "lifeinsurance",
-  "pippu.hokkaido.jp",
-  "netbank",
-  "koya.wakayama.jp",
-  "village.museum",
-  "ca.us",
-  "academy",
-  "k12.il",
-  "rs.ba",
-  "ebino.miyazaki.jp",
-  "snillfjord.no",
-  "\u4f01\u4e1a",
-  "yasaka.nagano.jp",
-  "bridgestone",
-  "rogers",
-  "takahama.aichi.jp",
-  "stavanger.no",
-  "allstate",
-  "teramo.it",
-  "um.gov.pl",
-  "yamashina.kyoto.jp",
-  "*.er",
-  "\u0443\u043f\u0440.\u0441\u0440\u0431",
-  "minamidaito.okinawa.jp",
-  "iron.museum",
-  "lomza.pl",
-  "honjyo.akita.jp",
-  "solutions",
-  "earth",
-  "kokubunji.tokyo.jp",
-  "edu.mw",
-  "edu.mv",
-  "edu.mt",
-  "edu.ms",
-  "consulado.st",
-  "ha.no",
-  "portland.museum",
-  "\u5e7f\u4e1c",
-  "edu.my",
-  "edu.mx",
-  "edu.mg",
-  "edu.me",
-  "wakuya.miyagi.jp",
-  "taishin.fukushima.jp",
-  "edu.mo",
-  "edu.mn",
-  "edu.ml",
-  "edu.mk",
-  "watch",
-  "zamami.okinawa.jp",
-  "rec.br",
-  "wedding",
-  "report",
-  "\u5065\u5eb7",
-  "com.na",
-  "com.ng",
-  "com.nf",
-  "com.ni",
-  "tsubame.niigata.jp",
-  "com.nr",
-  "3.bg",
-  "tonsberg.no",
-  "iizuna.nagano.jp",
-  "valle-daosta.it",
-  "ueda.nagano.jp",
-  "kazan.ru",
-  "midsund.no",
-  "westfalen.museum",
-  "panerai",
-  "store.nf",
-  "emilia-romagna.it",
-  "anpachi.gifu.jp",
-  "takino.hyogo.jp",
-  "bargains",
-  "viking.museum",
-  "gon.pk",
-  "news",
-  "tushu",
-  "mi.th",
-  "rimini.it",
-  "lu.it",
-  "games",
-  "utah.museum",
-  "rivne.ua",
-  "trust",
-  "kawasaki.miyagi.jp",
-  "bingo",
-  "kamifurano.hokkaido.jp",
-  "newholland",
-  "fuso.aichi.jp",
-  "beer",
-  "pp.ru",
-  "judygarland.museum",
-  "matsuyama.ehime.jp",
-  "gov.tt",
-  "gov.tw",
-  "loft",
-  "gov.tr",
-  "xxx",
-  "zp.gov.pl",
-  "gov.tl",
-  "gov.tm",
-  "gov.tn",
-  "cal.it",
-  "sor-fron.no",
-  "lodi.it",
-  "pilot.aero",
-  "nara.nara.jp",
-  "rome.it",
-  "trapani.it",
-  "allfinanz",
-  "net.lk",
-  "org.sz",
-  "org.sy",
-  "si.it",
-  "org.sv",
-  "org.st",
-  "net.lc",
-  "net.lb",
-  "net.la",
-  "org.so",
-  "org.sn",
-  "org.sl",
-  "net.ly",
-  "org.sh",
-  "org.sg",
-  "net.lv",
-  "org.se",
-  "org.sd",
-  "org.sc",
-  "net.lr",
-  "org.sa",
-  "pro.mv",
-  "ama.aichi.jp",
-  "moroyama.saitama.jp",
-  "gamagori.aichi.jp",
-  "shoo.okayama.jp",
-  "chukotka.ru",
-  "aogashima.tokyo.jp",
-  "lib.ms.us",
-  "ac.be",
-  "podhale.pl",
-  "\u6211\u7231\u4f60",
-  "ingatlan.hu",
-  "arab",
-  "trentinoa-adige.it",
-  "osakasayama.osaka.jp",
-  "jeonnam.kr",
-  "fukumitsu.toyama.jp",
-  "lombardy.it",
-  "toray",
-  "british.museum",
-  "gov.bf",
-  "coop.km",
-  "bearalv\u00e1hki.no",
-  "vologda.su",
-  "pharmacy",
-  "\u30b0\u30fc\u30b0\u30eb",
-  "pe.ca",
-  "\u00e5fjord.no",
-  "gov.bb",
-  "kuzbass.ru",
-  "udmurtia.ru",
-  "mombetsu.hokkaido.jp",
-  "scotland.museum",
-  "tosashimizu.kochi.jp",
-  "africa",
-  "rep.kp",
-  "k12.tx.us",
-  "arai.shizuoka.jp",
-  "ao.it",
-  "gift",
-  "oz.au",
-  "schwarz",
-  "meland.no",
-  "square.museum",
-  "kamioka.akita.jp",
-  "public.museum",
-  "troms\u00f8.no",
-  "conference.aero",
-  "cyber.museum",
-  "tanabe.kyoto.jp",
-  "ice",
-  "andriatranibarletta.it",
-  "m\u00e1tta-v\u00e1rjjat.no",
-  "fujimi.saitama.jp",
-  "p.se",
-  "toba.mie.jp",
-  "christmas",
-  "booking",
-  "or.kr",
-  "aomori.jp",
-  "randaberg.no",
-  "name.tt",
-  "name.tr",
-  "discount",
-  "name.tj",
-  "seihi.nagasaki.jp",
-  "trolley.museum",
-  "hokuto.yamanashi.jp",
-  "jewish.museum",
-  "go.it",
-  "pordenone.it",
-  "plus",
-  "go.id",
-  "\u5a31\u4e50",
-  "imageandsound.museum",
-  "yaroslavl.ru",
-  "web.co",
-  "eco.br",
-  "nm.us",
-  "southwest.museum",
-  "mandal.no",
-  "perso.sn",
-  "edu.vc",
-  "kochi.jp",
-  "virgin",
-  "edu.vu",
-  "mup.gov.pl",
-  "milano.it",
-  "kv\u00e6fjord.no",
-  "if.ua",
-  "bd.se",
-  "yonezawa.yamagata.jp",
-  "ostrowiec.pl",
-  "kadogawa.miyazaki.jp",
-  "naka.ibaraki.jp",
-  "egyptian.museum",
-  "solar",
-  "alt.za",
-  "cc.tn.us",
-  "viva",
-  "australia.museum",
-  "vivo",
-  "qc.ca",
-  "id.us",
-  "\u5927\u4f17\u6c7d\u8f66",
-  "tomika.gifu.jp",
-  "chel.ru",
-  "rovigo.it",
-  "shiraoi.hokkaido.jp",
-  "cahcesuolo.no",
-  "pomorskie.pl",
-  "valled-aosta.it",
-  "pub.sa",
-  "\u654e\u80b2.hk",
-  "nl",
-  "no",
-  "m.bg",
-  "na",
-  "nc",
-  "ne",
-  "nf",
-  "ng",
-  "nz",
-  "passagens",
-  "nr",
-  "lib.nv.us",
-  "nu",
-  "x.se",
-  "ky.us",
-  "masoy.no",
-  "football",
-  "mb.it",
-  "shibetsu.hokkaido.jp",
-  "spb.su",
-  "univ.sn",
-  "komvux.se",
-  "telefonica",
-  "olbia-tempio.it",
-  "dazaifu.fukuoka.jp",
-  "yamakita.kanagawa.jp",
-  "otofuke.hokkaido.jp",
-  "coach",
-  "omaha.museum",
-  "yamatokoriyama.nara.jp",
-  "takasago.hyogo.jp",
-  "sakata.yamagata.jp",
-  "click",
-  "sakegawa.yamagata.jp",
-  "mat.br",
-  "nishitosa.kochi.jp",
-  "etne.no",
-  "gjemnes.no",
-  "coop",
-  "gen.tr",
-  "matsuura.nagasaki.jp",
-  "kawanabe.kagoshima.jp",
-  "kawatana.nagasaki.jp",
-  "yashiro.hyogo.jp",
-  "geology.museum",
-  "mma",
-  "brother",
-  "mi.us",
-  "computer.museum",
-  "icu",
-  "movie",
-  "chikuzen.fukuoka.jp",
-  "gorlice.pl",
-  "ri.it",
-  "gs.nl.no",
-  "padua.it",
-  "porn",
-  "usuki.oita.jp",
-  "asso.ci",
-  "salvadordali.museum",
-  "hemne.no",
-  "edu.kp",
-  "edu.ky",
-  "edu.kz",
-  "pisa.it",
-  "n\u00e1vuotna.no",
-  "toyohashi.aichi.jp",
-  "edu.kg",
-  "shirakawa.gifu.jp",
-  "edu.ki",
-  "edu.km",
-  "edu.kn",
-  "cc.fl.us",
-  "sakura.tochigi.jp",
-  "baseball",
-  "kolobrzeg.pl",
-  "kasugai.aichi.jp",
-  "santafe.museum",
-  "portal.museum",
-  "ts.it",
-  "nishiawakura.okayama.jp",
-  "modena.it",
-  "puglia.it",
-  "sakhalin.ru",
-  "sande.m\u00f8re-og-romsdal.no",
-  "lazio.it",
-  "compare",
-  "tmp.br",
-  "k12.pr.us",
-  "raisa.no",
-  "tone.ibaraki.jp",
-  "setouchi.okayama.jp",
-  "lyngdal.no",
-  "sener",
-  "msd",
-  "today",
-  "ltd.lk",
-  "symantec",
-  "gv.at",
-  "bremanger.no",
-  "\u5bae\u5d0e.jp",
-  "gv.ao",
-  "historisch.museum",
-  "\u5929\u4e3b\u6559",
-  "her\u00f8y.nordland.no",
-  "\u798f\u5cf6.jp",
-  "snz.ru",
-  "*.gu",
-  "k12.tn.us",
-  "nu.ca",
-  "katashina.gunma.jp",
-  "stream",
-  "froya.no",
-  "sorreisa.no",
-  "eng.br",
-  "sharp",
-  "reggio-emilia.it",
-  "sa.gov.au",
-  "ruovat.no",
-  "amsterdam.museum",
-  "\u6fb3\u95e8",
-  "en.it",
-  "kurogi.fukuoka.jp",
-  "\u7f51\u7d61.hk",
-  "atlanta.museum",
-  "ok.us",
-  "\u6fb3\u9580",
-  "biz.az",
-  "gov.za",
-  "k12.ma.us",
-  "usdecorativearts.museum",
-  "cc.oh.us",
-  "rm.it",
-  "bronnoysund.no",
-  "org.uy",
-  "org.uz",
-  "net.jo",
-  "hizen.saga.jp",
-  "obanazawa.yamagata.jp",
-  "net.je",
-  "tomakomai.hokkaido.jp",
-  "org.uk",
-  "ota.gunma.jp",
-  "hotel.tz",
-  "org.ug",
-  "sola.no",
-  "kushimoto.wakayama.jp",
-  "nov.su",
-  "l\u00e6rdal.no",
-  "gifu.gifu.jp",
-  "cc.ms.us",
-  "chungnam.kr",
-  "miharu.fukushima.jp",
-  "orskog.no",
-  "payu",
-  "name",
-  "vdonsk.ru",
-  "tamaki.mie.jp",
-  "lacaixa",
-  "per.sg",
-  "t.bg",
-  "science.museum",
-  "sex.hu",
-  "hornindal.no",
-  "kpmg",
-  "coop.mw",
-  "coop.mv",
-  "aa.no",
-  "skjerv\u00f8y.no",
-  "shangrila",
-  "zappos",
-  "\u00e5seral.no",
-  "botany.museum",
-  "filatelia.museum",
-  "austevoll.no",
-  "edu.ve",
-  "y.se",
-  "dallas.museum",
-  "urbino-pesaro.it",
-  "niepce.museum",
-  "edu.vn",
-  "place",
-  "daegu.kr",
-  "oshima.yamaguchi.jp",
-  "lasalle",
-  "steigen.no",
-  "nic.in",
-  "hiji.oita.jp",
-  "george",
-  "engineer",
-  "airbus",
-  "hb.cn",
-  "cng.br",
-  "chiyoda.tokyo.jp",
-  "kamisunagawa.hokkaido.jp",
-  "or.mu",
-  "isernia.it",
-  "ngo.ph",
-  "stargard.pl",
-  "go.kr",
-  "moss.no",
-  "santacruz.museum",
-  "clock.museum",
-  "suwalki.pl",
-  "nature.museum",
-  "chloe",
-  "pro",
-  "pru",
-  "itako.ibaraki.jp",
-  "ibaraki.osaka.jp",
-  "rent",
-  "skjervoy.no",
-  "anz",
-  "aoki.nagano.jp",
-  "police.uk",
-  "datsun",
-  "edu.tj",
-  "charter.aero",
-  "edu.to",
-  "edu.tr",
-  "surnadal.no",
-  "edu.tw",
-  "gmail",
-  "surf",
-  "karikatur.museum",
-  "mazowsze.pl",
-  "cc.or.us",
-  "gz.cn",
-  "gojome.akita.jp",
-  "j\u00f8rpeland.no",
-  "ut.us",
-  "bahccavuotna.no",
-  "frogans",
-  "sohu",
-  "sciencecenter.museum",
-  "lib.sd.us",
-  "tj.cn",
-  "cheap",
-  "matsumoto.kagoshima.jp",
-  "oyama.tochigi.jp",
-  "dyr\u00f8y.no",
-  "notogawa.shiga.jp",
-  "kazo.saitama.jp",
-  "frontdoor",
-  "fauske.no",
-  "yamanashi.jp",
-  "taito.tokyo.jp",
-  "naturalhistorymuseum.museum",
-  "psi.br",
-  "mormon",
-  "nasushiobara.tochigi.jp",
-  "wakasa.tottori.jp",
-  "bruxelles.museum",
-  "lorenskog.no",
-  "koga.ibaraki.jp",
-  "tatebayashi.gunma.jp",
-  "cc.mt.us",
-  "gjerstad.no",
-  "flog.br",
-  "kitanakagusuku.okinawa.jp",
-  "kamo.kyoto.jp",
-  "watchandclock.museum",
-  "cb.it",
-  "torsken.no",
-  "niihama.ehime.jp",
-  "gateway.museum",
-  "phoenix.museum",
-  "oamishirasato.chiba.jp",
-  "homegoods",
-  "tysnes.no",
-  "maintenance.aero",
-  "oguchi.aichi.jp",
-  "sumida.tokyo.jp",
-  "mortgage",
-  "farmers",
-  "review",
-  "dinosaur.museum",
-  "\u067e\u0627\u06a9\u0633\u062a\u0627\u0646",
-  "nanyo.yamagata.jp",
-  "k12.ar.us",
-  "srv.br",
-  "gallery.museum",
-  "hazu.aichi.jp",
-  "ltd.co.im",
-  "kitaakita.akita.jp",
-  "hs.kr",
-  "yamada.fukuoka.jp",
-  "kaita.hiroshima.jp",
-  "varggat.no",
-  "music.museum",
-  "iinet",
-  "konan.aichi.jp",
-  "nakama.fukuoka.jp",
-  "tokoname.aichi.jp",
-  "takagi.nagano.jp",
-  "hashikami.aomori.jp",
-  "surrey.museum",
-  "asso.mc",
-  "murata.miyagi.jp",
-  "transport.museum",
-  "gs.tm.no",
-  "saga.saga.jp",
-  "defense.tn",
-  "edu.is",
-  "edu.iq",
-  "m\u00e1latvuopmi.no",
-  "edu.it",
-  "valdaosta.it",
-  "edu.in",
-  "tomobe.ibaraki.jp",
-  "lig.it",
-  "ine.kyoto.jp",
-  "\u043e\u0434.\u0441\u0440\u0431",
-  "glas.museum",
-  "warabi.saitama.jp",
-  "zippo",
-  "shinkamigoto.nagasaki.jp",
-  "mochizuki.nagano.jp",
-  "gs.va.no",
-  "aquarelle",
-  "case",
-  "hughes",
-  "com.bt",
-  "com.bs",
-  "com.br",
-  "artgallery.museum",
-  "com.bz",
-  "com.by",
-  "career",
-  "nanae.hokkaido.jp",
-  "com.bb",
-  "com.ba",
-  "com.bo",
-  "com.bm",
-  "kobayashi.miyazaki.jp",
-  "com.bi",
-  "com.bh",
-  "nt.ro",
-  "sanfrancisco.museum",
-  "vuelos",
-  "net.bo",
-  "okegawa.saitama.jp",
-  "inatsuki.fukuoka.jp",
-  "lib.la.us",
-  "author",
-  "yakage.okayama.jp",
-  "stockholm.museum",
-  "net.br",
-  "jogasz.hu",
-  "coop.py",
-  "net.bt",
-  "barefoot",
-  "ozu.kumamoto.jp",
-  "bbs.tr",
-  "civilization.museum",
-  "uconnect",
-  "xj.cn",
-  "halloffame.museum",
-  "boehringer",
-  "fermo.it",
-  "porsgrunn.no",
-  "wakayama.jp",
-  "zuerich",
-  "r\u00f8d\u00f8y.no",
-  "tadaoka.osaka.jp",
-  "missile.museum",
-  "b\u00e1jddar.no",
-  "ikusaka.nagano.jp",
-  "mer\u00e5ker.no",
-  "club.tw",
-  "ureshino.mie.jp",
-  "yamato.fukushima.jp",
-  "kutno.pl",
-  "k12.ny.us",
-  "trentinosud-tirol.it",
-  "blog",
-  "kawaba.gunma.jp",
-  "yawatahama.ehime.jp",
-  "arts.ve",
-  "is.it",
-  "cc.ut.us",
-  "mitoyo.kagawa.jp",
-  "biz.cy",
-  "lanbib.se",
-  "furniture",
-  "ah.no",
-  "minamiechizen.fukui.jp",
-  "mashike.hokkaido.jp",
-  "nissan",
-  "selje.no",
-  "nes.buskerud.no",
-  "izumi.osaka.jp",
-  "toride.ibaraki.jp",
-  "nissay",
-  "montreal.museum",
-  "web.za",
-  "al.us",
-  "gs.mr.no",
-  "net.ht",
-  "madrid",
-  "ardal.no",
-  "mo.us",
-  "net.hk",
-  "net.hn",
-  "e164.arpa",
-  "london.museum",
-  "legal",
-  "kamagaya.chiba.jp",
-  "co.us",
-  "kepno.pl",
-  "nishiokoppe.hokkaido.jp",
-  "\u0641\u0644\u0633\u0637\u064a\u0646",
-  "org.af",
-  "ind.in",
-  "hatoyama.saitama.jp",
-  "om",
-  "zentsuji.kagawa.jp",
-  "nc.us",
-  "date.hokkaido.jp",
-  "elblag.pl",
-  "nom.ni",
-  "orkdal.no",
-  "cartier",
-  "fie.ee",
-  "yukuhashi.fukuoka.jp",
-  "mjondalen.no",
-  "radoy.no",
-  "higashiosaka.osaka.jp",
-  "ichinoseki.iwate.jp",
-  "minamata.kumamoto.jp",
-  "minami.fukuoka.jp",
-  "bindal.no",
-  "sec.ps",
-  "schaeffler",
-  "tsurugi.ishikawa.jp",
-  "kagami.kochi.jp",
-  "trani-andria-barletta.it",
-  "sumoto.hyogo.jp",
-  "fish",
-  "cherkassy.ua",
-  "educational.museum",
-  "juif.museum",
-  "\u8054\u901a",
-  "zt.ua",
-  "artdeco.museum",
-  "kiwa.mie.jp",
-  "ogose.saitama.jp",
-  "org.ws",
-  "\u00e5rdal.no",
-  "sakahogi.gifu.jp",
-  "naturalsciences.museum",
-  "cba",
-  "tambov.ru",
-  "beiarn.no",
-  "avoues.fr",
-  "cbs",
-  "misato.shimane.jp",
-  "inabe.mie.jp",
-  "toon.ehime.jp",
-  "ome.tokyo.jp",
-  "hl.no",
-  "kerryhotels",
-  "kawanishi.hyogo.jp",
-  "name.pr",
-  "taa.it",
-  "law.za",
-  "ikano",
-  "rollag.no",
-  "nagai.yamagata.jp",
-  "tsubata.ishikawa.jp",
-  "ekloges.cy",
-  "dog",
-  "barcelona",
-  "rifu.miyagi.jp",
-  "directory",
-  "colonialwilliamsburg.museum",
-  "togakushi.nagano.jp",
-  "k12.la.us",
-  "ambulance.museum",
-  "kawaguchi.saitama.jp",
-  "entomology.museum",
-  "chita.ru",
-  "rygge.no",
-  "florence.it",
-  "gob.hn",
-  "chtr.k12.ma.us",
-  "med.om",
-  "edu.rs",
-  "motorcycle.museum",
-  "cnt.br",
-  "edu.rw",
-  "edu.ru",
-  "global",
-  "song",
-  "fan",
-  "drobak.no",
-  "sony",
-  "meldal.no",
-  "matsubara.osaka.jp",
-  "watch-and-clock.museum",
-  "id.ir",
-  "glogow.pl",
-  "wsa.gov.pl",
-  "journalist.aero",
-  "tel",
-  "school.museum",
-  "r\u00f8ros.no",
-  "habikino.osaka.jp",
-  "bt.it",
-  "design",
-  "nba",
-  "\u0645\u0635\u0631",
-  "sondrio.it",
-  "ivano-frankivsk.ua",
-  "unnan.shimane.jp",
-  "date.fukushima.jp",
-  "s\u00f8r-fron.no",
-  "mil.za",
-  "tsukiyono.gunma.jp",
-  "racing",
-  "sld.do",
-  "horology.museum",
-  "storfjord.no",
-  "f.se",
-  "shitara.aichi.jp",
-  "neyagawa.osaka.jp",
-  "happou.akita.jp",
-  "modalen.no",
-  "anjo.aichi.jp",
-  "kuroiso.tochigi.jp",
-  "\u0dbd\u0d82\u0d9a\u0dcf",
-  "shikaoi.hokkaido.jp",
-  "hermes",
-  "crafts.museum",
-  "markets",
-  "nirasaki.yamanashi.jp",
-  "onna.okinawa.jp",
-  "nakatane.kagoshima.jp",
-  "mishima.shizuoka.jp",
-  "h\u00e1mm\u00e1rfeasta.no",
-  "md.us",
-  "sanjo.niigata.jp",
-  "virtual.museum",
-  "mw.gov.pl",
-  "firm.co",
-  "me.uk",
-  "hinohara.tokyo.jp",
-  "me.us",
-  "dnipropetrovsk.ua",
-  "nakano.nagano.jp",
-  "foundation.museum",
-  "mil.ni",
-  "fujishiro.ibaraki.jp",
-  "nogi.tochigi.jp",
-  "ninomiya.kanagawa.jp",
-  "inder\u00f8y.no",
-  "of.by",
-  "imabari.ehime.jp",
-  "neues.museum",
-  "mihara.kochi.jp",
-  "am.br",
-  "org.tw",
-  "war.museum",
-  "lighting",
-  "mizusawa.iwate.jp",
-  "horonobe.hokkaido.jp",
-  "org.tj",
-  "iwamizawa.hokkaido.jp",
-  "com.dz",
-  "a.bg",
-  "alta.no",
-  "vegas",
-  "k12.ne.us",
-  "sherbrooke.museum",
-  "rentals",
-  "nisshin.aichi.jp",
-  "kaho.fukuoka.jp",
-  "int.ar",
-  "tobishima.aichi.jp",
-  "int.az",
-  "nakijin.okinawa.jp",
-  "sch.ir",
-  "lierne.no",
-  "pg.it",
-  "sale",
-  "med.ec",
-  "scot",
-  "sch.id",
-  "cool",
-  "trondheim.no",
-  "embetsu.hokkaido.jp",
-  "oharu.aichi.jp",
-  "kautokeino.no",
-  "miyako.fukuoka.jp",
-  "*.kw",
-  "sandefjord.no",
-  "bestbuy",
-  "sciences.museum",
-  "shiogama.miyagi.jp",
-  "*.ke",
-  "unicom",
-  "vevelstad.no",
-  "nago.okinawa.jp",
-  "*.kh",
-  "kafjord.no",
-  "aseral.no",
-  "florist",
-  "ushistory.museum",
-  "tokai.aichi.jp",
-  "higashinaruse.akita.jp",
-  "r\u00e6lingen.no",
-  "sologne.museum",
-  "lib.tx.us",
-  "venezia.it",
-  "multichoice",
-  "center.museum",
-  "yatsuka.shimane.jp",
-  "health",
-  "okawa.kochi.jp",
-  "balashov.su",
-  "qpon",
-  "ce.it",
-  "inuyama.aichi.jp",
-  "biz.et",
-  "b.se",
-  "kakinoki.shimane.jp",
-  "landrover",
-  "oristano.it",
-  "\u00e1lt\u00e1.no",
-  "shinjuku.tokyo.jp",
-  "folldal.no",
-  "kumatori.osaka.jp",
-  "\u4e2a\u4eba.hk",
-  "vega.no",
-  "ivanovo.ru",
-  "championship.aero",
-  "sumoto.kumamoto.jp",
-  "naamesjevuemie.no",
-  "oguni.kumamoto.jp",
-  "\u00e5lg\u00e5rd.no",
-  "watches",
-  "shimoji.okinawa.jp",
-  "mihama.mie.jp",
-  "mito.ibaraki.jp",
-  "store",
-  "k12.ks.us",
-  "idv.hk",
-  "nonoichi.ishikawa.jp",
-  "hamura.tokyo.jp",
-  "certification.aero",
-  "auspost",
-  "semboku.akita.jp",
-  "kalmykia.ru",
-  "cc.nm.us",
-  "tana.no",
-  "ashoro.hokkaido.jp",
-  "siena.it",
-  "h.bg",
-  "kaneyama.fukushima.jp",
-  "reise",
-  "kasuga.hyogo.jp",
-  "otoyo.kochi.jp",
-  "gorizia.it",
-  "aomori.aomori.jp",
-  "gujo.gifu.jp",
-  "cc.az.us",
-  "ternopil.ua",
-  "mnet",
-  "urn.arpa",
-  "maison",
-  "im.it",
-  "genkai.saga.jp",
-  "trustee.museum",
-  "nakagawa.nagano.jp",
-  "ovre-eiker.no",
-  "it.ao",
-  "kasai.hyogo.jp",
-  "skierv\u00e1.no",
-  "tagami.niigata.jp",
-  "windows",
-  "tt.im",
-  "dentist",
-  "drammen.no",
-  "latrobe",
-  "v\u00e1rgg\u00e1t.no",
-  "niigata.niigata.jp",
-  "pars",
-  "samsclub",
-  "ato.br",
-  "saga.jp",
-  "taishi.osaka.jp",
-  "\u57fc\u7389.jp",
-  "christiansburg.museum",
-  "\u043c\u043a\u0434",
-  "paris.museum",
-  "tuva.su",
-  "\u5cf6\u6839.jp",
-  "plc.uk",
-  "\u0627\u0644\u0645\u063a\u0631\u0628",
-  "or.at",
-  "iwaki.fukushima.jp",
-  "hiv",
-  "a\u00e9roport.ci",
-  "rnrt.tn",
-  "yao.osaka.jp",
-  "iwatsuki.saitama.jp",
-  "plo.ps",
-  "amica",
-  "chippubetsu.hokkaido.jp",
-  "budapest",
-  "lib.me.us",
-  "5.bg",
-  "\u65b0\u52a0\u5761",
-  "\u65f6\u5c1a",
-  "soundandvision.museum",
-  "milan.it",
-  "koeln.museum",
-  "parti.se",
-  "tci",
-  "homebuilt.aero",
-  "federation.aero",
-  "intelligence.museum",
-  "stalbans.museum",
-  "edu.pt",
-  "shima.mie.jp",
-  "edu.pr",
-  "edu.ps",
-  "stord.no",
-  "edu.pe",
-  "edu.pf",
-  "edu.pa",
-  "edu.pl",
-  "edu.pn",
-  "edu.ph",
-  "kitamoto.saitama.jp",
-  "edu.pk",
-  "f.bg",
-  "erni",
-  "gyeonggi.kr",
-  "takanezawa.tochigi.jp",
-  "oiso.kanagawa.jp",
-  "kamikitayama.nara.jp",
-  "desa.id",
-  "obama.fukui.jp",
-  "vibo-valentia.it",
-  "fr\u00f8ya.no",
-  "insurance",
-  "hamatonbetsu.hokkaido.jp",
-  "akishima.tokyo.jp",
-  "\u30bb\u30fc\u30eb",
-  "asda",
-  "tyumen.ru",
-  "nat.tn",
-  "pr",
-  "ps",
-  "nadex",
-  "java",
-  "pw",
-  "pt",
-  "pharmacy.museum",
-  "py",
-  "pa",
-  "pf",
-  "pe",
-  "pk",
-  "ph",
-  "pn",
-  "pl",
-  "pm",
-  "ltd.uk",
-  "kasaoka.okayama.jp",
-  "toyama.jp",
-  "student.aero",
-  "okayama.okayama.jp",
-  "baidar.no",
-  "*.pg",
-  "chikugo.fukuoka.jp",
-  "higashiizu.shizuoka.jp",
-  "kred",
-  "info.sd",
-  "nishi.fukuoka.jp",
-  "rip",
-  "rio",
-  "ril",
-  "fukusaki.hyogo.jp",
-  "bo.telemark.no",
-  "yashio.saitama.jp",
-  "skodje.no",
-  "everbank",
-  "panasonic",
-  "tysv\u00e6r.no",
-  "redumbrella",
-  "\u0438\u043a\u043e\u043c.museum",
-  "agematsu.nagano.jp",
-  "nagatoro.saitama.jp",
-  "flora.no",
-  "orland.no",
-  "\u067e\u0627\u0643\u0633\u062a\u0627\u0646",
-  "moka.tochigi.jp",
-  "tohnosho.chiba.jp",
-  "flesberg.no",
-  "campobasso.it",
-  "mosjoen.no",
-  "naturalhistory.museum",
-  "okutama.tokyo.jp",
-  "\uc0bc\uc131",
-  "nordre-land.no",
-  "tochigi.jp",
-  "press",
-  "lib.pr.us",
-  "pohl",
-  "kwp.gov.pl",
-  "lexus",
-  "reliance",
-  "cn.ua",
-  "gonohe.aomori.jp",
-  "sakai.fukui.jp",
-  "tateyama.toyama.jp",
-  "schokoladen.museum",
-  "askim.no",
-  "vaga.no",
-  "ogasawara.tokyo.jp",
-  "vladikavkaz.ru",
-  "fairwinds",
-  "softbank",
-  "fvg.it",
-  "fukagawa.hokkaido.jp",
-  "kerryproperties",
-  "com.fr",
-  "crimea.ua",
-  "nordreisa.no",
-  "lib.ia.us",
-  "osakikamijima.hiroshima.jp",
-  "altoadige.it",
-  "int.co",
-  "int.ci",
-  "nt.no",
-  "luxe",
-  "newspaper.museum",
-  "k12.ca.us",
-  "prof",
-  "prod",
-  "humanities.museum",
-  "bellevue.museum",
-  "weir",
-  "k12.nm.us",
-  "kushima.miyazaki.jp",
-  "2000.hu",
-  "lib.oh.us",
-  "gov.cn",
-  "yamaxun",
-  "*.mz",
-  "ikeda.osaka.jp",
-  "muosat.no",
-  "vefsn.no",
-  "adygeya.ru",
-  "*.mm",
-  "notodden.no",
-  "aca.pro",
-  "northwesternmutual",
-  "cherkasy.ua",
-  "countryestate.museum",
-  "zj.cn",
-  "sx.cn",
-  "ubank",
-  "fast",
-  "time.museum",
-  "tarumizu.kagoshima.jp",
-  "kitami.hokkaido.jp",
-  "aizumisato.fukushima.jp",
-  "campidanomedio.it",
-  "delta",
-  "!city.kobe.jp",
-  "9.bg",
-  "arts.ro",
-  "sirdal.no",
-  "equipment.aero",
-  "kyknet",
-  "ebina.kanagawa.jp",
-  "tochigi.tochigi.jp",
-  "ug.gov.pl",
-  "mitsue.nara.jp",
-  "eun.eg",
-  "toyoura.hokkaido.jp",
-  "associates",
-  "lans.museum",
-  "toki.gifu.jp",
-  "tsuchiura.ibaraki.jp",
-  "trv",
-  "jfk.museum",
-  "ac.za",
-  "nico",
-  "lucerne.museum",
-  "takata.fukuoka.jp",
-  "\u30b3\u30e0",
-  "kofu.yamanashi.jp",
-  "\u624b\u8868",
-  "tromsa.no",
-  "mo\u00e5reke.no",
-  "kv\u00e6nangen.no",
-  "ky",
-  "net.ai",
-  "treviso.it",
-  "asahi.chiba.jp",
-  "net.ae",
-  "film.hu",
-  "levanger.no",
-  "hakui.ishikawa.jp",
-  "cc.co.us",
-  "vestvagoy.no",
-  "scienceandindustry.museum",
-  "edu",
-  "gouv.ci",
-  "lawyer",
-  "pe.kr",
-  "raholt.no",
-  "an.it",
-  "usa.museum",
-  "fukuroi.shizuoka.jp",
-  "yabu.hyogo.jp",
-  "es.kr",
-  "kujukuri.chiba.jp",
-  "maritimo.museum",
-  "forde.no",
-  "ancona.it",
-  "asaka.saitama.jp",
-  "sayo.hyogo.jp",
-  "abo.pa",
-  "b.bg",
-  "turek.pl",
-  "skydiving.aero",
-  "artanddesign.museum",
-  "!teledata.mz",
-  "net.do",
-  "net.dm",
-  "elk.pl",
-  "opoczno.pl",
-  "grondar.za",
-  "embroidery.museum",
-  "val-d-aosta.it",
-  "net.dz",
-  "midori.gunma.jp",
-  "kusu.oita.jp",
-  "cfd",
-  "edu.bm",
-  "grue.no",
-  "edu.bb",
-  "gmbh",
-  "soni.nara.jp",
-  "himeshima.oita.jp",
-  "\u8328\u57ce.jp",
-  "or.ci",
-  "mima.tokushima.jp",
-  "w.bg",
-  "sicily.it",
-  "gyeongnam.kr",
-  "rnu.tn",
-  "capital",
-  "or.cr",
-  "k12.mn.us",
-  "airtel",
-  "degree",
-  "lib.vi.us",
-  "cc.pr.us",
-  "fyresdal.no",
-  "mielno.pl",
-  "k12.mo.us",
-  "sexy",
-  "ikeda.gifu.jp",
-  "kozagawa.wakayama.jp",
-  "tv.im",
-  "\u7f51\u5e97",
-  "fukushima.hokkaido.jp",
-  "hdfcbank",
-  "tatamotors",
-  "sanok.pl",
-  "haga.tochigi.jp",
-  "tv.it",
-  "uto.kumamoto.jp",
-  "etajima.hiroshima.jp",
-  "app",
-  "wuoz.gov.pl",
-  "duck",
-  "molde.no",
-  "kai.yamanashi.jp",
-  "gob.do",
-  "kouzushima.tokyo.jp",
-  "nexus",
-  "8.bg",
-  "muko.kyoto.jp",
-  "cipriani",
-  "kihoku.ehime.jp",
-  "shonai.fukuoka.jp",
-  "pvt.k12.ma.us",
-  "v\u00e5ler.hedmark.no",
-  "granvin.no",
-  "int.vn",
-  "pccw",
-  "nedre-eiker.no",
-  "aerobatic.aero",
-  "joyo.kyoto.jp",
-  "tax",
-  "hiraya.nagano.jp",
-  "tachiarai.fukuoka.jp",
-  "navigation.aero",
-  "guru",
-  "canada.museum",
-  "anamizu.ishikawa.jp",
-  "dwg",
-  "jondal.no",
-  "eidsvoll.no",
-  "zao.miyagi.jp",
-  "friuli-venezia-giulia.it",
-  "winners",
-  "firenze.it",
-  "silk.museum",
-  "kumejima.okinawa.jp",
-  "oksnes.no",
-  "villas",
-  "tos.it",
-  "ono.fukushima.jp",
-  "mi.it",
-  "kouyama.kagoshima.jp",
-  "uwajima.ehime.jp",
-  "kasuga.fukuoka.jp",
-  "go.tz",
-  "egersund.no",
-  "norilsk.ru",
-  "yawata.kyoto.jp",
-  "navuotna.no",
-  "meguro.tokyo.jp",
-  "minami.kyoto.jp",
-  "omachi.nagano.jp",
-  "holiday",
-  "rsvp",
-  "kanoya.kagoshima.jp",
-  "enna.it",
-  "ooshika.nagano.jp",
-  "crs",
-  "fujimi.nagano.jp",
-  "pharmaciens.km",
-  "fjaler.no",
-  "griw.gov.pl",
-  "\u5546\u6807",
-  "shop.hu",
-  "shop.ht",
-  "republican",
-  "lo.it",
-  "americanfamily",
-  "me.it",
-  "konskowola.pl",
-  "nfl",
-  "pyatigorsk.ru",
-  "go.tj",
-  "hasvik.no",
-  "vic.au",
-  "nakagusuku.okinawa.jp",
-  "higashitsuno.kochi.jp",
-  "bentley",
-  "palana.ru",
-  "k12.mt.us",
-  "asso.km",
-  "stateofdelaware.museum",
-  "leirvik.no",
-  "ag.it",
-  "nara.jp",
-  "frontier",
-  "koganei.tokyo.jp",
-  "stj\u00f8rdalshalsen.no",
-  "deloitte",
-  "newport.museum",
-  "kawai.nara.jp",
-  "saikai.nagasaki.jp",
-  "nikaho.akita.jp",
-  "co.gy",
-  "ibaraki.jp",
-  "jus.br",
-  "vyatka.ru",
-  "vacations",
-  "co.gg",
-  "agents.aero",
-  "organic",
-  "towada.aomori.jp",
-  "siracusa.it",
-  "ltd",
-  "naval.museum",
-  "higashikurume.tokyo.jp",
-  "ise.mie.jp",
-  "walter",
-  "varoy.no",
-  "toyokawa.aichi.jp",
-  "sci.eg",
-  "s.se",
-  "vig",
-  "kamisato.saitama.jp",
-  "olawa.pl",
-  "higashihiroshima.hiroshima.jp",
-  "slask.pl",
-  "iizuka.fukuoka.jp",
-  "szczytno.pl",
-  "shell",
-  "r\u00e1hkker\u00e1vju.no",
-  "engine.aero",
-  "memorial.museum",
-  "amami.kagoshima.jp",
-  "h\u00f8ylandet.no",
-  "kainan.tokushima.jp",
-  "sardinia.it",
-  "bahcavuotna.no",
-  "vardo.no",
-  "nic.tj",
-  "lutsk.ua",
-  "kviteseid.no",
-  "leclerc",
-  "\u516c\u76ca",
-  "maizuru.kyoto.jp",
-  "travelchannel",
-  "adv.br",
-  "inami.wakayama.jp",
-  "imdb",
-  "andriabarlettatrani.it",
-  "cesena-forli.it",
-  "catholic",
-  "gov.bt",
-  "gov.br",
-  "gov.bs",
-  "sannohe.aomori.jp",
-  "li.it",
-  "gov.bz",
-  "gov.by",
-  "kawagoe.mie.jp",
-  "usgarden.museum",
-  "bv.nl",
-  "gov.ba",
-  "gov.bo",
-  "gov.bm",
-  "gov.bh",
-  "cinema.museum",
-  "accountants",
-  "inazawa.aichi.jp",
-  "mitake.gifu.jp",
-  "biz.id",
-  "lamer",
-  "kamchatka.ru",
-  "hakone.kanagawa.jp",
-  "schule",
-  "k12.fl.us",
-  "fujitsu",
-  "toyone.aichi.jp",
-  "vin",
-  "blog.br",
-  "stadt.museum",
-  "sodegaura.chiba.jp",
-  "pro.cy",
-  "amakusa.kumamoto.jp",
-  "kyuragi.saga.jp",
-  "hol.no",
-  "sano.tochigi.jp",
-  "k12.vt.us",
-  "dclk",
-  "frana.no",
-  "takashima.shiga.jp",
-  "oita.oita.jp",
-  "indianmarket.museum",
-  "kaga.ishikawa.jp",
-  "paleo.museum",
-  "ind.gt",
-  "yosemite.museum",
-  "fm.no",
-  "ena.gifu.jp",
-  "qa",
-  "ora.gunma.jp",
-  "ikata.ehime.jp",
-  "kitakata.miyazaki.jp",
-  "verm\u00f6gensberater",
-  "daejeon.kr",
-  "org.ua",
-  "yusui.kagoshima.jp",
-  "hoteles",
-  "omsk.ru",
-  "pe.it",
-  "fujiidera.osaka.jp",
-  "alaheadju.no",
-  "opole.pl",
-  "\u8c37\u6b4c",
-  "saka.hiroshima.jp",
-  "kagamiishi.fukushima.jp",
-  "verisign",
-  "jot",
-  "joy",
-  "amex",
-  "grozny.su",
-  "barum.no",
-  "net.ba",
-  "net.bb",
-  "net.bh",
-  "net.bm",
-  "miyada.nagano.jp",
-  "wales.museum",
-  "net.bs",
-  "asahi.mie.jp",
-  "eniwa.hokkaido.jp",
-  "\u0645\u0648\u0642\u0639",
-  "net.bz",
-  "recht.pro",
-  "la-spezia.it",
-  "krodsherad.no",
-  "isesaki.gunma.jp",
-  "\u0628\u06be\u0627\u0631\u062a",
-  "bbc",
-  "upow.gov.pl",
-  "bbt",
-  "tokushima.tokushima.jp",
-  "parachuting.aero",
-  "rzgw.gov.pl",
-  "sannan.hyogo.jp",
-  "chambagri.fr",
-  "oregontrail.museum",
-  "kunst.museum",
-  "franziskaner.museum",
-  "supply",
-  "penza.su",
-  "station.museum",
-  "\u049b\u0430\u0437",
-  "sanagochi.tokushima.jp",
-  "society.museum",
-  "ketrzyn.pl",
-  "kvitsoy.no",
-  "sakado.saitama.jp",
-  "vlaanderen.museum",
-  "bonn.museum",
-  "med.ee",
-  "kaluga.su",
-  "tarama.okinawa.jp",
-  "gob.bo",
-  "aogaki.hyogo.jp",
-  "promo",
-  "omiya.saitama.jp",
-  "tromso.no",
-  "carboniaiglesias.it",
-  "pa.it",
-  "agency",
-  "rns.tn",
-  "erotica.hu",
-  "fuel.aero",
-  "nakano.tokyo.jp",
-  "modern.museum",
-  "lib.wi.us",
-  "fishing",
-  "kashima.ibaraki.jp",
-  "kirovograd.ua",
-  "hokuto.hokkaido.jp",
-  "minobu.yamanashi.jp",
-  "norfolk.museum",
-  "rankoshi.hokkaido.jp",
-  "sky",
-  "\u5317\u6d77\u9053.jp",
-  "he.cn",
-  "furano.hokkaido.jp",
-  "ski",
-  "isahaya.nagasaki.jp",
-  "\u9577\u91ce.jp",
-  "kawakami.nara.jp",
-  "\u0628\u0627\u0632\u0627\u0631",
-  "lahppi.no",
-  "kahoku.ishikawa.jp",
-  "miami",
-  "minato.osaka.jp",
-  "vegarshei.no",
-  "wiih.gov.pl",
-  "trentino-a-adige.it",
-  "church",
-  "fl.us",
-  "acct.pro",
-  "naspers",
-  "k12.ec",
-  "kawajima.saitama.jp",
-  "so.it",
-  "izumo.shimane.jp",
-  "kawaminami.miyazaki.jp",
-  "\u0627\u0644\u062c\u0632\u0627\u0626\u0631",
-  "pri.ee",
-  "ra.it",
-  "gen.nz",
-  "hi.cn",
-  "stockholm",
-  "capitalone",
-  "godo.gifu.jp",
-  "kunneppu.hokkaido.jp",
-  "kyotanabe.kyoto.jp",
-  "friuliveneziagiulia.it",
-  "aridagawa.wakayama.jp",
-  "badaddja.no",
-  "gotsu.shimane.jp",
-  "trainer.aero",
-  "usantiques.museum",
-  "kanegasaki.iwate.jp",
-  "travelers",
-  "trento.it",
-  "kwpsp.gov.pl",
-  "jinsekikogen.hiroshima.jp",
-  "texas.museum",
-  "clinique",
-  "al.no",
-  "izena.okinawa.jp",
-  "aarborte.no",
-  "aarp",
-  "rec.nf",
-  "bologna.it",
-  "net.to",
-  "otari.nagano.jp",
-  "naie.hokkaido.jp",
-  "clinton.museum",
-  "gu.us",
-  "co.at",
-  "sakyo.kyoto.jp",
-  "royken.no",
-  "godaddy",
-  "co.ao",
-  "pesaro-urbino.it",
-  "fjell.no",
-  "washingtondc.museum",
-  "co.ag",
-  "co.ae",
-  "s\u00f8rum.no",
-  "yugawara.kanagawa.jp",
-  "org.bh",
-  "\u0627\u0644\u0627\u0631\u062f\u0646",
-  "hikari.yamaguchi.jp",
-  "tm.cy",
-  "bo.nordland.no",
-  "store.bb",
-  "theatre",
-  "kakamigahara.gifu.jp",
-  "mutual",
-  "toshima.tokyo.jp",
-  "cc.mo.us",
-  "\u53f0\u7063",
-  "book",
-  "kl\u00e6bu.no",
-  "aejrie.no",
-  "koka.shiga.jp",
-  "nikolaev.ua",
-  "notaires.fr",
-  "scientist.aero",
-  "conf.au",
-  "org.bw",
-  "topology.museum",
-  "cq.cn",
-  "kvanangen.no",
-  "org.bz",
-  "hinode.tokyo.jp",
-  "org.ba",
-  "org.bb",
-  "umaji.kochi.jp",
-  "org.bi",
-  "space",
-  "org.bm",
-  "shintomi.miyazaki.jp",
-  "org.bo",
-  "org.br",
-  "org.bs",
-  "org.bt",
-  "tanohata.iwate.jp",
-  "ofunato.iwate.jp",
-  "gildesk\u00e5l.no"
-]
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Please pull this list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,
+// rather than any other VCS sites. Pulling from any other URL is not guaranteed to be supported.
+
+// Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.
+
+// ===BEGIN ICANN DOMAINS===
+
+// ac : https://en.wikipedia.org/wiki/.ac
+ac
+com.ac
+edu.ac
+gov.ac
+net.ac
+mil.ac
+org.ac
+
+// ad : https://en.wikipedia.org/wiki/.ad
+ad
+nom.ad
+
+// ae : https://en.wikipedia.org/wiki/.ae
+// see also: "Domain Name Eligibility Policy" at http://www.aeda.ae/eng/aepolicy.php
+ae
+co.ae
+net.ae
+org.ae
+sch.ae
+ac.ae
+gov.ae
+mil.ae
+
+// aero : see https://www.information.aero/index.php?id=66
+aero
+accident-investigation.aero
+accident-prevention.aero
+aerobatic.aero
+aeroclub.aero
+aerodrome.aero
+agents.aero
+aircraft.aero
+airline.aero
+airport.aero
+air-surveillance.aero
+airtraffic.aero
+air-traffic-control.aero
+ambulance.aero
+amusement.aero
+association.aero
+author.aero
+ballooning.aero
+broker.aero
+caa.aero
+cargo.aero
+catering.aero
+certification.aero
+championship.aero
+charter.aero
+civilaviation.aero
+club.aero
+conference.aero
+consultant.aero
+consulting.aero
+control.aero
+council.aero
+crew.aero
+design.aero
+dgca.aero
+educator.aero
+emergency.aero
+engine.aero
+engineer.aero
+entertainment.aero
+equipment.aero
+exchange.aero
+express.aero
+federation.aero
+flight.aero
+fuel.aero
+gliding.aero
+government.aero
+groundhandling.aero
+group.aero
+hanggliding.aero
+homebuilt.aero
+insurance.aero
+journal.aero
+journalist.aero
+leasing.aero
+logistics.aero
+magazine.aero
+maintenance.aero
+media.aero
+microlight.aero
+modelling.aero
+navigation.aero
+parachuting.aero
+paragliding.aero
+passenger-association.aero
+pilot.aero
+press.aero
+production.aero
+recreation.aero
+repbody.aero
+res.aero
+research.aero
+rotorcraft.aero
+safety.aero
+scientist.aero
+services.aero
+show.aero
+skydiving.aero
+software.aero
+student.aero
+trader.aero
+trading.aero
+trainer.aero
+union.aero
+workinggroup.aero
+works.aero
+
+// af : http://www.nic.af/help.jsp
+af
+gov.af
+com.af
+org.af
+net.af
+edu.af
+
+// ag : http://www.nic.ag/prices.htm
+ag
+com.ag
+org.ag
+net.ag
+co.ag
+nom.ag
+
+// ai : http://nic.com.ai/
+ai
+off.ai
+com.ai
+net.ai
+org.ai
+
+// al : http://www.ert.gov.al/ert_alb/faq_det.html?Id=31
+al
+com.al
+edu.al
+gov.al
+mil.al
+net.al
+org.al
+
+// am : https://www.amnic.net/policy/en/Policy_EN.pdf
+am
+co.am
+com.am
+commune.am
+net.am
+org.am
+
+// ao : https://en.wikipedia.org/wiki/.ao
+// http://www.dns.ao/REGISTR.DOC
+ao
+ed.ao
+gv.ao
+og.ao
+co.ao
+pb.ao
+it.ao
+
+// aq : https://en.wikipedia.org/wiki/.aq
+aq
+
+// ar : https://nic.ar/nic-argentina/normativa-vigente
+ar
+com.ar
+edu.ar
+gob.ar
+gov.ar
+int.ar
+mil.ar
+musica.ar
+net.ar
+org.ar
+tur.ar
+
+// arpa : https://en.wikipedia.org/wiki/.arpa
+// Confirmed by registry <iana-questions@icann.org> 2008-06-18
+arpa
+e164.arpa
+in-addr.arpa
+ip6.arpa
+iris.arpa
+uri.arpa
+urn.arpa
+
+// as : https://en.wikipedia.org/wiki/.as
+as
+gov.as
+
+// asia : https://en.wikipedia.org/wiki/.asia
+asia
+
+// at : https://en.wikipedia.org/wiki/.at
+// Confirmed by registry <it@nic.at> 2008-06-17
+at
+ac.at
+co.at
+gv.at
+or.at
+sth.ac.at
+
+// au : https://en.wikipedia.org/wiki/.au
+// http://www.auda.org.au/
+au
+// 2LDs
+com.au
+net.au
+org.au
+edu.au
+gov.au
+asn.au
+id.au
+// Historic 2LDs (closed to new registration, but sites still exist)
+info.au
+conf.au
+oz.au
+// CGDNs - http://www.cgdn.org.au/
+act.au
+nsw.au
+nt.au
+qld.au
+sa.au
+tas.au
+vic.au
+wa.au
+// 3LDs
+act.edu.au
+catholic.edu.au
+// eq.edu.au - Removed at the request of the Queensland Department of Education
+nsw.edu.au
+nt.edu.au
+qld.edu.au
+sa.edu.au
+tas.edu.au
+vic.edu.au
+wa.edu.au
+// act.gov.au  Bug 984824 - Removed at request of Greg Tankard
+// nsw.gov.au  Bug 547985 - Removed at request of <Shae.Donelan@services.nsw.gov.au>
+// nt.gov.au  Bug 940478 - Removed at request of Greg Connors <Greg.Connors@nt.gov.au>
+qld.gov.au
+sa.gov.au
+tas.gov.au
+vic.gov.au
+wa.gov.au
+// 4LDs
+// education.tas.edu.au - Removed at the request of the Department of Education Tasmania
+schools.nsw.edu.au
+
+// aw : https://en.wikipedia.org/wiki/.aw
+aw
+com.aw
+
+// ax : https://en.wikipedia.org/wiki/.ax
+ax
+
+// az : https://en.wikipedia.org/wiki/.az
+az
+com.az
+net.az
+int.az
+gov.az
+org.az
+edu.az
+info.az
+pp.az
+mil.az
+name.az
+pro.az
+biz.az
+
+// ba : http://nic.ba/users_data/files/pravilnik_o_registraciji.pdf
+ba
+com.ba
+edu.ba
+gov.ba
+mil.ba
+net.ba
+org.ba
+
+// bb : https://en.wikipedia.org/wiki/.bb
+bb
+biz.bb
+co.bb
+com.bb
+edu.bb
+gov.bb
+info.bb
+net.bb
+org.bb
+store.bb
+tv.bb
+
+// bd : https://en.wikipedia.org/wiki/.bd
+*.bd
+
+// be : https://en.wikipedia.org/wiki/.be
+// Confirmed by registry <tech@dns.be> 2008-06-08
+be
+ac.be
+
+// bf : https://en.wikipedia.org/wiki/.bf
+bf
+gov.bf
+
+// bg : https://en.wikipedia.org/wiki/.bg
+// https://www.register.bg/user/static/rules/en/index.html
+bg
+a.bg
+b.bg
+c.bg
+d.bg
+e.bg
+f.bg
+g.bg
+h.bg
+i.bg
+j.bg
+k.bg
+l.bg
+m.bg
+n.bg
+o.bg
+p.bg
+q.bg
+r.bg
+s.bg
+t.bg
+u.bg
+v.bg
+w.bg
+x.bg
+y.bg
+z.bg
+0.bg
+1.bg
+2.bg
+3.bg
+4.bg
+5.bg
+6.bg
+7.bg
+8.bg
+9.bg
+
+// bh : https://en.wikipedia.org/wiki/.bh
+bh
+com.bh
+edu.bh
+net.bh
+org.bh
+gov.bh
+
+// bi : https://en.wikipedia.org/wiki/.bi
+// http://whois.nic.bi/
+bi
+co.bi
+com.bi
+edu.bi
+or.bi
+org.bi
+
+// biz : https://en.wikipedia.org/wiki/.biz
+biz
+
+// bj : https://en.wikipedia.org/wiki/.bj
+bj
+asso.bj
+barreau.bj
+gouv.bj
+
+// bm : http://www.bermudanic.bm/dnr-text.txt
+bm
+com.bm
+edu.bm
+gov.bm
+net.bm
+org.bm
+
+// bn : http://www.bnnic.bn/faqs
+bn
+com.bn
+edu.bn
+gov.bn
+net.bn
+org.bn
+
+// bo : https://nic.bo/delegacion2015.php#h-1.10
+bo
+com.bo
+edu.bo
+gob.bo
+int.bo
+org.bo
+net.bo
+mil.bo
+tv.bo
+web.bo
+// Social Domains
+academia.bo
+agro.bo
+arte.bo
+blog.bo
+bolivia.bo
+ciencia.bo
+cooperativa.bo
+democracia.bo
+deporte.bo
+ecologia.bo
+economia.bo
+empresa.bo
+indigena.bo
+industria.bo
+info.bo
+medicina.bo
+movimiento.bo
+musica.bo
+natural.bo
+nombre.bo
+noticias.bo
+patria.bo
+politica.bo
+profesional.bo
+plurinacional.bo
+pueblo.bo
+revista.bo
+salud.bo
+tecnologia.bo
+tksat.bo
+transporte.bo
+wiki.bo
+
+// br : http://registro.br/dominio/categoria.html
+// Submitted by registry <fneves@registro.br>
+br
+9guacu.br
+abc.br
+adm.br
+adv.br
+agr.br
+aju.br
+am.br
+anani.br
+aparecida.br
+app.br
+arq.br
+art.br
+ato.br
+b.br
+barueri.br
+belem.br
+bhz.br
+bib.br
+bio.br
+blog.br
+bmd.br
+boavista.br
+bsb.br
+campinagrande.br
+campinas.br
+caxias.br
+cim.br
+cng.br
+cnt.br
+com.br
+contagem.br
+coop.br
+coz.br
+cri.br
+cuiaba.br
+curitiba.br
+def.br
+des.br
+det.br
+dev.br
+ecn.br
+eco.br
+edu.br
+emp.br
+enf.br
+eng.br
+esp.br
+etc.br
+eti.br
+far.br
+feira.br
+flog.br
+floripa.br
+fm.br
+fnd.br
+fortal.br
+fot.br
+foz.br
+fst.br
+g12.br
+geo.br
+ggf.br
+goiania.br
+gov.br
+// gov.br 26 states + df https://en.wikipedia.org/wiki/States_of_Brazil
+ac.gov.br
+al.gov.br
+am.gov.br
+ap.gov.br
+ba.gov.br
+ce.gov.br
+df.gov.br
+es.gov.br
+go.gov.br
+ma.gov.br
+mg.gov.br
+ms.gov.br
+mt.gov.br
+pa.gov.br
+pb.gov.br
+pe.gov.br
+pi.gov.br
+pr.gov.br
+rj.gov.br
+rn.gov.br
+ro.gov.br
+rr.gov.br
+rs.gov.br
+sc.gov.br
+se.gov.br
+sp.gov.br
+to.gov.br
+gru.br
+imb.br
+ind.br
+inf.br
+jab.br
+jampa.br
+jdf.br
+joinville.br
+jor.br
+jus.br
+leg.br
+lel.br
+log.br
+londrina.br
+macapa.br
+maceio.br
+manaus.br
+maringa.br
+mat.br
+med.br
+mil.br
+morena.br
+mp.br
+mus.br
+natal.br
+net.br
+niteroi.br
+*.nom.br
+not.br
+ntr.br
+odo.br
+ong.br
+org.br
+osasco.br
+palmas.br
+poa.br
+ppg.br
+pro.br
+psc.br
+psi.br
+pvh.br
+qsl.br
+radio.br
+rec.br
+recife.br
+rep.br
+ribeirao.br
+rio.br
+riobranco.br
+riopreto.br
+salvador.br
+sampa.br
+santamaria.br
+santoandre.br
+saobernardo.br
+saogonca.br
+seg.br
+sjc.br
+slg.br
+slz.br
+sorocaba.br
+srv.br
+taxi.br
+tc.br
+tec.br
+teo.br
+the.br
+tmp.br
+trd.br
+tur.br
+tv.br
+udi.br
+vet.br
+vix.br
+vlog.br
+wiki.br
+zlg.br
+
+// bs : http://www.nic.bs/rules.html
+bs
+com.bs
+net.bs
+org.bs
+edu.bs
+gov.bs
+
+// bt : https://en.wikipedia.org/wiki/.bt
+bt
+com.bt
+edu.bt
+gov.bt
+net.bt
+org.bt
+
+// bv : No registrations at this time.
+// Submitted by registry <jarle@uninett.no>
+bv
+
+// bw : https://en.wikipedia.org/wiki/.bw
+// http://www.gobin.info/domainname/bw.doc
+// list of other 2nd level tlds ?
+bw
+co.bw
+org.bw
+
+// by : https://en.wikipedia.org/wiki/.by
+// http://tld.by/rules_2006_en.html
+// list of other 2nd level tlds ?
+by
+gov.by
+mil.by
+// Official information does not indicate that com.by is a reserved
+// second-level domain, but it's being used as one (see www.google.com.by and
+// www.yahoo.com.by, for example), so we list it here for safety's sake.
+com.by
+
+// http://hoster.by/
+of.by
+
+// bz : https://en.wikipedia.org/wiki/.bz
+// http://www.belizenic.bz/
+bz
+com.bz
+net.bz
+org.bz
+edu.bz
+gov.bz
+
+// ca : https://en.wikipedia.org/wiki/.ca
+ca
+// ca geographical names
+ab.ca
+bc.ca
+mb.ca
+nb.ca
+nf.ca
+nl.ca
+ns.ca
+nt.ca
+nu.ca
+on.ca
+pe.ca
+qc.ca
+sk.ca
+yk.ca
+// gc.ca: https://en.wikipedia.org/wiki/.gc.ca
+// see also: http://registry.gc.ca/en/SubdomainFAQ
+gc.ca
+
+// cat : https://en.wikipedia.org/wiki/.cat
+cat
+
+// cc : https://en.wikipedia.org/wiki/.cc
+cc
+
+// cd : https://en.wikipedia.org/wiki/.cd
+// see also: https://www.nic.cd/domain/insertDomain_2.jsp?act=1
+cd
+gov.cd
+
+// cf : https://en.wikipedia.org/wiki/.cf
+cf
+
+// cg : https://en.wikipedia.org/wiki/.cg
+cg
+
+// ch : https://en.wikipedia.org/wiki/.ch
+ch
+
+// ci : https://en.wikipedia.org/wiki/.ci
+// http://www.nic.ci/index.php?page=charte
+ci
+org.ci
+or.ci
+com.ci
+co.ci
+edu.ci
+ed.ci
+ac.ci
+net.ci
+go.ci
+asso.ci
+aéroport.ci
+int.ci
+presse.ci
+md.ci
+gouv.ci
+
+// ck : https://en.wikipedia.org/wiki/.ck
+*.ck
+!www.ck
+
+// cl : https://www.nic.cl
+// Confirmed by .CL registry <hsalgado@nic.cl>
+cl
+aprendemas.cl
+co.cl
+gob.cl
+gov.cl
+mil.cl
+
+// cm : https://en.wikipedia.org/wiki/.cm plus bug 981927
+cm
+co.cm
+com.cm
+gov.cm
+net.cm
+
+// cn : https://en.wikipedia.org/wiki/.cn
+// Submitted by registry <tanyaling@cnnic.cn>
+cn
+ac.cn
+com.cn
+edu.cn
+gov.cn
+net.cn
+org.cn
+mil.cn
+公司.cn
+网络.cn
+網絡.cn
+// cn geographic names
+ah.cn
+bj.cn
+cq.cn
+fj.cn
+gd.cn
+gs.cn
+gz.cn
+gx.cn
+ha.cn
+hb.cn
+he.cn
+hi.cn
+hl.cn
+hn.cn
+jl.cn
+js.cn
+jx.cn
+ln.cn
+nm.cn
+nx.cn
+qh.cn
+sc.cn
+sd.cn
+sh.cn
+sn.cn
+sx.cn
+tj.cn
+xj.cn
+xz.cn
+yn.cn
+zj.cn
+hk.cn
+mo.cn
+tw.cn
+
+// co : https://en.wikipedia.org/wiki/.co
+// Submitted by registry <tecnico@uniandes.edu.co>
+co
+arts.co
+com.co
+edu.co
+firm.co
+gov.co
+info.co
+int.co
+mil.co
+net.co
+nom.co
+org.co
+rec.co
+web.co
+
+// com : https://en.wikipedia.org/wiki/.com
+com
+
+// coop : https://en.wikipedia.org/wiki/.coop
+coop
+
+// cr : http://www.nic.cr/niccr_publico/showRegistroDominiosScreen.do
+cr
+ac.cr
+co.cr
+ed.cr
+fi.cr
+go.cr
+or.cr
+sa.cr
+
+// cu : https://en.wikipedia.org/wiki/.cu
+cu
+com.cu
+edu.cu
+org.cu
+net.cu
+gov.cu
+inf.cu
+
+// cv : https://en.wikipedia.org/wiki/.cv
+cv
+
+// cw : http://www.una.cw/cw_registry/
+// Confirmed by registry <registry@una.net> 2013-03-26
+cw
+com.cw
+edu.cw
+net.cw
+org.cw
+
+// cx : https://en.wikipedia.org/wiki/.cx
+// list of other 2nd level tlds ?
+cx
+gov.cx
+
+// cy : http://www.nic.cy/
+// Submitted by registry Panayiotou Fotia <cydns@ucy.ac.cy>
+cy
+ac.cy
+biz.cy
+com.cy
+ekloges.cy
+gov.cy
+ltd.cy
+name.cy
+net.cy
+org.cy
+parliament.cy
+press.cy
+pro.cy
+tm.cy
+
+// cz : https://en.wikipedia.org/wiki/.cz
+cz
+
+// de : https://en.wikipedia.org/wiki/.de
+// Confirmed by registry <ops@denic.de> (with technical
+// reservations) 2008-07-01
+de
+
+// dj : https://en.wikipedia.org/wiki/.dj
+dj
+
+// dk : https://en.wikipedia.org/wiki/.dk
+// Confirmed by registry <robert@dk-hostmaster.dk> 2008-06-17
+dk
+
+// dm : https://en.wikipedia.org/wiki/.dm
+dm
+com.dm
+net.dm
+org.dm
+edu.dm
+gov.dm
+
+// do : https://en.wikipedia.org/wiki/.do
+do
+art.do
+com.do
+edu.do
+gob.do
+gov.do
+mil.do
+net.do
+org.do
+sld.do
+web.do
+
+// dz : http://www.nic.dz/images/pdf_nic/charte.pdf
+dz
+art.dz
+asso.dz
+com.dz
+edu.dz
+gov.dz
+org.dz
+net.dz
+pol.dz
+soc.dz
+tm.dz
+
+// ec : http://www.nic.ec/reg/paso1.asp
+// Submitted by registry <vabboud@nic.ec>
+ec
+com.ec
+info.ec
+net.ec
+fin.ec
+k12.ec
+med.ec
+pro.ec
+org.ec
+edu.ec
+gov.ec
+gob.ec
+mil.ec
+
+// edu : https://en.wikipedia.org/wiki/.edu
+edu
+
+// ee : http://www.eenet.ee/EENet/dom_reeglid.html#lisa_B
+ee
+edu.ee
+gov.ee
+riik.ee
+lib.ee
+med.ee
+com.ee
+pri.ee
+aip.ee
+org.ee
+fie.ee
+
+// eg : https://en.wikipedia.org/wiki/.eg
+eg
+com.eg
+edu.eg
+eun.eg
+gov.eg
+mil.eg
+name.eg
+net.eg
+org.eg
+sci.eg
+
+// er : https://en.wikipedia.org/wiki/.er
+*.er
+
+// es : https://www.nic.es/site_ingles/ingles/dominios/index.html
+es
+com.es
+nom.es
+org.es
+gob.es
+edu.es
+
+// et : https://en.wikipedia.org/wiki/.et
+et
+com.et
+gov.et
+org.et
+edu.et
+biz.et
+name.et
+info.et
+net.et
+
+// eu : https://en.wikipedia.org/wiki/.eu
+eu
+
+// fi : https://en.wikipedia.org/wiki/.fi
+fi
+// aland.fi : https://en.wikipedia.org/wiki/.ax
+// This domain is being phased out in favor of .ax. As there are still many
+// domains under aland.fi, we still keep it on the list until aland.fi is
+// completely removed.
+// TODO: Check for updates (expected to be phased out around Q1/2009)
+aland.fi
+
+// fj : http://domains.fj/
+// Submitted by registry <garth.miller@cocca.org.nz> 2020-02-11
+fj
+ac.fj
+biz.fj
+com.fj
+gov.fj
+info.fj
+mil.fj
+name.fj
+net.fj
+org.fj
+pro.fj
+
+// fk : https://en.wikipedia.org/wiki/.fk
+*.fk
+
+// fm : https://en.wikipedia.org/wiki/.fm
+com.fm
+edu.fm
+net.fm
+org.fm
+fm
+
+// fo : https://en.wikipedia.org/wiki/.fo
+fo
+
+// fr : http://www.afnic.fr/
+// domaines descriptifs : https://www.afnic.fr/medias/documents/Cadre_legal/Afnic_Naming_Policy_12122016_VEN.pdf
+fr
+asso.fr
+com.fr
+gouv.fr
+nom.fr
+prd.fr
+tm.fr
+// domaines sectoriels : https://www.afnic.fr/en/products-and-services/the-fr-tld/sector-based-fr-domains-4.html
+aeroport.fr
+avocat.fr
+avoues.fr
+cci.fr
+chambagri.fr
+chirurgiens-dentistes.fr
+experts-comptables.fr
+geometre-expert.fr
+greta.fr
+huissier-justice.fr
+medecin.fr
+notaires.fr
+pharmacien.fr
+port.fr
+veterinaire.fr
+
+// ga : https://en.wikipedia.org/wiki/.ga
+ga
+
+// gb : This registry is effectively dormant
+// Submitted by registry <Damien.Shaw@ja.net>
+gb
+
+// gd : https://en.wikipedia.org/wiki/.gd
+edu.gd
+gov.gd
+gd
+
+// ge : http://www.nic.net.ge/policy_en.pdf
+ge
+com.ge
+edu.ge
+gov.ge
+org.ge
+mil.ge
+net.ge
+pvt.ge
+
+// gf : https://en.wikipedia.org/wiki/.gf
+gf
+
+// gg : http://www.channelisles.net/register-domains/
+// Confirmed by registry <nigel@channelisles.net> 2013-11-28
+gg
+co.gg
+net.gg
+org.gg
+
+// gh : https://en.wikipedia.org/wiki/.gh
+// see also: http://www.nic.gh/reg_now.php
+// Although domains directly at second level are not possible at the moment,
+// they have been possible for some time and may come back.
+gh
+com.gh
+edu.gh
+gov.gh
+org.gh
+mil.gh
+
+// gi : http://www.nic.gi/rules.html
+gi
+com.gi
+ltd.gi
+gov.gi
+mod.gi
+edu.gi
+org.gi
+
+// gl : https://en.wikipedia.org/wiki/.gl
+// http://nic.gl
+gl
+co.gl
+com.gl
+edu.gl
+net.gl
+org.gl
+
+// gm : http://www.nic.gm/htmlpages%5Cgm-policy.htm
+gm
+
+// gn : http://psg.com/dns/gn/gn.txt
+// Submitted by registry <randy@psg.com>
+gn
+ac.gn
+com.gn
+edu.gn
+gov.gn
+org.gn
+net.gn
+
+// gov : https://en.wikipedia.org/wiki/.gov
+gov
+
+// gp : http://www.nic.gp/index.php?lang=en
+gp
+com.gp
+net.gp
+mobi.gp
+edu.gp
+org.gp
+asso.gp
+
+// gq : https://en.wikipedia.org/wiki/.gq
+gq
+
+// gr : https://grweb.ics.forth.gr/english/1617-B-2005.html
+// Submitted by registry <segred@ics.forth.gr>
+gr
+com.gr
+edu.gr
+net.gr
+org.gr
+gov.gr
+
+// gs : https://en.wikipedia.org/wiki/.gs
+gs
+
+// gt : http://www.gt/politicas_de_registro.html
+gt
+com.gt
+edu.gt
+gob.gt
+ind.gt
+mil.gt
+net.gt
+org.gt
+
+// gu : http://gadao.gov.gu/register.html
+// University of Guam : https://www.uog.edu
+// Submitted by uognoc@triton.uog.edu
+gu
+com.gu
+edu.gu
+gov.gu
+guam.gu
+info.gu
+net.gu
+org.gu
+web.gu
+
+// gw : https://en.wikipedia.org/wiki/.gw
+gw
+
+// gy : https://en.wikipedia.org/wiki/.gy
+// http://registry.gy/
+gy
+co.gy
+com.gy
+edu.gy
+gov.gy
+net.gy
+org.gy
+
+// hk : https://www.hkirc.hk
+// Submitted by registry <hk.tech@hkirc.hk>
+hk
+com.hk
+edu.hk
+gov.hk
+idv.hk
+net.hk
+org.hk
+公司.hk
+教育.hk
+敎育.hk
+政府.hk
+個人.hk
+个人.hk
+箇人.hk
+網络.hk
+网络.hk
+组織.hk
+網絡.hk
+网絡.hk
+组织.hk
+組織.hk
+組织.hk
+
+// hm : https://en.wikipedia.org/wiki/.hm
+hm
+
+// hn : http://www.nic.hn/politicas/ps02,,05.html
+hn
+com.hn
+edu.hn
+org.hn
+net.hn
+mil.hn
+gob.hn
+
+// hr : http://www.dns.hr/documents/pdf/HRTLD-regulations.pdf
+hr
+iz.hr
+from.hr
+name.hr
+com.hr
+
+// ht : http://www.nic.ht/info/charte.cfm
+ht
+com.ht
+shop.ht
+firm.ht
+info.ht
+adult.ht
+net.ht
+pro.ht
+org.ht
+med.ht
+art.ht
+coop.ht
+pol.ht
+asso.ht
+edu.ht
+rel.ht
+gouv.ht
+perso.ht
+
+// hu : http://www.domain.hu/domain/English/sld.html
+// Confirmed by registry <pasztor@iszt.hu> 2008-06-12
+hu
+co.hu
+info.hu
+org.hu
+priv.hu
+sport.hu
+tm.hu
+2000.hu
+agrar.hu
+bolt.hu
+casino.hu
+city.hu
+erotica.hu
+erotika.hu
+film.hu
+forum.hu
+games.hu
+hotel.hu
+ingatlan.hu
+jogasz.hu
+konyvelo.hu
+lakas.hu
+media.hu
+news.hu
+reklam.hu
+sex.hu
+shop.hu
+suli.hu
+szex.hu
+tozsde.hu
+utazas.hu
+video.hu
+
+// id : https://pandi.id/en/domain/registration-requirements/
+id
+ac.id
+biz.id
+co.id
+desa.id
+go.id
+mil.id
+my.id
+net.id
+or.id
+ponpes.id
+sch.id
+web.id
+
+// ie : https://en.wikipedia.org/wiki/.ie
+ie
+gov.ie
+
+// il : http://www.isoc.org.il/domains/
+il
+ac.il
+co.il
+gov.il
+idf.il
+k12.il
+muni.il
+net.il
+org.il
+
+// im : https://www.nic.im/
+// Submitted by registry <info@nic.im>
+im
+ac.im
+co.im
+com.im
+ltd.co.im
+net.im
+org.im
+plc.co.im
+tt.im
+tv.im
+
+// in : https://en.wikipedia.org/wiki/.in
+// see also: https://registry.in/Policies
+// Please note, that nic.in is not an official eTLD, but used by most
+// government institutions.
+in
+co.in
+firm.in
+net.in
+org.in
+gen.in
+ind.in
+nic.in
+ac.in
+edu.in
+res.in
+gov.in
+mil.in
+
+// info : https://en.wikipedia.org/wiki/.info
+info
+
+// int : https://en.wikipedia.org/wiki/.int
+// Confirmed by registry <iana-questions@icann.org> 2008-06-18
+int
+eu.int
+
+// io : http://www.nic.io/rules.html
+// list of other 2nd level tlds ?
+io
+com.io
+
+// iq : http://www.cmc.iq/english/iq/iqregister1.htm
+iq
+gov.iq
+edu.iq
+mil.iq
+com.iq
+org.iq
+net.iq
+
+// ir : http://www.nic.ir/Terms_and_Conditions_ir,_Appendix_1_Domain_Rules
+// Also see http://www.nic.ir/Internationalized_Domain_Names
+// Two <iran>.ir entries added at request of <tech-team@nic.ir>, 2010-04-16
+ir
+ac.ir
+co.ir
+gov.ir
+id.ir
+net.ir
+org.ir
+sch.ir
+// xn--mgba3a4f16a.ir (<iran>.ir, Persian YEH)
+ایران.ir
+// xn--mgba3a4fra.ir (<iran>.ir, Arabic YEH)
+ايران.ir
+
+// is : http://www.isnic.is/domain/rules.php
+// Confirmed by registry <marius@isgate.is> 2008-12-06
+is
+net.is
+com.is
+edu.is
+gov.is
+org.is
+int.is
+
+// it : https://en.wikipedia.org/wiki/.it
+it
+gov.it
+edu.it
+// Reserved geo-names (regions and provinces):
+// https://www.nic.it/sites/default/files/archivio/docs/Regulation_assignation_v7.1.pdf
+// Regions
+abr.it
+abruzzo.it
+aosta-valley.it
+aostavalley.it
+bas.it
+basilicata.it
+cal.it
+calabria.it
+cam.it
+campania.it
+emilia-romagna.it
+emiliaromagna.it
+emr.it
+friuli-v-giulia.it
+friuli-ve-giulia.it
+friuli-vegiulia.it
+friuli-venezia-giulia.it
+friuli-veneziagiulia.it
+friuli-vgiulia.it
+friuliv-giulia.it
+friulive-giulia.it
+friulivegiulia.it
+friulivenezia-giulia.it
+friuliveneziagiulia.it
+friulivgiulia.it
+fvg.it
+laz.it
+lazio.it
+lig.it
+liguria.it
+lom.it
+lombardia.it
+lombardy.it
+lucania.it
+mar.it
+marche.it
+mol.it
+molise.it
+piedmont.it
+piemonte.it
+pmn.it
+pug.it
+puglia.it
+sar.it
+sardegna.it
+sardinia.it
+sic.it
+sicilia.it
+sicily.it
+taa.it
+tos.it
+toscana.it
+trentin-sud-tirol.it
+trentin-süd-tirol.it
+trentin-sudtirol.it
+trentin-südtirol.it
+trentin-sued-tirol.it
+trentin-suedtirol.it
+trentino-a-adige.it
+trentino-aadige.it
+trentino-alto-adige.it
+trentino-altoadige.it
+trentino-s-tirol.it
+trentino-stirol.it
+trentino-sud-tirol.it
+trentino-süd-tirol.it
+trentino-sudtirol.it
+trentino-südtirol.it
+trentino-sued-tirol.it
+trentino-suedtirol.it
+trentino.it
+trentinoa-adige.it
+trentinoaadige.it
+trentinoalto-adige.it
+trentinoaltoadige.it
+trentinos-tirol.it
+trentinostirol.it
+trentinosud-tirol.it
+trentinosüd-tirol.it
+trentinosudtirol.it
+trentinosüdtirol.it
+trentinosued-tirol.it
+trentinosuedtirol.it
+trentinsud-tirol.it
+trentinsüd-tirol.it
+trentinsudtirol.it
+trentinsüdtirol.it
+trentinsued-tirol.it
+trentinsuedtirol.it
+tuscany.it
+umb.it
+umbria.it
+val-d-aosta.it
+val-daosta.it
+vald-aosta.it
+valdaosta.it
+valle-aosta.it
+valle-d-aosta.it
+valle-daosta.it
+valleaosta.it
+valled-aosta.it
+valledaosta.it
+vallee-aoste.it
+vallée-aoste.it
+vallee-d-aoste.it
+vallée-d-aoste.it
+valleeaoste.it
+valléeaoste.it
+valleedaoste.it
+valléedaoste.it
+vao.it
+vda.it
+ven.it
+veneto.it
+// Provinces
+ag.it
+agrigento.it
+al.it
+alessandria.it
+alto-adige.it
+altoadige.it
+an.it
+ancona.it
+andria-barletta-trani.it
+andria-trani-barletta.it
+andriabarlettatrani.it
+andriatranibarletta.it
+ao.it
+aosta.it
+aoste.it
+ap.it
+aq.it
+aquila.it
+ar.it
+arezzo.it
+ascoli-piceno.it
+ascolipiceno.it
+asti.it
+at.it
+av.it
+avellino.it
+ba.it
+balsan-sudtirol.it
+balsan-südtirol.it
+balsan-suedtirol.it
+balsan.it
+bari.it
+barletta-trani-andria.it
+barlettatraniandria.it
+belluno.it
+benevento.it
+bergamo.it
+bg.it
+bi.it
+biella.it
+bl.it
+bn.it
+bo.it
+bologna.it
+bolzano-altoadige.it
+bolzano.it
+bozen-sudtirol.it
+bozen-südtirol.it
+bozen-suedtirol.it
+bozen.it
+br.it
+brescia.it
+brindisi.it
+bs.it
+bt.it
+bulsan-sudtirol.it
+bulsan-südtirol.it
+bulsan-suedtirol.it
+bulsan.it
+bz.it
+ca.it
+cagliari.it
+caltanissetta.it
+campidano-medio.it
+campidanomedio.it
+campobasso.it
+carbonia-iglesias.it
+carboniaiglesias.it
+carrara-massa.it
+carraramassa.it
+caserta.it
+catania.it
+catanzaro.it
+cb.it
+ce.it
+cesena-forli.it
+cesena-forlì.it
+cesenaforli.it
+cesenaforlì.it
+ch.it
+chieti.it
+ci.it
+cl.it
+cn.it
+co.it
+como.it
+cosenza.it
+cr.it
+cremona.it
+crotone.it
+cs.it
+ct.it
+cuneo.it
+cz.it
+dell-ogliastra.it
+dellogliastra.it
+en.it
+enna.it
+fc.it
+fe.it
+fermo.it
+ferrara.it
+fg.it
+fi.it
+firenze.it
+florence.it
+fm.it
+foggia.it
+forli-cesena.it
+forlì-cesena.it
+forlicesena.it
+forlìcesena.it
+fr.it
+frosinone.it
+ge.it
+genoa.it
+genova.it
+go.it
+gorizia.it
+gr.it
+grosseto.it
+iglesias-carbonia.it
+iglesiascarbonia.it
+im.it
+imperia.it
+is.it
+isernia.it
+kr.it
+la-spezia.it
+laquila.it
+laspezia.it
+latina.it
+lc.it
+le.it
+lecce.it
+lecco.it
+li.it
+livorno.it
+lo.it
+lodi.it
+lt.it
+lu.it
+lucca.it
+macerata.it
+mantova.it
+massa-carrara.it
+massacarrara.it
+matera.it
+mb.it
+mc.it
+me.it
+medio-campidano.it
+mediocampidano.it
+messina.it
+mi.it
+milan.it
+milano.it
+mn.it
+mo.it
+modena.it
+monza-brianza.it
+monza-e-della-brianza.it
+monza.it
+monzabrianza.it
+monzaebrianza.it
+monzaedellabrianza.it
+ms.it
+mt.it
+na.it
+naples.it
+napoli.it
+no.it
+novara.it
+nu.it
+nuoro.it
+og.it
+ogliastra.it
+olbia-tempio.it
+olbiatempio.it
+or.it
+oristano.it
+ot.it
+pa.it
+padova.it
+padua.it
+palermo.it
+parma.it
+pavia.it
+pc.it
+pd.it
+pe.it
+perugia.it
+pesaro-urbino.it
+pesarourbino.it
+pescara.it
+pg.it
+pi.it
+piacenza.it
+pisa.it
+pistoia.it
+pn.it
+po.it
+pordenone.it
+potenza.it
+pr.it
+prato.it
+pt.it
+pu.it
+pv.it
+pz.it
+ra.it
+ragusa.it
+ravenna.it
+rc.it
+re.it
+reggio-calabria.it
+reggio-emilia.it
+reggiocalabria.it
+reggioemilia.it
+rg.it
+ri.it
+rieti.it
+rimini.it
+rm.it
+rn.it
+ro.it
+roma.it
+rome.it
+rovigo.it
+sa.it
+salerno.it
+sassari.it
+savona.it
+si.it
+siena.it
+siracusa.it
+so.it
+sondrio.it
+sp.it
+sr.it
+ss.it
+suedtirol.it
+südtirol.it
+sv.it
+ta.it
+taranto.it
+te.it
+tempio-olbia.it
+tempioolbia.it
+teramo.it
+terni.it
+tn.it
+to.it
+torino.it
+tp.it
+tr.it
+trani-andria-barletta.it
+trani-barletta-andria.it
+traniandriabarletta.it
+tranibarlettaandria.it
+trapani.it
+trento.it
+treviso.it
+trieste.it
+ts.it
+turin.it
+tv.it
+ud.it
+udine.it
+urbino-pesaro.it
+urbinopesaro.it
+va.it
+varese.it
+vb.it
+vc.it
+ve.it
+venezia.it
+venice.it
+verbania.it
+vercelli.it
+verona.it
+vi.it
+vibo-valentia.it
+vibovalentia.it
+vicenza.it
+viterbo.it
+vr.it
+vs.it
+vt.it
+vv.it
+
+// je : http://www.channelisles.net/register-domains/
+// Confirmed by registry <nigel@channelisles.net> 2013-11-28
+je
+co.je
+net.je
+org.je
+
+// jm : http://www.com.jm/register.html
+*.jm
+
+// jo : http://www.dns.jo/Registration_policy.aspx
+jo
+com.jo
+org.jo
+net.jo
+edu.jo
+sch.jo
+gov.jo
+mil.jo
+name.jo
+
+// jobs : https://en.wikipedia.org/wiki/.jobs
+jobs
+
+// jp : https://en.wikipedia.org/wiki/.jp
+// http://jprs.co.jp/en/jpdomain.html
+// Submitted by registry <info@jprs.jp>
+jp
+// jp organizational type names
+ac.jp
+ad.jp
+co.jp
+ed.jp
+go.jp
+gr.jp
+lg.jp
+ne.jp
+or.jp
+// jp prefecture type names
+aichi.jp
+akita.jp
+aomori.jp
+chiba.jp
+ehime.jp
+fukui.jp
+fukuoka.jp
+fukushima.jp
+gifu.jp
+gunma.jp
+hiroshima.jp
+hokkaido.jp
+hyogo.jp
+ibaraki.jp
+ishikawa.jp
+iwate.jp
+kagawa.jp
+kagoshima.jp
+kanagawa.jp
+kochi.jp
+kumamoto.jp
+kyoto.jp
+mie.jp
+miyagi.jp
+miyazaki.jp
+nagano.jp
+nagasaki.jp
+nara.jp
+niigata.jp
+oita.jp
+okayama.jp
+okinawa.jp
+osaka.jp
+saga.jp
+saitama.jp
+shiga.jp
+shimane.jp
+shizuoka.jp
+tochigi.jp
+tokushima.jp
+tokyo.jp
+tottori.jp
+toyama.jp
+wakayama.jp
+yamagata.jp
+yamaguchi.jp
+yamanashi.jp
+栃木.jp
+愛知.jp
+愛媛.jp
+兵庫.jp
+熊本.jp
+茨城.jp
+北海道.jp
+千葉.jp
+和歌山.jp
+長崎.jp
+長野.jp
+新潟.jp
+青森.jp
+静岡.jp
+東京.jp
+石川.jp
+埼玉.jp
+三重.jp
+京都.jp
+佐賀.jp
+大分.jp
+大阪.jp
+奈良.jp
+宮城.jp
+宮崎.jp
+富山.jp
+山口.jp
+山形.jp
+山梨.jp
+岩手.jp
+岐阜.jp
+岡山.jp
+島根.jp
+広島.jp
+徳島.jp
+沖縄.jp
+滋賀.jp
+神奈川.jp
+福井.jp
+福岡.jp
+福島.jp
+秋田.jp
+群馬.jp
+香川.jp
+高知.jp
+鳥取.jp
+鹿児島.jp
+// jp geographic type names
+// http://jprs.jp/doc/rule/saisoku-1.html
+*.kawasaki.jp
+*.kitakyushu.jp
+*.kobe.jp
+*.nagoya.jp
+*.sapporo.jp
+*.sendai.jp
+*.yokohama.jp
+!city.kawasaki.jp
+!city.kitakyushu.jp
+!city.kobe.jp
+!city.nagoya.jp
+!city.sapporo.jp
+!city.sendai.jp
+!city.yokohama.jp
+// 4th level registration
+aisai.aichi.jp
+ama.aichi.jp
+anjo.aichi.jp
+asuke.aichi.jp
+chiryu.aichi.jp
+chita.aichi.jp
+fuso.aichi.jp
+gamagori.aichi.jp
+handa.aichi.jp
+hazu.aichi.jp
+hekinan.aichi.jp
+higashiura.aichi.jp
+ichinomiya.aichi.jp
+inazawa.aichi.jp
+inuyama.aichi.jp
+isshiki.aichi.jp
+iwakura.aichi.jp
+kanie.aichi.jp
+kariya.aichi.jp
+kasugai.aichi.jp
+kira.aichi.jp
+kiyosu.aichi.jp
+komaki.aichi.jp
+konan.aichi.jp
+kota.aichi.jp
+mihama.aichi.jp
+miyoshi.aichi.jp
+nishio.aichi.jp
+nisshin.aichi.jp
+obu.aichi.jp
+oguchi.aichi.jp
+oharu.aichi.jp
+okazaki.aichi.jp
+owariasahi.aichi.jp
+seto.aichi.jp
+shikatsu.aichi.jp
+shinshiro.aichi.jp
+shitara.aichi.jp
+tahara.aichi.jp
+takahama.aichi.jp
+tobishima.aichi.jp
+toei.aichi.jp
+togo.aichi.jp
+tokai.aichi.jp
+tokoname.aichi.jp
+toyoake.aichi.jp
+toyohashi.aichi.jp
+toyokawa.aichi.jp
+toyone.aichi.jp
+toyota.aichi.jp
+tsushima.aichi.jp
+yatomi.aichi.jp
+akita.akita.jp
+daisen.akita.jp
+fujisato.akita.jp
+gojome.akita.jp
+hachirogata.akita.jp
+happou.akita.jp
+higashinaruse.akita.jp
+honjo.akita.jp
+honjyo.akita.jp
+ikawa.akita.jp
+kamikoani.akita.jp
+kamioka.akita.jp
+katagami.akita.jp
+kazuno.akita.jp
+kitaakita.akita.jp
+kosaka.akita.jp
+kyowa.akita.jp
+misato.akita.jp
+mitane.akita.jp
+moriyoshi.akita.jp
+nikaho.akita.jp
+noshiro.akita.jp
+odate.akita.jp
+oga.akita.jp
+ogata.akita.jp
+semboku.akita.jp
+yokote.akita.jp
+yurihonjo.akita.jp
+aomori.aomori.jp
+gonohe.aomori.jp
+hachinohe.aomori.jp
+hashikami.aomori.jp
+hiranai.aomori.jp
+hirosaki.aomori.jp
+itayanagi.aomori.jp
+kuroishi.aomori.jp
+misawa.aomori.jp
+mutsu.aomori.jp
+nakadomari.aomori.jp
+noheji.aomori.jp
+oirase.aomori.jp
+owani.aomori.jp
+rokunohe.aomori.jp
+sannohe.aomori.jp
+shichinohe.aomori.jp
+shingo.aomori.jp
+takko.aomori.jp
+towada.aomori.jp
+tsugaru.aomori.jp
+tsuruta.aomori.jp
+abiko.chiba.jp
+asahi.chiba.jp
+chonan.chiba.jp
+chosei.chiba.jp
+choshi.chiba.jp
+chuo.chiba.jp
+funabashi.chiba.jp
+futtsu.chiba.jp
+hanamigawa.chiba.jp
+ichihara.chiba.jp
+ichikawa.chiba.jp
+ichinomiya.chiba.jp
+inzai.chiba.jp
+isumi.chiba.jp
+kamagaya.chiba.jp
+kamogawa.chiba.jp
+kashiwa.chiba.jp
+katori.chiba.jp
+katsuura.chiba.jp
+kimitsu.chiba.jp
+kisarazu.chiba.jp
+kozaki.chiba.jp
+kujukuri.chiba.jp
+kyonan.chiba.jp
+matsudo.chiba.jp
+midori.chiba.jp
+mihama.chiba.jp
+minamiboso.chiba.jp
+mobara.chiba.jp
+mutsuzawa.chiba.jp
+nagara.chiba.jp
+nagareyama.chiba.jp
+narashino.chiba.jp
+narita.chiba.jp
+noda.chiba.jp
+oamishirasato.chiba.jp
+omigawa.chiba.jp
+onjuku.chiba.jp
+otaki.chiba.jp
+sakae.chiba.jp
+sakura.chiba.jp
+shimofusa.chiba.jp
+shirako.chiba.jp
+shiroi.chiba.jp
+shisui.chiba.jp
+sodegaura.chiba.jp
+sosa.chiba.jp
+tako.chiba.jp
+tateyama.chiba.jp
+togane.chiba.jp
+tohnosho.chiba.jp
+tomisato.chiba.jp
+urayasu.chiba.jp
+yachimata.chiba.jp
+yachiyo.chiba.jp
+yokaichiba.chiba.jp
+yokoshibahikari.chiba.jp
+yotsukaido.chiba.jp
+ainan.ehime.jp
+honai.ehime.jp
+ikata.ehime.jp
+imabari.ehime.jp
+iyo.ehime.jp
+kamijima.ehime.jp
+kihoku.ehime.jp
+kumakogen.ehime.jp
+masaki.ehime.jp
+matsuno.ehime.jp
+matsuyama.ehime.jp
+namikata.ehime.jp
+niihama.ehime.jp
+ozu.ehime.jp
+saijo.ehime.jp
+seiyo.ehime.jp
+shikokuchuo.ehime.jp
+tobe.ehime.jp
+toon.ehime.jp
+uchiko.ehime.jp
+uwajima.ehime.jp
+yawatahama.ehime.jp
+echizen.fukui.jp
+eiheiji.fukui.jp
+fukui.fukui.jp
+ikeda.fukui.jp
+katsuyama.fukui.jp
+mihama.fukui.jp
+minamiechizen.fukui.jp
+obama.fukui.jp
+ohi.fukui.jp
+ono.fukui.jp
+sabae.fukui.jp
+sakai.fukui.jp
+takahama.fukui.jp
+tsuruga.fukui.jp
+wakasa.fukui.jp
+ashiya.fukuoka.jp
+buzen.fukuoka.jp
+chikugo.fukuoka.jp
+chikuho.fukuoka.jp
+chikujo.fukuoka.jp
+chikushino.fukuoka.jp
+chikuzen.fukuoka.jp
+chuo.fukuoka.jp
+dazaifu.fukuoka.jp
+fukuchi.fukuoka.jp
+hakata.fukuoka.jp
+higashi.fukuoka.jp
+hirokawa.fukuoka.jp
+hisayama.fukuoka.jp
+iizuka.fukuoka.jp
+inatsuki.fukuoka.jp
+kaho.fukuoka.jp
+kasuga.fukuoka.jp
+kasuya.fukuoka.jp
+kawara.fukuoka.jp
+keisen.fukuoka.jp
+koga.fukuoka.jp
+kurate.fukuoka.jp
+kurogi.fukuoka.jp
+kurume.fukuoka.jp
+minami.fukuoka.jp
+miyako.fukuoka.jp
+miyama.fukuoka.jp
+miyawaka.fukuoka.jp
+mizumaki.fukuoka.jp
+munakata.fukuoka.jp
+nakagawa.fukuoka.jp
+nakama.fukuoka.jp
+nishi.fukuoka.jp
+nogata.fukuoka.jp
+ogori.fukuoka.jp
+okagaki.fukuoka.jp
+okawa.fukuoka.jp
+oki.fukuoka.jp
+omuta.fukuoka.jp
+onga.fukuoka.jp
+onojo.fukuoka.jp
+oto.fukuoka.jp
+saigawa.fukuoka.jp
+sasaguri.fukuoka.jp
+shingu.fukuoka.jp
+shinyoshitomi.fukuoka.jp
+shonai.fukuoka.jp
+soeda.fukuoka.jp
+sue.fukuoka.jp
+tachiarai.fukuoka.jp
+tagawa.fukuoka.jp
+takata.fukuoka.jp
+toho.fukuoka.jp
+toyotsu.fukuoka.jp
+tsuiki.fukuoka.jp
+ukiha.fukuoka.jp
+umi.fukuoka.jp
+usui.fukuoka.jp
+yamada.fukuoka.jp
+yame.fukuoka.jp
+yanagawa.fukuoka.jp
+yukuhashi.fukuoka.jp
+aizubange.fukushima.jp
+aizumisato.fukushima.jp
+aizuwakamatsu.fukushima.jp
+asakawa.fukushima.jp
+bandai.fukushima.jp
+date.fukushima.jp
+fukushima.fukushima.jp
+furudono.fukushima.jp
+futaba.fukushima.jp
+hanawa.fukushima.jp
+higashi.fukushima.jp
+hirata.fukushima.jp
+hirono.fukushima.jp
+iitate.fukushima.jp
+inawashiro.fukushima.jp
+ishikawa.fukushima.jp
+iwaki.fukushima.jp
+izumizaki.fukushima.jp
+kagamiishi.fukushima.jp
+kaneyama.fukushima.jp
+kawamata.fukushima.jp
+kitakata.fukushima.jp
+kitashiobara.fukushima.jp
+koori.fukushima.jp
+koriyama.fukushima.jp
+kunimi.fukushima.jp
+miharu.fukushima.jp
+mishima.fukushima.jp
+namie.fukushima.jp
+nango.fukushima.jp
+nishiaizu.fukushima.jp
+nishigo.fukushima.jp
+okuma.fukushima.jp
+omotego.fukushima.jp
+ono.fukushima.jp
+otama.fukushima.jp
+samegawa.fukushima.jp
+shimogo.fukushima.jp
+shirakawa.fukushima.jp
+showa.fukushima.jp
+soma.fukushima.jp
+sukagawa.fukushima.jp
+taishin.fukushima.jp
+tamakawa.fukushima.jp
+tanagura.fukushima.jp
+tenei.fukushima.jp
+yabuki.fukushima.jp
+yamato.fukushima.jp
+yamatsuri.fukushima.jp
+yanaizu.fukushima.jp
+yugawa.fukushima.jp
+anpachi.gifu.jp
+ena.gifu.jp
+gifu.gifu.jp
+ginan.gifu.jp
+godo.gifu.jp
+gujo.gifu.jp
+hashima.gifu.jp
+hichiso.gifu.jp
+hida.gifu.jp
+higashishirakawa.gifu.jp
+ibigawa.gifu.jp
+ikeda.gifu.jp
+kakamigahara.gifu.jp
+kani.gifu.jp
+kasahara.gifu.jp
+kasamatsu.gifu.jp
+kawaue.gifu.jp
+kitagata.gifu.jp
+mino.gifu.jp
+minokamo.gifu.jp
+mitake.gifu.jp
+mizunami.gifu.jp
+motosu.gifu.jp
+nakatsugawa.gifu.jp
+ogaki.gifu.jp
+sakahogi.gifu.jp
+seki.gifu.jp
+sekigahara.gifu.jp
+shirakawa.gifu.jp
+tajimi.gifu.jp
+takayama.gifu.jp
+tarui.gifu.jp
+toki.gifu.jp
+tomika.gifu.jp
+wanouchi.gifu.jp
+yamagata.gifu.jp
+yaotsu.gifu.jp
+yoro.gifu.jp
+annaka.gunma.jp
+chiyoda.gunma.jp
+fujioka.gunma.jp
+higashiagatsuma.gunma.jp
+isesaki.gunma.jp
+itakura.gunma.jp
+kanna.gunma.jp
+kanra.gunma.jp
+katashina.gunma.jp
+kawaba.gunma.jp
+kiryu.gunma.jp
+kusatsu.gunma.jp
+maebashi.gunma.jp
+meiwa.gunma.jp
+midori.gunma.jp
+minakami.gunma.jp
+naganohara.gunma.jp
+nakanojo.gunma.jp
+nanmoku.gunma.jp
+numata.gunma.jp
+oizumi.gunma.jp
+ora.gunma.jp
+ota.gunma.jp
+shibukawa.gunma.jp
+shimonita.gunma.jp
+shinto.gunma.jp
+showa.gunma.jp
+takasaki.gunma.jp
+takayama.gunma.jp
+tamamura.gunma.jp
+tatebayashi.gunma.jp
+tomioka.gunma.jp
+tsukiyono.gunma.jp
+tsumagoi.gunma.jp
+ueno.gunma.jp
+yoshioka.gunma.jp
+asaminami.hiroshima.jp
+daiwa.hiroshima.jp
+etajima.hiroshima.jp
+fuchu.hiroshima.jp
+fukuyama.hiroshima.jp
+hatsukaichi.hiroshima.jp
+higashihiroshima.hiroshima.jp
+hongo.hiroshima.jp
+jinsekikogen.hiroshima.jp
+kaita.hiroshima.jp
+kui.hiroshima.jp
+kumano.hiroshima.jp
+kure.hiroshima.jp
+mihara.hiroshima.jp
+miyoshi.hiroshima.jp
+naka.hiroshima.jp
+onomichi.hiroshima.jp
+osakikamijima.hiroshima.jp
+otake.hiroshima.jp
+saka.hiroshima.jp
+sera.hiroshima.jp
+seranishi.hiroshima.jp
+shinichi.hiroshima.jp
+shobara.hiroshima.jp
+takehara.hiroshima.jp
+abashiri.hokkaido.jp
+abira.hokkaido.jp
+aibetsu.hokkaido.jp
+akabira.hokkaido.jp
+akkeshi.hokkaido.jp
+asahikawa.hokkaido.jp
+ashibetsu.hokkaido.jp
+ashoro.hokkaido.jp
+assabu.hokkaido.jp
+atsuma.hokkaido.jp
+bibai.hokkaido.jp
+biei.hokkaido.jp
+bifuka.hokkaido.jp
+bihoro.hokkaido.jp
+biratori.hokkaido.jp
+chippubetsu.hokkaido.jp
+chitose.hokkaido.jp
+date.hokkaido.jp
+ebetsu.hokkaido.jp
+embetsu.hokkaido.jp
+eniwa.hokkaido.jp
+erimo.hokkaido.jp
+esan.hokkaido.jp
+esashi.hokkaido.jp
+fukagawa.hokkaido.jp
+fukushima.hokkaido.jp
+furano.hokkaido.jp
+furubira.hokkaido.jp
+haboro.hokkaido.jp
+hakodate.hokkaido.jp
+hamatonbetsu.hokkaido.jp
+hidaka.hokkaido.jp
+higashikagura.hokkaido.jp
+higashikawa.hokkaido.jp
+hiroo.hokkaido.jp
+hokuryu.hokkaido.jp
+hokuto.hokkaido.jp
+honbetsu.hokkaido.jp
+horokanai.hokkaido.jp
+horonobe.hokkaido.jp
+ikeda.hokkaido.jp
+imakane.hokkaido.jp
+ishikari.hokkaido.jp
+iwamizawa.hokkaido.jp
+iwanai.hokkaido.jp
+kamifurano.hokkaido.jp
+kamikawa.hokkaido.jp
+kamishihoro.hokkaido.jp
+kamisunagawa.hokkaido.jp
+kamoenai.hokkaido.jp
+kayabe.hokkaido.jp
+kembuchi.hokkaido.jp
+kikonai.hokkaido.jp
+kimobetsu.hokkaido.jp
+kitahiroshima.hokkaido.jp
+kitami.hokkaido.jp
+kiyosato.hokkaido.jp
+koshimizu.hokkaido.jp
+kunneppu.hokkaido.jp
+kuriyama.hokkaido.jp
+kuromatsunai.hokkaido.jp
+kushiro.hokkaido.jp
+kutchan.hokkaido.jp
+kyowa.hokkaido.jp
+mashike.hokkaido.jp
+matsumae.hokkaido.jp
+mikasa.hokkaido.jp
+minamifurano.hokkaido.jp
+mombetsu.hokkaido.jp
+moseushi.hokkaido.jp
+mukawa.hokkaido.jp
+muroran.hokkaido.jp
+naie.hokkaido.jp
+nakagawa.hokkaido.jp
+nakasatsunai.hokkaido.jp
+nakatombetsu.hokkaido.jp
+nanae.hokkaido.jp
+nanporo.hokkaido.jp
+nayoro.hokkaido.jp
+nemuro.hokkaido.jp
+niikappu.hokkaido.jp
+niki.hokkaido.jp
+nishiokoppe.hokkaido.jp
+noboribetsu.hokkaido.jp
+numata.hokkaido.jp
+obihiro.hokkaido.jp
+obira.hokkaido.jp
+oketo.hokkaido.jp
+okoppe.hokkaido.jp
+otaru.hokkaido.jp
+otobe.hokkaido.jp
+otofuke.hokkaido.jp
+otoineppu.hokkaido.jp
+oumu.hokkaido.jp
+ozora.hokkaido.jp
+pippu.hokkaido.jp
+rankoshi.hokkaido.jp
+rebun.hokkaido.jp
+rikubetsu.hokkaido.jp
+rishiri.hokkaido.jp
+rishirifuji.hokkaido.jp
+saroma.hokkaido.jp
+sarufutsu.hokkaido.jp
+shakotan.hokkaido.jp
+shari.hokkaido.jp
+shibecha.hokkaido.jp
+shibetsu.hokkaido.jp
+shikabe.hokkaido.jp
+shikaoi.hokkaido.jp
+shimamaki.hokkaido.jp
+shimizu.hokkaido.jp
+shimokawa.hokkaido.jp
+shinshinotsu.hokkaido.jp
+shintoku.hokkaido.jp
+shiranuka.hokkaido.jp
+shiraoi.hokkaido.jp
+shiriuchi.hokkaido.jp
+sobetsu.hokkaido.jp
+sunagawa.hokkaido.jp
+taiki.hokkaido.jp
+takasu.hokkaido.jp
+takikawa.hokkaido.jp
+takinoue.hokkaido.jp
+teshikaga.hokkaido.jp
+tobetsu.hokkaido.jp
+tohma.hokkaido.jp
+tomakomai.hokkaido.jp
+tomari.hokkaido.jp
+toya.hokkaido.jp
+toyako.hokkaido.jp
+toyotomi.hokkaido.jp
+toyoura.hokkaido.jp
+tsubetsu.hokkaido.jp
+tsukigata.hokkaido.jp
+urakawa.hokkaido.jp
+urausu.hokkaido.jp
+uryu.hokkaido.jp
+utashinai.hokkaido.jp
+wakkanai.hokkaido.jp
+wassamu.hokkaido.jp
+yakumo.hokkaido.jp
+yoichi.hokkaido.jp
+aioi.hyogo.jp
+akashi.hyogo.jp
+ako.hyogo.jp
+amagasaki.hyogo.jp
+aogaki.hyogo.jp
+asago.hyogo.jp
+ashiya.hyogo.jp
+awaji.hyogo.jp
+fukusaki.hyogo.jp
+goshiki.hyogo.jp
+harima.hyogo.jp
+himeji.hyogo.jp
+ichikawa.hyogo.jp
+inagawa.hyogo.jp
+itami.hyogo.jp
+kakogawa.hyogo.jp
+kamigori.hyogo.jp
+kamikawa.hyogo.jp
+kasai.hyogo.jp
+kasuga.hyogo.jp
+kawanishi.hyogo.jp
+miki.hyogo.jp
+minamiawaji.hyogo.jp
+nishinomiya.hyogo.jp
+nishiwaki.hyogo.jp
+ono.hyogo.jp
+sanda.hyogo.jp
+sannan.hyogo.jp
+sasayama.hyogo.jp
+sayo.hyogo.jp
+shingu.hyogo.jp
+shinonsen.hyogo.jp
+shiso.hyogo.jp
+sumoto.hyogo.jp
+taishi.hyogo.jp
+taka.hyogo.jp
+takarazuka.hyogo.jp
+takasago.hyogo.jp
+takino.hyogo.jp
+tamba.hyogo.jp
+tatsuno.hyogo.jp
+toyooka.hyogo.jp
+yabu.hyogo.jp
+yashiro.hyogo.jp
+yoka.hyogo.jp
+yokawa.hyogo.jp
+ami.ibaraki.jp
+asahi.ibaraki.jp
+bando.ibaraki.jp
+chikusei.ibaraki.jp
+daigo.ibaraki.jp
+fujishiro.ibaraki.jp
+hitachi.ibaraki.jp
+hitachinaka.ibaraki.jp
+hitachiomiya.ibaraki.jp
+hitachiota.ibaraki.jp
+ibaraki.ibaraki.jp
+ina.ibaraki.jp
+inashiki.ibaraki.jp
+itako.ibaraki.jp
+iwama.ibaraki.jp
+joso.ibaraki.jp
+kamisu.ibaraki.jp
+kasama.ibaraki.jp
+kashima.ibaraki.jp
+kasumigaura.ibaraki.jp
+koga.ibaraki.jp
+miho.ibaraki.jp
+mito.ibaraki.jp
+moriya.ibaraki.jp
+naka.ibaraki.jp
+namegata.ibaraki.jp
+oarai.ibaraki.jp
+ogawa.ibaraki.jp
+omitama.ibaraki.jp
+ryugasaki.ibaraki.jp
+sakai.ibaraki.jp
+sakuragawa.ibaraki.jp
+shimodate.ibaraki.jp
+shimotsuma.ibaraki.jp
+shirosato.ibaraki.jp
+sowa.ibaraki.jp
+suifu.ibaraki.jp
+takahagi.ibaraki.jp
+tamatsukuri.ibaraki.jp
+tokai.ibaraki.jp
+tomobe.ibaraki.jp
+tone.ibaraki.jp
+toride.ibaraki.jp
+tsuchiura.ibaraki.jp
+tsukuba.ibaraki.jp
+uchihara.ibaraki.jp
+ushiku.ibaraki.jp
+yachiyo.ibaraki.jp
+yamagata.ibaraki.jp
+yawara.ibaraki.jp
+yuki.ibaraki.jp
+anamizu.ishikawa.jp
+hakui.ishikawa.jp
+hakusan.ishikawa.jp
+kaga.ishikawa.jp
+kahoku.ishikawa.jp
+kanazawa.ishikawa.jp
+kawakita.ishikawa.jp
+komatsu.ishikawa.jp
+nakanoto.ishikawa.jp
+nanao.ishikawa.jp
+nomi.ishikawa.jp
+nonoichi.ishikawa.jp
+noto.ishikawa.jp
+shika.ishikawa.jp
+suzu.ishikawa.jp
+tsubata.ishikawa.jp
+tsurugi.ishikawa.jp
+uchinada.ishikawa.jp
+wajima.ishikawa.jp
+fudai.iwate.jp
+fujisawa.iwate.jp
+hanamaki.iwate.jp
+hiraizumi.iwate.jp
+hirono.iwate.jp
+ichinohe.iwate.jp
+ichinoseki.iwate.jp
+iwaizumi.iwate.jp
+iwate.iwate.jp
+joboji.iwate.jp
+kamaishi.iwate.jp
+kanegasaki.iwate.jp
+karumai.iwate.jp
+kawai.iwate.jp
+kitakami.iwate.jp
+kuji.iwate.jp
+kunohe.iwate.jp
+kuzumaki.iwate.jp
+miyako.iwate.jp
+mizusawa.iwate.jp
+morioka.iwate.jp
+ninohe.iwate.jp
+noda.iwate.jp
+ofunato.iwate.jp
+oshu.iwate.jp
+otsuchi.iwate.jp
+rikuzentakata.iwate.jp
+shiwa.iwate.jp
+shizukuishi.iwate.jp
+sumita.iwate.jp
+tanohata.iwate.jp
+tono.iwate.jp
+yahaba.iwate.jp
+yamada.iwate.jp
+ayagawa.kagawa.jp
+higashikagawa.kagawa.jp
+kanonji.kagawa.jp
+kotohira.kagawa.jp
+manno.kagawa.jp
+marugame.kagawa.jp
+mitoyo.kagawa.jp
+naoshima.kagawa.jp
+sanuki.kagawa.jp
+tadotsu.kagawa.jp
+takamatsu.kagawa.jp
+tonosho.kagawa.jp
+uchinomi.kagawa.jp
+utazu.kagawa.jp
+zentsuji.kagawa.jp
+akune.kagoshima.jp
+amami.kagoshima.jp
+hioki.kagoshima.jp
+isa.kagoshima.jp
+isen.kagoshima.jp
+izumi.kagoshima.jp
+kagoshima.kagoshima.jp
+kanoya.kagoshima.jp
+kawanabe.kagoshima.jp
+kinko.kagoshima.jp
+kouyama.kagoshima.jp
+makurazaki.kagoshima.jp
+matsumoto.kagoshima.jp
+minamitane.kagoshima.jp
+nakatane.kagoshima.jp
+nishinoomote.kagoshima.jp
+satsumasendai.kagoshima.jp
+soo.kagoshima.jp
+tarumizu.kagoshima.jp
+yusui.kagoshima.jp
+aikawa.kanagawa.jp
+atsugi.kanagawa.jp
+ayase.kanagawa.jp
+chigasaki.kanagawa.jp
+ebina.kanagawa.jp
+fujisawa.kanagawa.jp
+hadano.kanagawa.jp
+hakone.kanagawa.jp
+hiratsuka.kanagawa.jp
+isehara.kanagawa.jp
+kaisei.kanagawa.jp
+kamakura.kanagawa.jp
+kiyokawa.kanagawa.jp
+matsuda.kanagawa.jp
+minamiashigara.kanagawa.jp
+miura.kanagawa.jp
+nakai.kanagawa.jp
+ninomiya.kanagawa.jp
+odawara.kanagawa.jp
+oi.kanagawa.jp
+oiso.kanagawa.jp
+sagamihara.kanagawa.jp
+samukawa.kanagawa.jp
+tsukui.kanagawa.jp
+yamakita.kanagawa.jp
+yamato.kanagawa.jp
+yokosuka.kanagawa.jp
+yugawara.kanagawa.jp
+zama.kanagawa.jp
+zushi.kanagawa.jp
+aki.kochi.jp
+geisei.kochi.jp
+hidaka.kochi.jp
+higashitsuno.kochi.jp
+ino.kochi.jp
+kagami.kochi.jp
+kami.kochi.jp
+kitagawa.kochi.jp
+kochi.kochi.jp
+mihara.kochi.jp
+motoyama.kochi.jp
+muroto.kochi.jp
+nahari.kochi.jp
+nakamura.kochi.jp
+nankoku.kochi.jp
+nishitosa.kochi.jp
+niyodogawa.kochi.jp
+ochi.kochi.jp
+okawa.kochi.jp
+otoyo.kochi.jp
+otsuki.kochi.jp
+sakawa.kochi.jp
+sukumo.kochi.jp
+susaki.kochi.jp
+tosa.kochi.jp
+tosashimizu.kochi.jp
+toyo.kochi.jp
+tsuno.kochi.jp
+umaji.kochi.jp
+yasuda.kochi.jp
+yusuhara.kochi.jp
+amakusa.kumamoto.jp
+arao.kumamoto.jp
+aso.kumamoto.jp
+choyo.kumamoto.jp
+gyokuto.kumamoto.jp
+kamiamakusa.kumamoto.jp
+kikuchi.kumamoto.jp
+kumamoto.kumamoto.jp
+mashiki.kumamoto.jp
+mifune.kumamoto.jp
+minamata.kumamoto.jp
+minamioguni.kumamoto.jp
+nagasu.kumamoto.jp
+nishihara.kumamoto.jp
+oguni.kumamoto.jp
+ozu.kumamoto.jp
+sumoto.kumamoto.jp
+takamori.kumamoto.jp
+uki.kumamoto.jp
+uto.kumamoto.jp
+yamaga.kumamoto.jp
+yamato.kumamoto.jp
+yatsushiro.kumamoto.jp
+ayabe.kyoto.jp
+fukuchiyama.kyoto.jp
+higashiyama.kyoto.jp
+ide.kyoto.jp
+ine.kyoto.jp
+joyo.kyoto.jp
+kameoka.kyoto.jp
+kamo.kyoto.jp
+kita.kyoto.jp
+kizu.kyoto.jp
+kumiyama.kyoto.jp
+kyotamba.kyoto.jp
+kyotanabe.kyoto.jp
+kyotango.kyoto.jp
+maizuru.kyoto.jp
+minami.kyoto.jp
+minamiyamashiro.kyoto.jp
+miyazu.kyoto.jp
+muko.kyoto.jp
+nagaokakyo.kyoto.jp
+nakagyo.kyoto.jp
+nantan.kyoto.jp
+oyamazaki.kyoto.jp
+sakyo.kyoto.jp
+seika.kyoto.jp
+tanabe.kyoto.jp
+uji.kyoto.jp
+ujitawara.kyoto.jp
+wazuka.kyoto.jp
+yamashina.kyoto.jp
+yawata.kyoto.jp
+asahi.mie.jp
+inabe.mie.jp
+ise.mie.jp
+kameyama.mie.jp
+kawagoe.mie.jp
+kiho.mie.jp
+kisosaki.mie.jp
+kiwa.mie.jp
+komono.mie.jp
+kumano.mie.jp
+kuwana.mie.jp
+matsusaka.mie.jp
+meiwa.mie.jp
+mihama.mie.jp
+minamiise.mie.jp
+misugi.mie.jp
+miyama.mie.jp
+nabari.mie.jp
+shima.mie.jp
+suzuka.mie.jp
+tado.mie.jp
+taiki.mie.jp
+taki.mie.jp
+tamaki.mie.jp
+toba.mie.jp
+tsu.mie.jp
+udono.mie.jp
+ureshino.mie.jp
+watarai.mie.jp
+yokkaichi.mie.jp
+furukawa.miyagi.jp
+higashimatsushima.miyagi.jp
+ishinomaki.miyagi.jp
+iwanuma.miyagi.jp
+kakuda.miyagi.jp
+kami.miyagi.jp
+kawasaki.miyagi.jp
+marumori.miyagi.jp
+matsushima.miyagi.jp
+minamisanriku.miyagi.jp
+misato.miyagi.jp
+murata.miyagi.jp
+natori.miyagi.jp
+ogawara.miyagi.jp
+ohira.miyagi.jp
+onagawa.miyagi.jp
+osaki.miyagi.jp
+rifu.miyagi.jp
+semine.miyagi.jp
+shibata.miyagi.jp
+shichikashuku.miyagi.jp
+shikama.miyagi.jp
+shiogama.miyagi.jp
+shiroishi.miyagi.jp
+tagajo.miyagi.jp
+taiwa.miyagi.jp
+tome.miyagi.jp
+tomiya.miyagi.jp
+wakuya.miyagi.jp
+watari.miyagi.jp
+yamamoto.miyagi.jp
+zao.miyagi.jp
+aya.miyazaki.jp
+ebino.miyazaki.jp
+gokase.miyazaki.jp
+hyuga.miyazaki.jp
+kadogawa.miyazaki.jp
+kawaminami.miyazaki.jp
+kijo.miyazaki.jp
+kitagawa.miyazaki.jp
+kitakata.miyazaki.jp
+kitaura.miyazaki.jp
+kobayashi.miyazaki.jp
+kunitomi.miyazaki.jp
+kushima.miyazaki.jp
+mimata.miyazaki.jp
+miyakonojo.miyazaki.jp
+miyazaki.miyazaki.jp
+morotsuka.miyazaki.jp
+nichinan.miyazaki.jp
+nishimera.miyazaki.jp
+nobeoka.miyazaki.jp
+saito.miyazaki.jp
+shiiba.miyazaki.jp
+shintomi.miyazaki.jp
+takaharu.miyazaki.jp
+takanabe.miyazaki.jp
+takazaki.miyazaki.jp
+tsuno.miyazaki.jp
+achi.nagano.jp
+agematsu.nagano.jp
+anan.nagano.jp
+aoki.nagano.jp
+asahi.nagano.jp
+azumino.nagano.jp
+chikuhoku.nagano.jp
+chikuma.nagano.jp
+chino.nagano.jp
+fujimi.nagano.jp
+hakuba.nagano.jp
+hara.nagano.jp
+hiraya.nagano.jp
+iida.nagano.jp
+iijima.nagano.jp
+iiyama.nagano.jp
+iizuna.nagano.jp
+ikeda.nagano.jp
+ikusaka.nagano.jp
+ina.nagano.jp
+karuizawa.nagano.jp
+kawakami.nagano.jp
+kiso.nagano.jp
+kisofukushima.nagano.jp
+kitaaiki.nagano.jp
+komagane.nagano.jp
+komoro.nagano.jp
+matsukawa.nagano.jp
+matsumoto.nagano.jp
+miasa.nagano.jp
+minamiaiki.nagano.jp
+minamimaki.nagano.jp
+minamiminowa.nagano.jp
+minowa.nagano.jp
+miyada.nagano.jp
+miyota.nagano.jp
+mochizuki.nagano.jp
+nagano.nagano.jp
+nagawa.nagano.jp
+nagiso.nagano.jp
+nakagawa.nagano.jp
+nakano.nagano.jp
+nozawaonsen.nagano.jp
+obuse.nagano.jp
+ogawa.nagano.jp
+okaya.nagano.jp
+omachi.nagano.jp
+omi.nagano.jp
+ookuwa.nagano.jp
+ooshika.nagano.jp
+otaki.nagano.jp
+otari.nagano.jp
+sakae.nagano.jp
+sakaki.nagano.jp
+saku.nagano.jp
+sakuho.nagano.jp
+shimosuwa.nagano.jp
+shinanomachi.nagano.jp
+shiojiri.nagano.jp
+suwa.nagano.jp
+suzaka.nagano.jp
+takagi.nagano.jp
+takamori.nagano.jp
+takayama.nagano.jp
+tateshina.nagano.jp
+tatsuno.nagano.jp
+togakushi.nagano.jp
+togura.nagano.jp
+tomi.nagano.jp
+ueda.nagano.jp
+wada.nagano.jp
+yamagata.nagano.jp
+yamanouchi.nagano.jp
+yasaka.nagano.jp
+yasuoka.nagano.jp
+chijiwa.nagasaki.jp
+futsu.nagasaki.jp
+goto.nagasaki.jp
+hasami.nagasaki.jp
+hirado.nagasaki.jp
+iki.nagasaki.jp
+isahaya.nagasaki.jp
+kawatana.nagasaki.jp
+kuchinotsu.nagasaki.jp
+matsuura.nagasaki.jp
+nagasaki.nagasaki.jp
+obama.nagasaki.jp
+omura.nagasaki.jp
+oseto.nagasaki.jp
+saikai.nagasaki.jp
+sasebo.nagasaki.jp
+seihi.nagasaki.jp
+shimabara.nagasaki.jp
+shinkamigoto.nagasaki.jp
+togitsu.nagasaki.jp
+tsushima.nagasaki.jp
+unzen.nagasaki.jp
+ando.nara.jp
+gose.nara.jp
+heguri.nara.jp
+higashiyoshino.nara.jp
+ikaruga.nara.jp
+ikoma.nara.jp
+kamikitayama.nara.jp
+kanmaki.nara.jp
+kashiba.nara.jp
+kashihara.nara.jp
+katsuragi.nara.jp
+kawai.nara.jp
+kawakami.nara.jp
+kawanishi.nara.jp
+koryo.nara.jp
+kurotaki.nara.jp
+mitsue.nara.jp
+miyake.nara.jp
+nara.nara.jp
+nosegawa.nara.jp
+oji.nara.jp
+ouda.nara.jp
+oyodo.nara.jp
+sakurai.nara.jp
+sango.nara.jp
+shimoichi.nara.jp
+shimokitayama.nara.jp
+shinjo.nara.jp
+soni.nara.jp
+takatori.nara.jp
+tawaramoto.nara.jp
+tenkawa.nara.jp
+tenri.nara.jp
+uda.nara.jp
+yamatokoriyama.nara.jp
+yamatotakada.nara.jp
+yamazoe.nara.jp
+yoshino.nara.jp
+aga.niigata.jp
+agano.niigata.jp
+gosen.niigata.jp
+itoigawa.niigata.jp
+izumozaki.niigata.jp
+joetsu.niigata.jp
+kamo.niigata.jp
+kariwa.niigata.jp
+kashiwazaki.niigata.jp
+minamiuonuma.niigata.jp
+mitsuke.niigata.jp
+muika.niigata.jp
+murakami.niigata.jp
+myoko.niigata.jp
+nagaoka.niigata.jp
+niigata.niigata.jp
+ojiya.niigata.jp
+omi.niigata.jp
+sado.niigata.jp
+sanjo.niigata.jp
+seiro.niigata.jp
+seirou.niigata.jp
+sekikawa.niigata.jp
+shibata.niigata.jp
+tagami.niigata.jp
+tainai.niigata.jp
+tochio.niigata.jp
+tokamachi.niigata.jp
+tsubame.niigata.jp
+tsunan.niigata.jp
+uonuma.niigata.jp
+yahiko.niigata.jp
+yoita.niigata.jp
+yuzawa.niigata.jp
+beppu.oita.jp
+bungoono.oita.jp
+bungotakada.oita.jp
+hasama.oita.jp
+hiji.oita.jp
+himeshima.oita.jp
+hita.oita.jp
+kamitsue.oita.jp
+kokonoe.oita.jp
+kuju.oita.jp
+kunisaki.oita.jp
+kusu.oita.jp
+oita.oita.jp
+saiki.oita.jp
+taketa.oita.jp
+tsukumi.oita.jp
+usa.oita.jp
+usuki.oita.jp
+yufu.oita.jp
+akaiwa.okayama.jp
+asakuchi.okayama.jp
+bizen.okayama.jp
+hayashima.okayama.jp
+ibara.okayama.jp
+kagamino.okayama.jp
+kasaoka.okayama.jp
+kibichuo.okayama.jp
+kumenan.okayama.jp
+kurashiki.okayama.jp
+maniwa.okayama.jp
+misaki.okayama.jp
+nagi.okayama.jp
+niimi.okayama.jp
+nishiawakura.okayama.jp
+okayama.okayama.jp
+satosho.okayama.jp
+setouchi.okayama.jp
+shinjo.okayama.jp
+shoo.okayama.jp
+soja.okayama.jp
+takahashi.okayama.jp
+tamano.okayama.jp
+tsuyama.okayama.jp
+wake.okayama.jp
+yakage.okayama.jp
+aguni.okinawa.jp
+ginowan.okinawa.jp
+ginoza.okinawa.jp
+gushikami.okinawa.jp
+haebaru.okinawa.jp
+higashi.okinawa.jp
+hirara.okinawa.jp
+iheya.okinawa.jp
+ishigaki.okinawa.jp
+ishikawa.okinawa.jp
+itoman.okinawa.jp
+izena.okinawa.jp
+kadena.okinawa.jp
+kin.okinawa.jp
+kitadaito.okinawa.jp
+kitanakagusuku.okinawa.jp
+kumejima.okinawa.jp
+kunigami.okinawa.jp
+minamidaito.okinawa.jp
+motobu.okinawa.jp
+nago.okinawa.jp
+naha.okinawa.jp
+nakagusuku.okinawa.jp
+nakijin.okinawa.jp
+nanjo.okinawa.jp
+nishihara.okinawa.jp
+ogimi.okinawa.jp
+okinawa.okinawa.jp
+onna.okinawa.jp
+shimoji.okinawa.jp
+taketomi.okinawa.jp
+tarama.okinawa.jp
+tokashiki.okinawa.jp
+tomigusuku.okinawa.jp
+tonaki.okinawa.jp
+urasoe.okinawa.jp
+uruma.okinawa.jp
+yaese.okinawa.jp
+yomitan.okinawa.jp
+yonabaru.okinawa.jp
+yonaguni.okinawa.jp
+zamami.okinawa.jp
+abeno.osaka.jp
+chihayaakasaka.osaka.jp
+chuo.osaka.jp
+daito.osaka.jp
+fujiidera.osaka.jp
+habikino.osaka.jp
+hannan.osaka.jp
+higashiosaka.osaka.jp
+higashisumiyoshi.osaka.jp
+higashiyodogawa.osaka.jp
+hirakata.osaka.jp
+ibaraki.osaka.jp
+ikeda.osaka.jp
+izumi.osaka.jp
+izumiotsu.osaka.jp
+izumisano.osaka.jp
+kadoma.osaka.jp
+kaizuka.osaka.jp
+kanan.osaka.jp
+kashiwara.osaka.jp
+katano.osaka.jp
+kawachinagano.osaka.jp
+kishiwada.osaka.jp
+kita.osaka.jp
+kumatori.osaka.jp
+matsubara.osaka.jp
+minato.osaka.jp
+minoh.osaka.jp
+misaki.osaka.jp
+moriguchi.osaka.jp
+neyagawa.osaka.jp
+nishi.osaka.jp
+nose.osaka.jp
+osakasayama.osaka.jp
+sakai.osaka.jp
+sayama.osaka.jp
+sennan.osaka.jp
+settsu.osaka.jp
+shijonawate.osaka.jp
+shimamoto.osaka.jp
+suita.osaka.jp
+tadaoka.osaka.jp
+taishi.osaka.jp
+tajiri.osaka.jp
+takaishi.osaka.jp
+takatsuki.osaka.jp
+tondabayashi.osaka.jp
+toyonaka.osaka.jp
+toyono.osaka.jp
+yao.osaka.jp
+ariake.saga.jp
+arita.saga.jp
+fukudomi.saga.jp
+genkai.saga.jp
+hamatama.saga.jp
+hizen.saga.jp
+imari.saga.jp
+kamimine.saga.jp
+kanzaki.saga.jp
+karatsu.saga.jp
+kashima.saga.jp
+kitagata.saga.jp
+kitahata.saga.jp
+kiyama.saga.jp
+kouhoku.saga.jp
+kyuragi.saga.jp
+nishiarita.saga.jp
+ogi.saga.jp
+omachi.saga.jp
+ouchi.saga.jp
+saga.saga.jp
+shiroishi.saga.jp
+taku.saga.jp
+tara.saga.jp
+tosu.saga.jp
+yoshinogari.saga.jp
+arakawa.saitama.jp
+asaka.saitama.jp
+chichibu.saitama.jp
+fujimi.saitama.jp
+fujimino.saitama.jp
+fukaya.saitama.jp
+hanno.saitama.jp
+hanyu.saitama.jp
+hasuda.saitama.jp
+hatogaya.saitama.jp
+hatoyama.saitama.jp
+hidaka.saitama.jp
+higashichichibu.saitama.jp
+higashimatsuyama.saitama.jp
+honjo.saitama.jp
+ina.saitama.jp
+iruma.saitama.jp
+iwatsuki.saitama.jp
+kamiizumi.saitama.jp
+kamikawa.saitama.jp
+kamisato.saitama.jp
+kasukabe.saitama.jp
+kawagoe.saitama.jp
+kawaguchi.saitama.jp
+kawajima.saitama.jp
+kazo.saitama.jp
+kitamoto.saitama.jp
+koshigaya.saitama.jp
+kounosu.saitama.jp
+kuki.saitama.jp
+kumagaya.saitama.jp
+matsubushi.saitama.jp
+minano.saitama.jp
+misato.saitama.jp
+miyashiro.saitama.jp
+miyoshi.saitama.jp
+moroyama.saitama.jp
+nagatoro.saitama.jp
+namegawa.saitama.jp
+niiza.saitama.jp
+ogano.saitama.jp
+ogawa.saitama.jp
+ogose.saitama.jp
+okegawa.saitama.jp
+omiya.saitama.jp
+otaki.saitama.jp
+ranzan.saitama.jp
+ryokami.saitama.jp
+saitama.saitama.jp
+sakado.saitama.jp
+satte.saitama.jp
+sayama.saitama.jp
+shiki.saitama.jp
+shiraoka.saitama.jp
+soka.saitama.jp
+sugito.saitama.jp
+toda.saitama.jp
+tokigawa.saitama.jp
+tokorozawa.saitama.jp
+tsurugashima.saitama.jp
+urawa.saitama.jp
+warabi.saitama.jp
+yashio.saitama.jp
+yokoze.saitama.jp
+yono.saitama.jp
+yorii.saitama.jp
+yoshida.saitama.jp
+yoshikawa.saitama.jp
+yoshimi.saitama.jp
+aisho.shiga.jp
+gamo.shiga.jp
+higashiomi.shiga.jp
+hikone.shiga.jp
+koka.shiga.jp
+konan.shiga.jp
+kosei.shiga.jp
+koto.shiga.jp
+kusatsu.shiga.jp
+maibara.shiga.jp
+moriyama.shiga.jp
+nagahama.shiga.jp
+nishiazai.shiga.jp
+notogawa.shiga.jp
+omihachiman.shiga.jp
+otsu.shiga.jp
+ritto.shiga.jp
+ryuoh.shiga.jp
+takashima.shiga.jp
+takatsuki.shiga.jp
+torahime.shiga.jp
+toyosato.shiga.jp
+yasu.shiga.jp
+akagi.shimane.jp
+ama.shimane.jp
+gotsu.shimane.jp
+hamada.shimane.jp
+higashiizumo.shimane.jp
+hikawa.shimane.jp
+hikimi.shimane.jp
+izumo.shimane.jp
+kakinoki.shimane.jp
+masuda.shimane.jp
+matsue.shimane.jp
+misato.shimane.jp
+nishinoshima.shimane.jp
+ohda.shimane.jp
+okinoshima.shimane.jp
+okuizumo.shimane.jp
+shimane.shimane.jp
+tamayu.shimane.jp
+tsuwano.shimane.jp
+unnan.shimane.jp
+yakumo.shimane.jp
+yasugi.shimane.jp
+yatsuka.shimane.jp
+arai.shizuoka.jp
+atami.shizuoka.jp
+fuji.shizuoka.jp
+fujieda.shizuoka.jp
+fujikawa.shizuoka.jp
+fujinomiya.shizuoka.jp
+fukuroi.shizuoka.jp
+gotemba.shizuoka.jp
+haibara.shizuoka.jp
+hamamatsu.shizuoka.jp
+higashiizu.shizuoka.jp
+ito.shizuoka.jp
+iwata.shizuoka.jp
+izu.shizuoka.jp
+izunokuni.shizuoka.jp
+kakegawa.shizuoka.jp
+kannami.shizuoka.jp
+kawanehon.shizuoka.jp
+kawazu.shizuoka.jp
+kikugawa.shizuoka.jp
+kosai.shizuoka.jp
+makinohara.shizuoka.jp
+matsuzaki.shizuoka.jp
+minamiizu.shizuoka.jp
+mishima.shizuoka.jp
+morimachi.shizuoka.jp
+nishiizu.shizuoka.jp
+numazu.shizuoka.jp
+omaezaki.shizuoka.jp
+shimada.shizuoka.jp
+shimizu.shizuoka.jp
+shimoda.shizuoka.jp
+shizuoka.shizuoka.jp
+susono.shizuoka.jp
+yaizu.shizuoka.jp
+yoshida.shizuoka.jp
+ashikaga.tochigi.jp
+bato.tochigi.jp
+haga.tochigi.jp
+ichikai.tochigi.jp
+iwafune.tochigi.jp
+kaminokawa.tochigi.jp
+kanuma.tochigi.jp
+karasuyama.tochigi.jp
+kuroiso.tochigi.jp
+mashiko.tochigi.jp
+mibu.tochigi.jp
+moka.tochigi.jp
+motegi.tochigi.jp
+nasu.tochigi.jp
+nasushiobara.tochigi.jp
+nikko.tochigi.jp
+nishikata.tochigi.jp
+nogi.tochigi.jp
+ohira.tochigi.jp
+ohtawara.tochigi.jp
+oyama.tochigi.jp
+sakura.tochigi.jp
+sano.tochigi.jp
+shimotsuke.tochigi.jp
+shioya.tochigi.jp
+takanezawa.tochigi.jp
+tochigi.tochigi.jp
+tsuga.tochigi.jp
+ujiie.tochigi.jp
+utsunomiya.tochigi.jp
+yaita.tochigi.jp
+aizumi.tokushima.jp
+anan.tokushima.jp
+ichiba.tokushima.jp
+itano.tokushima.jp
+kainan.tokushima.jp
+komatsushima.tokushima.jp
+matsushige.tokushima.jp
+mima.tokushima.jp
+minami.tokushima.jp
+miyoshi.tokushima.jp
+mugi.tokushima.jp
+nakagawa.tokushima.jp
+naruto.tokushima.jp
+sanagochi.tokushima.jp
+shishikui.tokushima.jp
+tokushima.tokushima.jp
+wajiki.tokushima.jp
+adachi.tokyo.jp
+akiruno.tokyo.jp
+akishima.tokyo.jp
+aogashima.tokyo.jp
+arakawa.tokyo.jp
+bunkyo.tokyo.jp
+chiyoda.tokyo.jp
+chofu.tokyo.jp
+chuo.tokyo.jp
+edogawa.tokyo.jp
+fuchu.tokyo.jp
+fussa.tokyo.jp
+hachijo.tokyo.jp
+hachioji.tokyo.jp
+hamura.tokyo.jp
+higashikurume.tokyo.jp
+higashimurayama.tokyo.jp
+higashiyamato.tokyo.jp
+hino.tokyo.jp
+hinode.tokyo.jp
+hinohara.tokyo.jp
+inagi.tokyo.jp
+itabashi.tokyo.jp
+katsushika.tokyo.jp
+kita.tokyo.jp
+kiyose.tokyo.jp
+kodaira.tokyo.jp
+koganei.tokyo.jp
+kokubunji.tokyo.jp
+komae.tokyo.jp
+koto.tokyo.jp
+kouzushima.tokyo.jp
+kunitachi.tokyo.jp
+machida.tokyo.jp
+meguro.tokyo.jp
+minato.tokyo.jp
+mitaka.tokyo.jp
+mizuho.tokyo.jp
+musashimurayama.tokyo.jp
+musashino.tokyo.jp
+nakano.tokyo.jp
+nerima.tokyo.jp
+ogasawara.tokyo.jp
+okutama.tokyo.jp
+ome.tokyo.jp
+oshima.tokyo.jp
+ota.tokyo.jp
+setagaya.tokyo.jp
+shibuya.tokyo.jp
+shinagawa.tokyo.jp
+shinjuku.tokyo.jp
+suginami.tokyo.jp
+sumida.tokyo.jp
+tachikawa.tokyo.jp
+taito.tokyo.jp
+tama.tokyo.jp
+toshima.tokyo.jp
+chizu.tottori.jp
+hino.tottori.jp
+kawahara.tottori.jp
+koge.tottori.jp
+kotoura.tottori.jp
+misasa.tottori.jp
+nanbu.tottori.jp
+nichinan.tottori.jp
+sakaiminato.tottori.jp
+tottori.tottori.jp
+wakasa.tottori.jp
+yazu.tottori.jp
+yonago.tottori.jp
+asahi.toyama.jp
+fuchu.toyama.jp
+fukumitsu.toyama.jp
+funahashi.toyama.jp
+himi.toyama.jp
+imizu.toyama.jp
+inami.toyama.jp
+johana.toyama.jp
+kamiichi.toyama.jp
+kurobe.toyama.jp
+nakaniikawa.toyama.jp
+namerikawa.toyama.jp
+nanto.toyama.jp
+nyuzen.toyama.jp
+oyabe.toyama.jp
+taira.toyama.jp
+takaoka.toyama.jp
+tateyama.toyama.jp
+toga.toyama.jp
+tonami.toyama.jp
+toyama.toyama.jp
+unazuki.toyama.jp
+uozu.toyama.jp
+yamada.toyama.jp
+arida.wakayama.jp
+aridagawa.wakayama.jp
+gobo.wakayama.jp
+hashimoto.wakayama.jp
+hidaka.wakayama.jp
+hirogawa.wakayama.jp
+inami.wakayama.jp
+iwade.wakayama.jp
+kainan.wakayama.jp
+kamitonda.wakayama.jp
+katsuragi.wakayama.jp
+kimino.wakayama.jp
+kinokawa.wakayama.jp
+kitayama.wakayama.jp
+koya.wakayama.jp
+koza.wakayama.jp
+kozagawa.wakayama.jp
+kudoyama.wakayama.jp
+kushimoto.wakayama.jp
+mihama.wakayama.jp
+misato.wakayama.jp
+nachikatsuura.wakayama.jp
+shingu.wakayama.jp
+shirahama.wakayama.jp
+taiji.wakayama.jp
+tanabe.wakayama.jp
+wakayama.wakayama.jp
+yuasa.wakayama.jp
+yura.wakayama.jp
+asahi.yamagata.jp
+funagata.yamagata.jp
+higashine.yamagata.jp
+iide.yamagata.jp
+kahoku.yamagata.jp
+kaminoyama.yamagata.jp
+kaneyama.yamagata.jp
+kawanishi.yamagata.jp
+mamurogawa.yamagata.jp
+mikawa.yamagata.jp
+murayama.yamagata.jp
+nagai.yamagata.jp
+nakayama.yamagata.jp
+nanyo.yamagata.jp
+nishikawa.yamagata.jp
+obanazawa.yamagata.jp
+oe.yamagata.jp
+oguni.yamagata.jp
+ohkura.yamagata.jp
+oishida.yamagata.jp
+sagae.yamagata.jp
+sakata.yamagata.jp
+sakegawa.yamagata.jp
+shinjo.yamagata.jp
+shirataka.yamagata.jp
+shonai.yamagata.jp
+takahata.yamagata.jp
+tendo.yamagata.jp
+tozawa.yamagata.jp
+tsuruoka.yamagata.jp
+yamagata.yamagata.jp
+yamanobe.yamagata.jp
+yonezawa.yamagata.jp
+yuza.yamagata.jp
+abu.yamaguchi.jp
+hagi.yamaguchi.jp
+hikari.yamaguchi.jp
+hofu.yamaguchi.jp
+iwakuni.yamaguchi.jp
+kudamatsu.yamaguchi.jp
+mitou.yamaguchi.jp
+nagato.yamaguchi.jp
+oshima.yamaguchi.jp
+shimonoseki.yamaguchi.jp
+shunan.yamaguchi.jp
+tabuse.yamaguchi.jp
+tokuyama.yamaguchi.jp
+toyota.yamaguchi.jp
+ube.yamaguchi.jp
+yuu.yamaguchi.jp
+chuo.yamanashi.jp
+doshi.yamanashi.jp
+fuefuki.yamanashi.jp
+fujikawa.yamanashi.jp
+fujikawaguchiko.yamanashi.jp
+fujiyoshida.yamanashi.jp
+hayakawa.yamanashi.jp
+hokuto.yamanashi.jp
+ichikawamisato.yamanashi.jp
+kai.yamanashi.jp
+kofu.yamanashi.jp
+koshu.yamanashi.jp
+kosuge.yamanashi.jp
+minami-alps.yamanashi.jp
+minobu.yamanashi.jp
+nakamichi.yamanashi.jp
+nanbu.yamanashi.jp
+narusawa.yamanashi.jp
+nirasaki.yamanashi.jp
+nishikatsura.yamanashi.jp
+oshino.yamanashi.jp
+otsuki.yamanashi.jp
+showa.yamanashi.jp
+tabayama.yamanashi.jp
+tsuru.yamanashi.jp
+uenohara.yamanashi.jp
+yamanakako.yamanashi.jp
+yamanashi.yamanashi.jp
+
+// ke : http://www.kenic.or.ke/index.php/en/ke-domains/ke-domains
+ke
+ac.ke
+co.ke
+go.ke
+info.ke
+me.ke
+mobi.ke
+ne.ke
+or.ke
+sc.ke
+
+// kg : http://www.domain.kg/dmn_n.html
+kg
+org.kg
+net.kg
+com.kg
+edu.kg
+gov.kg
+mil.kg
+
+// kh : http://www.mptc.gov.kh/dns_registration.htm
+*.kh
+
+// ki : http://www.ki/dns/index.html
+ki
+edu.ki
+biz.ki
+net.ki
+org.ki
+gov.ki
+info.ki
+com.ki
+
+// km : https://en.wikipedia.org/wiki/.km
+// http://www.domaine.km/documents/charte.doc
+km
+org.km
+nom.km
+gov.km
+prd.km
+tm.km
+edu.km
+mil.km
+ass.km
+com.km
+// These are only mentioned as proposed suggestions at domaine.km, but
+// https://en.wikipedia.org/wiki/.km says they're available for registration:
+coop.km
+asso.km
+presse.km
+medecin.km
+notaires.km
+pharmaciens.km
+veterinaire.km
+gouv.km
+
+// kn : https://en.wikipedia.org/wiki/.kn
+// http://www.dot.kn/domainRules.html
+kn
+net.kn
+org.kn
+edu.kn
+gov.kn
+
+// kp : http://www.kcce.kp/en_index.php
+kp
+com.kp
+edu.kp
+gov.kp
+org.kp
+rep.kp
+tra.kp
+
+// kr : https://en.wikipedia.org/wiki/.kr
+// see also: http://domain.nida.or.kr/eng/registration.jsp
+kr
+ac.kr
+co.kr
+es.kr
+go.kr
+hs.kr
+kg.kr
+mil.kr
+ms.kr
+ne.kr
+or.kr
+pe.kr
+re.kr
+sc.kr
+// kr geographical names
+busan.kr
+chungbuk.kr
+chungnam.kr
+daegu.kr
+daejeon.kr
+gangwon.kr
+gwangju.kr
+gyeongbuk.kr
+gyeonggi.kr
+gyeongnam.kr
+incheon.kr
+jeju.kr
+jeonbuk.kr
+jeonnam.kr
+seoul.kr
+ulsan.kr
+
+// kw : https://www.nic.kw/policies/
+// Confirmed by registry <nic.tech@citra.gov.kw>
+kw
+com.kw
+edu.kw
+emb.kw
+gov.kw
+ind.kw
+net.kw
+org.kw
+
+// ky : http://www.icta.ky/da_ky_reg_dom.php
+// Confirmed by registry <kysupport@perimeterusa.com> 2008-06-17
+ky
+edu.ky
+gov.ky
+com.ky
+org.ky
+net.ky
+
+// kz : https://en.wikipedia.org/wiki/.kz
+// see also: http://www.nic.kz/rules/index.jsp
+kz
+org.kz
+edu.kz
+net.kz
+gov.kz
+mil.kz
+com.kz
+
+// la : https://en.wikipedia.org/wiki/.la
+// Submitted by registry <gavin.brown@nic.la>
+la
+int.la
+net.la
+info.la
+edu.la
+gov.la
+per.la
+com.la
+org.la
+
+// lb : https://en.wikipedia.org/wiki/.lb
+// Submitted by registry <randy@psg.com>
+lb
+com.lb
+edu.lb
+gov.lb
+net.lb
+org.lb
+
+// lc : https://en.wikipedia.org/wiki/.lc
+// see also: http://www.nic.lc/rules.htm
+lc
+com.lc
+net.lc
+co.lc
+org.lc
+edu.lc
+gov.lc
+
+// li : https://en.wikipedia.org/wiki/.li
+li
+
+// lk : https://www.nic.lk/index.php/domain-registration/lk-domain-naming-structure
+lk
+gov.lk
+sch.lk
+net.lk
+int.lk
+com.lk
+org.lk
+edu.lk
+ngo.lk
+soc.lk
+web.lk
+ltd.lk
+assn.lk
+grp.lk
+hotel.lk
+ac.lk
+
+// lr : http://psg.com/dns/lr/lr.txt
+// Submitted by registry <randy@psg.com>
+lr
+com.lr
+edu.lr
+gov.lr
+org.lr
+net.lr
+
+// ls : http://www.nic.ls/
+// Confirmed by registry <lsadmin@nic.ls>
+ls
+ac.ls
+biz.ls
+co.ls
+edu.ls
+gov.ls
+info.ls
+net.ls
+org.ls
+sc.ls
+
+// lt : https://en.wikipedia.org/wiki/.lt
+lt
+// gov.lt : http://www.gov.lt/index_en.php
+gov.lt
+
+// lu : http://www.dns.lu/en/
+lu
+
+// lv : http://www.nic.lv/DNS/En/generic.php
+lv
+com.lv
+edu.lv
+gov.lv
+org.lv
+mil.lv
+id.lv
+net.lv
+asn.lv
+conf.lv
+
+// ly : http://www.nic.ly/regulations.php
+ly
+com.ly
+net.ly
+gov.ly
+plc.ly
+edu.ly
+sch.ly
+med.ly
+org.ly
+id.ly
+
+// ma : https://en.wikipedia.org/wiki/.ma
+// http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf
+ma
+co.ma
+net.ma
+gov.ma
+org.ma
+ac.ma
+press.ma
+
+// mc : http://www.nic.mc/
+mc
+tm.mc
+asso.mc
+
+// md : https://en.wikipedia.org/wiki/.md
+md
+
+// me : https://en.wikipedia.org/wiki/.me
+me
+co.me
+net.me
+org.me
+edu.me
+ac.me
+gov.me
+its.me
+priv.me
+
+// mg : http://nic.mg/nicmg/?page_id=39
+mg
+org.mg
+nom.mg
+gov.mg
+prd.mg
+tm.mg
+edu.mg
+mil.mg
+com.mg
+co.mg
+
+// mh : https://en.wikipedia.org/wiki/.mh
+mh
+
+// mil : https://en.wikipedia.org/wiki/.mil
+mil
+
+// mk : https://en.wikipedia.org/wiki/.mk
+// see also: http://dns.marnet.net.mk/postapka.php
+mk
+com.mk
+org.mk
+net.mk
+edu.mk
+gov.mk
+inf.mk
+name.mk
+
+// ml : http://www.gobin.info/domainname/ml-template.doc
+// see also: https://en.wikipedia.org/wiki/.ml
+ml
+com.ml
+edu.ml
+gouv.ml
+gov.ml
+net.ml
+org.ml
+presse.ml
+
+// mm : https://en.wikipedia.org/wiki/.mm
+*.mm
+
+// mn : https://en.wikipedia.org/wiki/.mn
+mn
+gov.mn
+edu.mn
+org.mn
+
+// mo : http://www.monic.net.mo/
+mo
+com.mo
+net.mo
+org.mo
+edu.mo
+gov.mo
+
+// mobi : https://en.wikipedia.org/wiki/.mobi
+mobi
+
+// mp : http://www.dot.mp/
+// Confirmed by registry <dcamacho@saipan.com> 2008-06-17
+mp
+
+// mq : https://en.wikipedia.org/wiki/.mq
+mq
+
+// mr : https://en.wikipedia.org/wiki/.mr
+mr
+gov.mr
+
+// ms : http://www.nic.ms/pdf/MS_Domain_Name_Rules.pdf
+ms
+com.ms
+edu.ms
+gov.ms
+net.ms
+org.ms
+
+// mt : https://www.nic.org.mt/go/policy
+// Submitted by registry <help@nic.org.mt>
+mt
+com.mt
+edu.mt
+net.mt
+org.mt
+
+// mu : https://en.wikipedia.org/wiki/.mu
+mu
+com.mu
+net.mu
+org.mu
+gov.mu
+ac.mu
+co.mu
+or.mu
+
+// museum : http://about.museum/naming/
+// http://index.museum/
+museum
+academy.museum
+agriculture.museum
+air.museum
+airguard.museum
+alabama.museum
+alaska.museum
+amber.museum
+ambulance.museum
+american.museum
+americana.museum
+americanantiques.museum
+americanart.museum
+amsterdam.museum
+and.museum
+annefrank.museum
+anthro.museum
+anthropology.museum
+antiques.museum
+aquarium.museum
+arboretum.museum
+archaeological.museum
+archaeology.museum
+architecture.museum
+art.museum
+artanddesign.museum
+artcenter.museum
+artdeco.museum
+arteducation.museum
+artgallery.museum
+arts.museum
+artsandcrafts.museum
+asmatart.museum
+assassination.museum
+assisi.museum
+association.museum
+astronomy.museum
+atlanta.museum
+austin.museum
+australia.museum
+automotive.museum
+aviation.museum
+axis.museum
+badajoz.museum
+baghdad.museum
+bahn.museum
+bale.museum
+baltimore.museum
+barcelona.museum
+baseball.museum
+basel.museum
+baths.museum
+bauern.museum
+beauxarts.museum
+beeldengeluid.museum
+bellevue.museum
+bergbau.museum
+berkeley.museum
+berlin.museum
+bern.museum
+bible.museum
+bilbao.museum
+bill.museum
+birdart.museum
+birthplace.museum
+bonn.museum
+boston.museum
+botanical.museum
+botanicalgarden.museum
+botanicgarden.museum
+botany.museum
+brandywinevalley.museum
+brasil.museum
+bristol.museum
+british.museum
+britishcolumbia.museum
+broadcast.museum
+brunel.museum
+brussel.museum
+brussels.museum
+bruxelles.museum
+building.museum
+burghof.museum
+bus.museum
+bushey.museum
+cadaques.museum
+california.museum
+cambridge.museum
+can.museum
+canada.museum
+capebreton.museum
+carrier.museum
+cartoonart.museum
+casadelamoneda.museum
+castle.museum
+castres.museum
+celtic.museum
+center.museum
+chattanooga.museum
+cheltenham.museum
+chesapeakebay.museum
+chicago.museum
+children.museum
+childrens.museum
+childrensgarden.museum
+chiropractic.museum
+chocolate.museum
+christiansburg.museum
+cincinnati.museum
+cinema.museum
+circus.museum
+civilisation.museum
+civilization.museum
+civilwar.museum
+clinton.museum
+clock.museum
+coal.museum
+coastaldefence.museum
+cody.museum
+coldwar.museum
+collection.museum
+colonialwilliamsburg.museum
+coloradoplateau.museum
+columbia.museum
+columbus.museum
+communication.museum
+communications.museum
+community.museum
+computer.museum
+computerhistory.museum
+comunicações.museum
+contemporary.museum
+contemporaryart.museum
+convent.museum
+copenhagen.museum
+corporation.museum
+correios-e-telecomunicações.museum
+corvette.museum
+costume.museum
+countryestate.museum
+county.museum
+crafts.museum
+cranbrook.museum
+creation.museum
+cultural.museum
+culturalcenter.museum
+culture.museum
+cyber.museum
+cymru.museum
+dali.museum
+dallas.museum
+database.museum
+ddr.museum
+decorativearts.museum
+delaware.museum
+delmenhorst.museum
+denmark.museum
+depot.museum
+design.museum
+detroit.museum
+dinosaur.museum
+discovery.museum
+dolls.museum
+donostia.museum
+durham.museum
+eastafrica.museum
+eastcoast.museum
+education.museum
+educational.museum
+egyptian.museum
+eisenbahn.museum
+elburg.museum
+elvendrell.museum
+embroidery.museum
+encyclopedic.museum
+england.museum
+entomology.museum
+environment.museum
+environmentalconservation.museum
+epilepsy.museum
+essex.museum
+estate.museum
+ethnology.museum
+exeter.museum
+exhibition.museum
+family.museum
+farm.museum
+farmequipment.museum
+farmers.museum
+farmstead.museum
+field.museum
+figueres.museum
+filatelia.museum
+film.museum
+fineart.museum
+finearts.museum
+finland.museum
+flanders.museum
+florida.museum
+force.museum
+fortmissoula.museum
+fortworth.museum
+foundation.museum
+francaise.museum
+frankfurt.museum
+franziskaner.museum
+freemasonry.museum
+freiburg.museum
+fribourg.museum
+frog.museum
+fundacio.museum
+furniture.museum
+gallery.museum
+garden.museum
+gateway.museum
+geelvinck.museum
+gemological.museum
+geology.museum
+georgia.museum
+giessen.museum
+glas.museum
+glass.museum
+gorge.museum
+grandrapids.museum
+graz.museum
+guernsey.museum
+halloffame.museum
+hamburg.museum
+handson.museum
+harvestcelebration.museum
+hawaii.museum
+health.museum
+heimatunduhren.museum
+hellas.museum
+helsinki.museum
+hembygdsforbund.museum
+heritage.museum
+histoire.museum
+historical.museum
+historicalsociety.museum
+historichouses.museum
+historisch.museum
+historisches.museum
+history.museum
+historyofscience.museum
+horology.museum
+house.museum
+humanities.museum
+illustration.museum
+imageandsound.museum
+indian.museum
+indiana.museum
+indianapolis.museum
+indianmarket.museum
+intelligence.museum
+interactive.museum
+iraq.museum
+iron.museum
+isleofman.museum
+jamison.museum
+jefferson.museum
+jerusalem.museum
+jewelry.museum
+jewish.museum
+jewishart.museum
+jfk.museum
+journalism.museum
+judaica.museum
+judygarland.museum
+juedisches.museum
+juif.museum
+karate.museum
+karikatur.museum
+kids.museum
+koebenhavn.museum
+koeln.museum
+kunst.museum
+kunstsammlung.museum
+kunstunddesign.museum
+labor.museum
+labour.museum
+lajolla.museum
+lancashire.museum
+landes.museum
+lans.museum
+läns.museum
+larsson.museum
+lewismiller.museum
+lincoln.museum
+linz.museum
+living.museum
+livinghistory.museum
+localhistory.museum
+london.museum
+losangeles.museum
+louvre.museum
+loyalist.museum
+lucerne.museum
+luxembourg.museum
+luzern.museum
+mad.museum
+madrid.museum
+mallorca.museum
+manchester.museum
+mansion.museum
+mansions.museum
+manx.museum
+marburg.museum
+maritime.museum
+maritimo.museum
+maryland.museum
+marylhurst.museum
+media.museum
+medical.museum
+medizinhistorisches.museum
+meeres.museum
+memorial.museum
+mesaverde.museum
+michigan.museum
+midatlantic.museum
+military.museum
+mill.museum
+miners.museum
+mining.museum
+minnesota.museum
+missile.museum
+missoula.museum
+modern.museum
+moma.museum
+money.museum
+monmouth.museum
+monticello.museum
+montreal.museum
+moscow.museum
+motorcycle.museum
+muenchen.museum
+muenster.museum
+mulhouse.museum
+muncie.museum
+museet.museum
+museumcenter.museum
+museumvereniging.museum
+music.museum
+national.museum
+nationalfirearms.museum
+nationalheritage.museum
+nativeamerican.museum
+naturalhistory.museum
+naturalhistorymuseum.museum
+naturalsciences.museum
+nature.museum
+naturhistorisches.museum
+natuurwetenschappen.museum
+naumburg.museum
+naval.museum
+nebraska.museum
+neues.museum
+newhampshire.museum
+newjersey.museum
+newmexico.museum
+newport.museum
+newspaper.museum
+newyork.museum
+niepce.museum
+norfolk.museum
+north.museum
+nrw.museum
+nyc.museum
+nyny.museum
+oceanographic.museum
+oceanographique.museum
+omaha.museum
+online.museum
+ontario.museum
+openair.museum
+oregon.museum
+oregontrail.museum
+otago.museum
+oxford.museum
+pacific.museum
+paderborn.museum
+palace.museum
+paleo.museum
+palmsprings.museum
+panama.museum
+paris.museum
+pasadena.museum
+pharmacy.museum
+philadelphia.museum
+philadelphiaarea.museum
+philately.museum
+phoenix.museum
+photography.museum
+pilots.museum
+pittsburgh.museum
+planetarium.museum
+plantation.museum
+plants.museum
+plaza.museum
+portal.museum
+portland.museum
+portlligat.museum
+posts-and-telecommunications.museum
+preservation.museum
+presidio.museum
+press.museum
+project.museum
+public.museum
+pubol.museum
+quebec.museum
+railroad.museum
+railway.museum
+research.museum
+resistance.museum
+riodejaneiro.museum
+rochester.museum
+rockart.museum
+roma.museum
+russia.museum
+saintlouis.museum
+salem.museum
+salvadordali.museum
+salzburg.museum
+sandiego.museum
+sanfrancisco.museum
+santabarbara.museum
+santacruz.museum
+santafe.museum
+saskatchewan.museum
+satx.museum
+savannahga.museum
+schlesisches.museum
+schoenbrunn.museum
+schokoladen.museum
+school.museum
+schweiz.museum
+science.museum
+scienceandhistory.museum
+scienceandindustry.museum
+sciencecenter.museum
+sciencecenters.museum
+science-fiction.museum
+sciencehistory.museum
+sciences.museum
+sciencesnaturelles.museum
+scotland.museum
+seaport.museum
+settlement.museum
+settlers.museum
+shell.museum
+sherbrooke.museum
+sibenik.museum
+silk.museum
+ski.museum
+skole.museum
+society.museum
+sologne.museum
+soundandvision.museum
+southcarolina.museum
+southwest.museum
+space.museum
+spy.museum
+square.museum
+stadt.museum
+stalbans.museum
+starnberg.museum
+state.museum
+stateofdelaware.museum
+station.museum
+steam.museum
+steiermark.museum
+stjohn.museum
+stockholm.museum
+stpetersburg.museum
+stuttgart.museum
+suisse.museum
+surgeonshall.museum
+surrey.museum
+svizzera.museum
+sweden.museum
+sydney.museum
+tank.museum
+tcm.museum
+technology.museum
+telekommunikation.museum
+television.museum
+texas.museum
+textile.museum
+theater.museum
+time.museum
+timekeeping.museum
+topology.museum
+torino.museum
+touch.museum
+town.museum
+transport.museum
+tree.museum
+trolley.museum
+trust.museum
+trustee.museum
+uhren.museum
+ulm.museum
+undersea.museum
+university.museum
+usa.museum
+usantiques.museum
+usarts.museum
+uscountryestate.museum
+usculture.museum
+usdecorativearts.museum
+usgarden.museum
+ushistory.museum
+ushuaia.museum
+uslivinghistory.museum
+utah.museum
+uvic.museum
+valley.museum
+vantaa.museum
+versailles.museum
+viking.museum
+village.museum
+virginia.museum
+virtual.museum
+virtuel.museum
+vlaanderen.museum
+volkenkunde.museum
+wales.museum
+wallonie.museum
+war.museum
+washingtondc.museum
+watchandclock.museum
+watch-and-clock.museum
+western.museum
+westfalen.museum
+whaling.museum
+wildlife.museum
+williamsburg.museum
+windmill.museum
+workshop.museum
+york.museum
+yorkshire.museum
+yosemite.museum
+youth.museum
+zoological.museum
+zoology.museum
+ירושלים.museum
+иком.museum
+
+// mv : https://en.wikipedia.org/wiki/.mv
+// "mv" included because, contra Wikipedia, google.mv exists.
+mv
+aero.mv
+biz.mv
+com.mv
+coop.mv
+edu.mv
+gov.mv
+info.mv
+int.mv
+mil.mv
+museum.mv
+name.mv
+net.mv
+org.mv
+pro.mv
+
+// mw : http://www.registrar.mw/
+mw
+ac.mw
+biz.mw
+co.mw
+com.mw
+coop.mw
+edu.mw
+gov.mw
+int.mw
+museum.mw
+net.mw
+org.mw
+
+// mx : http://www.nic.mx/
+// Submitted by registry <farias@nic.mx>
+mx
+com.mx
+org.mx
+gob.mx
+edu.mx
+net.mx
+
+// my : http://www.mynic.net.my/
+my
+com.my
+net.my
+org.my
+gov.my
+edu.my
+mil.my
+name.my
+
+// mz : http://www.uem.mz/
+// Submitted by registry <antonio@uem.mz>
+mz
+ac.mz
+adv.mz
+co.mz
+edu.mz
+gov.mz
+mil.mz
+net.mz
+org.mz
+
+// na : http://www.na-nic.com.na/
+// http://www.info.na/domain/
+na
+info.na
+pro.na
+name.na
+school.na
+or.na
+dr.na
+us.na
+mx.na
+ca.na
+in.na
+cc.na
+tv.na
+ws.na
+mobi.na
+co.na
+com.na
+org.na
+
+// name : has 2nd-level tlds, but there's no list of them
+name
+
+// nc : http://www.cctld.nc/
+nc
+asso.nc
+nom.nc
+
+// ne : https://en.wikipedia.org/wiki/.ne
+ne
+
+// net : https://en.wikipedia.org/wiki/.net
+net
+
+// nf : https://en.wikipedia.org/wiki/.nf
+nf
+com.nf
+net.nf
+per.nf
+rec.nf
+web.nf
+arts.nf
+firm.nf
+info.nf
+other.nf
+store.nf
+
+// ng : http://www.nira.org.ng/index.php/join-us/register-ng-domain/189-nira-slds
+ng
+com.ng
+edu.ng
+gov.ng
+i.ng
+mil.ng
+mobi.ng
+name.ng
+net.ng
+org.ng
+sch.ng
+
+// ni : http://www.nic.ni/
+ni
+ac.ni
+biz.ni
+co.ni
+com.ni
+edu.ni
+gob.ni
+in.ni
+info.ni
+int.ni
+mil.ni
+net.ni
+nom.ni
+org.ni
+web.ni
+
+// nl : https://en.wikipedia.org/wiki/.nl
+//      https://www.sidn.nl/
+//      ccTLD for the Netherlands
+nl
+
+// no : https://www.norid.no/en/om-domenenavn/regelverk-for-no/
+// Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
+// Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
+// Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
+no
+// Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/
+fhs.no
+vgs.no
+fylkesbibl.no
+folkebibl.no
+museum.no
+idrett.no
+priv.no
+// Norid category second-level domains managed by parties other than Norid : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/
+mil.no
+stat.no
+dep.no
+kommune.no
+herad.no
+// Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/
+// counties
+aa.no
+ah.no
+bu.no
+fm.no
+hl.no
+hm.no
+jan-mayen.no
+mr.no
+nl.no
+nt.no
+of.no
+ol.no
+oslo.no
+rl.no
+sf.no
+st.no
+svalbard.no
+tm.no
+tr.no
+va.no
+vf.no
+// primary and lower secondary schools per county
+gs.aa.no
+gs.ah.no
+gs.bu.no
+gs.fm.no
+gs.hl.no
+gs.hm.no
+gs.jan-mayen.no
+gs.mr.no
+gs.nl.no
+gs.nt.no
+gs.of.no
+gs.ol.no
+gs.oslo.no
+gs.rl.no
+gs.sf.no
+gs.st.no
+gs.svalbard.no
+gs.tm.no
+gs.tr.no
+gs.va.no
+gs.vf.no
+// cities
+akrehamn.no
+åkrehamn.no
+algard.no
+ålgård.no
+arna.no
+brumunddal.no
+bryne.no
+bronnoysund.no
+brønnøysund.no
+drobak.no
+drøbak.no
+egersund.no
+fetsund.no
+floro.no
+florø.no
+fredrikstad.no
+hokksund.no
+honefoss.no
+hønefoss.no
+jessheim.no
+jorpeland.no
+jørpeland.no
+kirkenes.no
+kopervik.no
+krokstadelva.no
+langevag.no
+langevåg.no
+leirvik.no
+mjondalen.no
+mjøndalen.no
+mo-i-rana.no
+mosjoen.no
+mosjøen.no
+nesoddtangen.no
+orkanger.no
+osoyro.no
+osøyro.no
+raholt.no
+råholt.no
+sandnessjoen.no
+sandnessjøen.no
+skedsmokorset.no
+slattum.no
+spjelkavik.no
+stathelle.no
+stavern.no
+stjordalshalsen.no
+stjørdalshalsen.no
+tananger.no
+tranby.no
+vossevangen.no
+// communities
+afjord.no
+åfjord.no
+agdenes.no
+al.no
+ål.no
+alesund.no
+ålesund.no
+alstahaug.no
+alta.no
+áltá.no
+alaheadju.no
+álaheadju.no
+alvdal.no
+amli.no
+åmli.no
+amot.no
+åmot.no
+andebu.no
+andoy.no
+andøy.no
+andasuolo.no
+ardal.no
+årdal.no
+aremark.no
+arendal.no
+ås.no
+aseral.no
+åseral.no
+asker.no
+askim.no
+askvoll.no
+askoy.no
+askøy.no
+asnes.no
+åsnes.no
+audnedaln.no
+aukra.no
+aure.no
+aurland.no
+aurskog-holand.no
+aurskog-høland.no
+austevoll.no
+austrheim.no
+averoy.no
+averøy.no
+balestrand.no
+ballangen.no
+balat.no
+bálát.no
+balsfjord.no
+bahccavuotna.no
+báhccavuotna.no
+bamble.no
+bardu.no
+beardu.no
+beiarn.no
+bajddar.no
+bájddar.no
+baidar.no
+báidár.no
+berg.no
+bergen.no
+berlevag.no
+berlevåg.no
+bearalvahki.no
+bearalváhki.no
+bindal.no
+birkenes.no
+bjarkoy.no
+bjarkøy.no
+bjerkreim.no
+bjugn.no
+bodo.no
+bodø.no
+badaddja.no
+bådåddjå.no
+budejju.no
+bokn.no
+bremanger.no
+bronnoy.no
+brønnøy.no
+bygland.no
+bykle.no
+barum.no
+bærum.no
+bo.telemark.no
+bø.telemark.no
+bo.nordland.no
+bø.nordland.no
+bievat.no
+bievát.no
+bomlo.no
+bømlo.no
+batsfjord.no
+båtsfjord.no
+bahcavuotna.no
+báhcavuotna.no
+dovre.no
+drammen.no
+drangedal.no
+dyroy.no
+dyrøy.no
+donna.no
+dønna.no
+eid.no
+eidfjord.no
+eidsberg.no
+eidskog.no
+eidsvoll.no
+eigersund.no
+elverum.no
+enebakk.no
+engerdal.no
+etne.no
+etnedal.no
+evenes.no
+evenassi.no
+evenášši.no
+evje-og-hornnes.no
+farsund.no
+fauske.no
+fuossko.no
+fuoisku.no
+fedje.no
+fet.no
+finnoy.no
+finnøy.no
+fitjar.no
+fjaler.no
+fjell.no
+flakstad.no
+flatanger.no
+flekkefjord.no
+flesberg.no
+flora.no
+fla.no
+flå.no
+folldal.no
+forsand.no
+fosnes.no
+frei.no
+frogn.no
+froland.no
+frosta.no
+frana.no
+fræna.no
+froya.no
+frøya.no
+fusa.no
+fyresdal.no
+forde.no
+førde.no
+gamvik.no
+gangaviika.no
+gáŋgaviika.no
+gaular.no
+gausdal.no
+gildeskal.no
+gildeskål.no
+giske.no
+gjemnes.no
+gjerdrum.no
+gjerstad.no
+gjesdal.no
+gjovik.no
+gjøvik.no
+gloppen.no
+gol.no
+gran.no
+grane.no
+granvin.no
+gratangen.no
+grimstad.no
+grong.no
+kraanghke.no
+kråanghke.no
+grue.no
+gulen.no
+hadsel.no
+halden.no
+halsa.no
+hamar.no
+hamaroy.no
+habmer.no
+hábmer.no
+hapmir.no
+hápmir.no
+hammerfest.no
+hammarfeasta.no
+hámmárfeasta.no
+haram.no
+hareid.no
+harstad.no
+hasvik.no
+aknoluokta.no
+ákŋoluokta.no
+hattfjelldal.no
+aarborte.no
+haugesund.no
+hemne.no
+hemnes.no
+hemsedal.no
+heroy.more-og-romsdal.no
+herøy.møre-og-romsdal.no
+heroy.nordland.no
+herøy.nordland.no
+hitra.no
+hjartdal.no
+hjelmeland.no
+hobol.no
+hobøl.no
+hof.no
+hol.no
+hole.no
+holmestrand.no
+holtalen.no
+holtålen.no
+hornindal.no
+horten.no
+hurdal.no
+hurum.no
+hvaler.no
+hyllestad.no
+hagebostad.no
+hægebostad.no
+hoyanger.no
+høyanger.no
+hoylandet.no
+høylandet.no
+ha.no
+hå.no
+ibestad.no
+inderoy.no
+inderøy.no
+iveland.no
+jevnaker.no
+jondal.no
+jolster.no
+jølster.no
+karasjok.no
+karasjohka.no
+kárášjohka.no
+karlsoy.no
+galsa.no
+gálsá.no
+karmoy.no
+karmøy.no
+kautokeino.no
+guovdageaidnu.no
+klepp.no
+klabu.no
+klæbu.no
+kongsberg.no
+kongsvinger.no
+kragero.no
+kragerø.no
+kristiansand.no
+kristiansund.no
+krodsherad.no
+krødsherad.no
+kvalsund.no
+rahkkeravju.no
+ráhkkerávju.no
+kvam.no
+kvinesdal.no
+kvinnherad.no
+kviteseid.no
+kvitsoy.no
+kvitsøy.no
+kvafjord.no
+kvæfjord.no
+giehtavuoatna.no
+kvanangen.no
+kvænangen.no
+navuotna.no
+návuotna.no
+kafjord.no
+kåfjord.no
+gaivuotna.no
+gáivuotna.no
+larvik.no
+lavangen.no
+lavagis.no
+loabat.no
+loabát.no
+lebesby.no
+davvesiida.no
+leikanger.no
+leirfjord.no
+leka.no
+leksvik.no
+lenvik.no
+leangaviika.no
+leaŋgaviika.no
+lesja.no
+levanger.no
+lier.no
+lierne.no
+lillehammer.no
+lillesand.no
+lindesnes.no
+lindas.no
+lindås.no
+lom.no
+loppa.no
+lahppi.no
+láhppi.no
+lund.no
+lunner.no
+luroy.no
+lurøy.no
+luster.no
+lyngdal.no
+lyngen.no
+ivgu.no
+lardal.no
+lerdal.no
+lærdal.no
+lodingen.no
+lødingen.no
+lorenskog.no
+lørenskog.no
+loten.no
+løten.no
+malvik.no
+masoy.no
+måsøy.no
+muosat.no
+muosát.no
+mandal.no
+marker.no
+marnardal.no
+masfjorden.no
+meland.no
+meldal.no
+melhus.no
+meloy.no
+meløy.no
+meraker.no
+meråker.no
+moareke.no
+moåreke.no
+midsund.no
+midtre-gauldal.no
+modalen.no
+modum.no
+molde.no
+moskenes.no
+moss.no
+mosvik.no
+malselv.no
+målselv.no
+malatvuopmi.no
+málatvuopmi.no
+namdalseid.no
+aejrie.no
+namsos.no
+namsskogan.no
+naamesjevuemie.no
+nååmesjevuemie.no
+laakesvuemie.no
+nannestad.no
+narvik.no
+narviika.no
+naustdal.no
+nedre-eiker.no
+nes.akershus.no
+nes.buskerud.no
+nesna.no
+nesodden.no
+nesseby.no
+unjarga.no
+unjárga.no
+nesset.no
+nissedal.no
+nittedal.no
+nord-aurdal.no
+nord-fron.no
+nord-odal.no
+norddal.no
+nordkapp.no
+davvenjarga.no
+davvenjárga.no
+nordre-land.no
+nordreisa.no
+raisa.no
+ráisa.no
+nore-og-uvdal.no
+notodden.no
+naroy.no
+nærøy.no
+notteroy.no
+nøtterøy.no
+odda.no
+oksnes.no
+øksnes.no
+oppdal.no
+oppegard.no
+oppegård.no
+orkdal.no
+orland.no
+ørland.no
+orskog.no
+ørskog.no
+orsta.no
+ørsta.no
+os.hedmark.no
+os.hordaland.no
+osen.no
+osteroy.no
+osterøy.no
+ostre-toten.no
+østre-toten.no
+overhalla.no
+ovre-eiker.no
+øvre-eiker.no
+oyer.no
+øyer.no
+oygarden.no
+øygarden.no
+oystre-slidre.no
+øystre-slidre.no
+porsanger.no
+porsangu.no
+porsáŋgu.no
+porsgrunn.no
+radoy.no
+radøy.no
+rakkestad.no
+rana.no
+ruovat.no
+randaberg.no
+rauma.no
+rendalen.no
+rennebu.no
+rennesoy.no
+rennesøy.no
+rindal.no
+ringebu.no
+ringerike.no
+ringsaker.no
+rissa.no
+risor.no
+risør.no
+roan.no
+rollag.no
+rygge.no
+ralingen.no
+rælingen.no
+rodoy.no
+rødøy.no
+romskog.no
+rømskog.no
+roros.no
+røros.no
+rost.no
+røst.no
+royken.no
+røyken.no
+royrvik.no
+røyrvik.no
+rade.no
+råde.no
+salangen.no
+siellak.no
+saltdal.no
+salat.no
+sálát.no
+sálat.no
+samnanger.no
+sande.more-og-romsdal.no
+sande.møre-og-romsdal.no
+sande.vestfold.no
+sandefjord.no
+sandnes.no
+sandoy.no
+sandøy.no
+sarpsborg.no
+sauda.no
+sauherad.no
+sel.no
+selbu.no
+selje.no
+seljord.no
+sigdal.no
+siljan.no
+sirdal.no
+skaun.no
+skedsmo.no
+ski.no
+skien.no
+skiptvet.no
+skjervoy.no
+skjervøy.no
+skierva.no
+skiervá.no
+skjak.no
+skjåk.no
+skodje.no
+skanland.no
+skånland.no
+skanit.no
+skánit.no
+smola.no
+smøla.no
+snillfjord.no
+snasa.no
+snåsa.no
+snoasa.no
+snaase.no
+snåase.no
+sogndal.no
+sokndal.no
+sola.no
+solund.no
+songdalen.no
+sortland.no
+spydeberg.no
+stange.no
+stavanger.no
+steigen.no
+steinkjer.no
+stjordal.no
+stjørdal.no
+stokke.no
+stor-elvdal.no
+stord.no
+stordal.no
+storfjord.no
+omasvuotna.no
+strand.no
+stranda.no
+stryn.no
+sula.no
+suldal.no
+sund.no
+sunndal.no
+surnadal.no
+sveio.no
+svelvik.no
+sykkylven.no
+sogne.no
+søgne.no
+somna.no
+sømna.no
+sondre-land.no
+søndre-land.no
+sor-aurdal.no
+sør-aurdal.no
+sor-fron.no
+sør-fron.no
+sor-odal.no
+sør-odal.no
+sor-varanger.no
+sør-varanger.no
+matta-varjjat.no
+mátta-várjjat.no
+sorfold.no
+sørfold.no
+sorreisa.no
+sørreisa.no
+sorum.no
+sørum.no
+tana.no
+deatnu.no
+time.no
+tingvoll.no
+tinn.no
+tjeldsund.no
+dielddanuorri.no
+tjome.no
+tjøme.no
+tokke.no
+tolga.no
+torsken.no
+tranoy.no
+tranøy.no
+tromso.no
+tromsø.no
+tromsa.no
+romsa.no
+trondheim.no
+troandin.no
+trysil.no
+trana.no
+træna.no
+trogstad.no
+trøgstad.no
+tvedestrand.no
+tydal.no
+tynset.no
+tysfjord.no
+divtasvuodna.no
+divttasvuotna.no
+tysnes.no
+tysvar.no
+tysvær.no
+tonsberg.no
+tønsberg.no
+ullensaker.no
+ullensvang.no
+ulvik.no
+utsira.no
+vadso.no
+vadsø.no
+cahcesuolo.no
+čáhcesuolo.no
+vaksdal.no
+valle.no
+vang.no
+vanylven.no
+vardo.no
+vardø.no
+varggat.no
+várggát.no
+vefsn.no
+vaapste.no
+vega.no
+vegarshei.no
+vegårshei.no
+vennesla.no
+verdal.no
+verran.no
+vestby.no
+vestnes.no
+vestre-slidre.no
+vestre-toten.no
+vestvagoy.no
+vestvågøy.no
+vevelstad.no
+vik.no
+vikna.no
+vindafjord.no
+volda.no
+voss.no
+varoy.no
+værøy.no
+vagan.no
+vågan.no
+voagat.no
+vagsoy.no
+vågsøy.no
+vaga.no
+vågå.no
+valer.ostfold.no
+våler.østfold.no
+valer.hedmark.no
+våler.hedmark.no
+
+// np : http://www.mos.com.np/register.html
+*.np
+
+// nr : http://cenpac.net.nr/dns/index.html
+// Submitted by registry <technician@cenpac.net.nr>
+nr
+biz.nr
+info.nr
+gov.nr
+edu.nr
+org.nr
+net.nr
+com.nr
+
+// nu : https://en.wikipedia.org/wiki/.nu
+nu
+
+// nz : https://en.wikipedia.org/wiki/.nz
+// Submitted by registry <jay@nzrs.net.nz>
+nz
+ac.nz
+co.nz
+cri.nz
+geek.nz
+gen.nz
+govt.nz
+health.nz
+iwi.nz
+kiwi.nz
+maori.nz
+mil.nz
+māori.nz
+net.nz
+org.nz
+parliament.nz
+school.nz
+
+// om : https://en.wikipedia.org/wiki/.om
+om
+co.om
+com.om
+edu.om
+gov.om
+med.om
+museum.om
+net.om
+org.om
+pro.om
+
+// onion : https://tools.ietf.org/html/rfc7686
+onion
+
+// org : https://en.wikipedia.org/wiki/.org
+org
+
+// pa : http://www.nic.pa/
+// Some additional second level "domains" resolve directly as hostnames, such as
+// pannet.pa, so we add a rule for "pa".
+pa
+ac.pa
+gob.pa
+com.pa
+org.pa
+sld.pa
+edu.pa
+net.pa
+ing.pa
+abo.pa
+med.pa
+nom.pa
+
+// pe : https://www.nic.pe/InformeFinalComision.pdf
+pe
+edu.pe
+gob.pe
+nom.pe
+mil.pe
+org.pe
+com.pe
+net.pe
+
+// pf : http://www.gobin.info/domainname/formulaire-pf.pdf
+pf
+com.pf
+org.pf
+edu.pf
+
+// pg : https://en.wikipedia.org/wiki/.pg
+*.pg
+
+// ph : http://www.domains.ph/FAQ2.asp
+// Submitted by registry <jed@email.com.ph>
+ph
+com.ph
+net.ph
+org.ph
+gov.ph
+edu.ph
+ngo.ph
+mil.ph
+i.ph
+
+// pk : http://pk5.pknic.net.pk/pk5/msgNamepk.PK
+pk
+com.pk
+net.pk
+edu.pk
+org.pk
+fam.pk
+biz.pk
+web.pk
+gov.pk
+gob.pk
+gok.pk
+gon.pk
+gop.pk
+gos.pk
+info.pk
+
+// pl http://www.dns.pl/english/index.html
+// Submitted by registry
+pl
+com.pl
+net.pl
+org.pl
+// pl functional domains (http://www.dns.pl/english/index.html)
+aid.pl
+agro.pl
+atm.pl
+auto.pl
+biz.pl
+edu.pl
+gmina.pl
+gsm.pl
+info.pl
+mail.pl
+miasta.pl
+media.pl
+mil.pl
+nieruchomosci.pl
+nom.pl
+pc.pl
+powiat.pl
+priv.pl
+realestate.pl
+rel.pl
+sex.pl
+shop.pl
+sklep.pl
+sos.pl
+szkola.pl
+targi.pl
+tm.pl
+tourism.pl
+travel.pl
+turystyka.pl
+// Government domains
+gov.pl
+ap.gov.pl
+ic.gov.pl
+is.gov.pl
+us.gov.pl
+kmpsp.gov.pl
+kppsp.gov.pl
+kwpsp.gov.pl
+psp.gov.pl
+wskr.gov.pl
+kwp.gov.pl
+mw.gov.pl
+ug.gov.pl
+um.gov.pl
+umig.gov.pl
+ugim.gov.pl
+upow.gov.pl
+uw.gov.pl
+starostwo.gov.pl
+pa.gov.pl
+po.gov.pl
+psse.gov.pl
+pup.gov.pl
+rzgw.gov.pl
+sa.gov.pl
+so.gov.pl
+sr.gov.pl
+wsa.gov.pl
+sko.gov.pl
+uzs.gov.pl
+wiih.gov.pl
+winb.gov.pl
+pinb.gov.pl
+wios.gov.pl
+witd.gov.pl
+wzmiuw.gov.pl
+piw.gov.pl
+wiw.gov.pl
+griw.gov.pl
+wif.gov.pl
+oum.gov.pl
+sdn.gov.pl
+zp.gov.pl
+uppo.gov.pl
+mup.gov.pl
+wuoz.gov.pl
+konsulat.gov.pl
+oirm.gov.pl
+// pl regional domains (http://www.dns.pl/english/index.html)
+augustow.pl
+babia-gora.pl
+bedzin.pl
+beskidy.pl
+bialowieza.pl
+bialystok.pl
+bielawa.pl
+bieszczady.pl
+boleslawiec.pl
+bydgoszcz.pl
+bytom.pl
+cieszyn.pl
+czeladz.pl
+czest.pl
+dlugoleka.pl
+elblag.pl
+elk.pl
+glogow.pl
+gniezno.pl
+gorlice.pl
+grajewo.pl
+ilawa.pl
+jaworzno.pl
+jelenia-gora.pl
+jgora.pl
+kalisz.pl
+kazimierz-dolny.pl
+karpacz.pl
+kartuzy.pl
+kaszuby.pl
+katowice.pl
+kepno.pl
+ketrzyn.pl
+klodzko.pl
+kobierzyce.pl
+kolobrzeg.pl
+konin.pl
+konskowola.pl
+kutno.pl
+lapy.pl
+lebork.pl
+legnica.pl
+lezajsk.pl
+limanowa.pl
+lomza.pl
+lowicz.pl
+lubin.pl
+lukow.pl
+malbork.pl
+malopolska.pl
+mazowsze.pl
+mazury.pl
+mielec.pl
+mielno.pl
+mragowo.pl
+naklo.pl
+nowaruda.pl
+nysa.pl
+olawa.pl
+olecko.pl
+olkusz.pl
+olsztyn.pl
+opoczno.pl
+opole.pl
+ostroda.pl
+ostroleka.pl
+ostrowiec.pl
+ostrowwlkp.pl
+pila.pl
+pisz.pl
+podhale.pl
+podlasie.pl
+polkowice.pl
+pomorze.pl
+pomorskie.pl
+prochowice.pl
+pruszkow.pl
+przeworsk.pl
+pulawy.pl
+radom.pl
+rawa-maz.pl
+rybnik.pl
+rzeszow.pl
+sanok.pl
+sejny.pl
+slask.pl
+slupsk.pl
+sosnowiec.pl
+stalowa-wola.pl
+skoczow.pl
+starachowice.pl
+stargard.pl
+suwalki.pl
+swidnica.pl
+swiebodzin.pl
+swinoujscie.pl
+szczecin.pl
+szczytno.pl
+tarnobrzeg.pl
+tgory.pl
+turek.pl
+tychy.pl
+ustka.pl
+walbrzych.pl
+warmia.pl
+warszawa.pl
+waw.pl
+wegrow.pl
+wielun.pl
+wlocl.pl
+wloclawek.pl
+wodzislaw.pl
+wolomin.pl
+wroclaw.pl
+zachpomor.pl
+zagan.pl
+zarow.pl
+zgora.pl
+zgorzelec.pl
+
+// pm : http://www.afnic.fr/medias/documents/AFNIC-naming-policy2012.pdf
+pm
+
+// pn : http://www.government.pn/PnRegistry/policies.htm
+pn
+gov.pn
+co.pn
+org.pn
+edu.pn
+net.pn
+
+// post : https://en.wikipedia.org/wiki/.post
+post
+
+// pr : http://www.nic.pr/index.asp?f=1
+pr
+com.pr
+net.pr
+org.pr
+gov.pr
+edu.pr
+isla.pr
+pro.pr
+biz.pr
+info.pr
+name.pr
+// these aren't mentioned on nic.pr, but on https://en.wikipedia.org/wiki/.pr
+est.pr
+prof.pr
+ac.pr
+
+// pro : http://registry.pro/get-pro
+pro
+aaa.pro
+aca.pro
+acct.pro
+avocat.pro
+bar.pro
+cpa.pro
+eng.pro
+jur.pro
+law.pro
+med.pro
+recht.pro
+
+// ps : https://en.wikipedia.org/wiki/.ps
+// http://www.nic.ps/registration/policy.html#reg
+ps
+edu.ps
+gov.ps
+sec.ps
+plo.ps
+com.ps
+org.ps
+net.ps
+
+// pt : http://online.dns.pt/dns/start_dns
+pt
+net.pt
+gov.pt
+org.pt
+edu.pt
+int.pt
+publ.pt
+com.pt
+nome.pt
+
+// pw : https://en.wikipedia.org/wiki/.pw
+pw
+co.pw
+ne.pw
+or.pw
+ed.pw
+go.pw
+belau.pw
+
+// py : http://www.nic.py/pautas.html#seccion_9
+// Submitted by registry
+py
+com.py
+coop.py
+edu.py
+gov.py
+mil.py
+net.py
+org.py
+
+// qa : http://domains.qa/en/
+qa
+com.qa
+edu.qa
+gov.qa
+mil.qa
+name.qa
+net.qa
+org.qa
+sch.qa
+
+// re : http://www.afnic.re/obtenir/chartes/nommage-re/annexe-descriptifs
+re
+asso.re
+com.re
+nom.re
+
+// ro : http://www.rotld.ro/
+ro
+arts.ro
+com.ro
+firm.ro
+info.ro
+nom.ro
+nt.ro
+org.ro
+rec.ro
+store.ro
+tm.ro
+www.ro
+
+// rs : https://www.rnids.rs/en/domains/national-domains
+rs
+ac.rs
+co.rs
+edu.rs
+gov.rs
+in.rs
+org.rs
+
+// ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
+ru
+
+// rw : https://www.ricta.org.rw/sites/default/files/resources/registry_registrar_contract_0.pdf
+rw
+ac.rw
+co.rw
+coop.rw
+gov.rw
+mil.rw
+net.rw
+org.rw
+
+// sa : http://www.nic.net.sa/
+sa
+com.sa
+net.sa
+org.sa
+gov.sa
+med.sa
+pub.sa
+edu.sa
+sch.sa
+
+// sb : http://www.sbnic.net.sb/
+// Submitted by registry <lee.humphries@telekom.com.sb>
+sb
+com.sb
+edu.sb
+gov.sb
+net.sb
+org.sb
+
+// sc : http://www.nic.sc/
+sc
+com.sc
+gov.sc
+net.sc
+org.sc
+edu.sc
+
+// sd : http://www.isoc.sd/sudanic.isoc.sd/billing_pricing.htm
+// Submitted by registry <admin@isoc.sd>
+sd
+com.sd
+net.sd
+org.sd
+edu.sd
+med.sd
+tv.sd
+gov.sd
+info.sd
+
+// se : https://en.wikipedia.org/wiki/.se
+// Submitted by registry <patrik.wallstrom@iis.se>
+se
+a.se
+ac.se
+b.se
+bd.se
+brand.se
+c.se
+d.se
+e.se
+f.se
+fh.se
+fhsk.se
+fhv.se
+g.se
+h.se
+i.se
+k.se
+komforb.se
+kommunalforbund.se
+komvux.se
+l.se
+lanbib.se
+m.se
+n.se
+naturbruksgymn.se
+o.se
+org.se
+p.se
+parti.se
+pp.se
+press.se
+r.se
+s.se
+t.se
+tm.se
+u.se
+w.se
+x.se
+y.se
+z.se
+
+// sg : http://www.nic.net.sg/page/registration-policies-procedures-and-guidelines
+sg
+com.sg
+net.sg
+org.sg
+gov.sg
+edu.sg
+per.sg
+
+// sh : http://www.nic.sh/registrar.html
+sh
+com.sh
+net.sh
+gov.sh
+org.sh
+mil.sh
+
+// si : https://en.wikipedia.org/wiki/.si
+si
+
+// sj : No registrations at this time.
+// Submitted by registry <jarle@uninett.no>
+sj
+
+// sk : https://en.wikipedia.org/wiki/.sk
+// list of 2nd level domains ?
+sk
+
+// sl : http://www.nic.sl
+// Submitted by registry <adam@neoip.com>
+sl
+com.sl
+net.sl
+edu.sl
+gov.sl
+org.sl
+
+// sm : https://en.wikipedia.org/wiki/.sm
+sm
+
+// sn : https://en.wikipedia.org/wiki/.sn
+sn
+art.sn
+com.sn
+edu.sn
+gouv.sn
+org.sn
+perso.sn
+univ.sn
+
+// so : http://sonic.so/policies/
+so
+com.so
+edu.so
+gov.so
+me.so
+net.so
+org.so
+
+// sr : https://en.wikipedia.org/wiki/.sr
+sr
+
+// ss : https://registry.nic.ss/
+// Submitted by registry <technical@nic.ss>
+ss
+biz.ss
+com.ss
+edu.ss
+gov.ss
+net.ss
+org.ss
+
+// st : http://www.nic.st/html/policyrules/
+st
+co.st
+com.st
+consulado.st
+edu.st
+embaixada.st
+gov.st
+mil.st
+net.st
+org.st
+principe.st
+saotome.st
+store.st
+
+// su : https://en.wikipedia.org/wiki/.su
+su
+
+// sv : http://www.svnet.org.sv/niveldos.pdf
+sv
+com.sv
+edu.sv
+gob.sv
+org.sv
+red.sv
+
+// sx : https://en.wikipedia.org/wiki/.sx
+// Submitted by registry <jcvignes@openregistry.com>
+sx
+gov.sx
+
+// sy : https://en.wikipedia.org/wiki/.sy
+// see also: http://www.gobin.info/domainname/sy.doc
+sy
+edu.sy
+gov.sy
+net.sy
+mil.sy
+com.sy
+org.sy
+
+// sz : https://en.wikipedia.org/wiki/.sz
+// http://www.sispa.org.sz/
+sz
+co.sz
+ac.sz
+org.sz
+
+// tc : https://en.wikipedia.org/wiki/.tc
+tc
+
+// td : https://en.wikipedia.org/wiki/.td
+td
+
+// tel: https://en.wikipedia.org/wiki/.tel
+// http://www.telnic.org/
+tel
+
+// tf : https://en.wikipedia.org/wiki/.tf
+tf
+
+// tg : https://en.wikipedia.org/wiki/.tg
+// http://www.nic.tg/
+tg
+
+// th : https://en.wikipedia.org/wiki/.th
+// Submitted by registry <krit@thains.co.th>
+th
+ac.th
+co.th
+go.th
+in.th
+mi.th
+net.th
+or.th
+
+// tj : http://www.nic.tj/policy.html
+tj
+ac.tj
+biz.tj
+co.tj
+com.tj
+edu.tj
+go.tj
+gov.tj
+int.tj
+mil.tj
+name.tj
+net.tj
+nic.tj
+org.tj
+test.tj
+web.tj
+
+// tk : https://en.wikipedia.org/wiki/.tk
+tk
+
+// tl : https://en.wikipedia.org/wiki/.tl
+tl
+gov.tl
+
+// tm : http://www.nic.tm/local.html
+tm
+com.tm
+co.tm
+org.tm
+net.tm
+nom.tm
+gov.tm
+mil.tm
+edu.tm
+
+// tn : https://en.wikipedia.org/wiki/.tn
+// http://whois.ati.tn/
+tn
+com.tn
+ens.tn
+fin.tn
+gov.tn
+ind.tn
+intl.tn
+nat.tn
+net.tn
+org.tn
+info.tn
+perso.tn
+tourism.tn
+edunet.tn
+rnrt.tn
+rns.tn
+rnu.tn
+mincom.tn
+agrinet.tn
+defense.tn
+turen.tn
+
+// to : https://en.wikipedia.org/wiki/.to
+// Submitted by registry <egullich@colo.to>
+to
+com.to
+gov.to
+net.to
+org.to
+edu.to
+mil.to
+
+// tr : https://nic.tr/
+// https://nic.tr/forms/eng/policies.pdf
+// https://nic.tr/index.php?USRACTN=PRICELST
+tr
+av.tr
+bbs.tr
+bel.tr
+biz.tr
+com.tr
+dr.tr
+edu.tr
+gen.tr
+gov.tr
+info.tr
+mil.tr
+k12.tr
+kep.tr
+name.tr
+net.tr
+org.tr
+pol.tr
+tel.tr
+tsk.tr
+tv.tr
+web.tr
+// Used by Northern Cyprus
+nc.tr
+// Used by government agencies of Northern Cyprus
+gov.nc.tr
+
+// tt : http://www.nic.tt/
+tt
+co.tt
+com.tt
+org.tt
+net.tt
+biz.tt
+info.tt
+pro.tt
+int.tt
+coop.tt
+jobs.tt
+mobi.tt
+travel.tt
+museum.tt
+aero.tt
+name.tt
+gov.tt
+edu.tt
+
+// tv : https://en.wikipedia.org/wiki/.tv
+// Not listing any 2LDs as reserved since none seem to exist in practice,
+// Wikipedia notwithstanding.
+tv
+
+// tw : https://en.wikipedia.org/wiki/.tw
+tw
+edu.tw
+gov.tw
+mil.tw
+com.tw
+net.tw
+org.tw
+idv.tw
+game.tw
+ebiz.tw
+club.tw
+網路.tw
+組織.tw
+商業.tw
+
+// tz : http://www.tznic.or.tz/index.php/domains
+// Submitted by registry <manager@tznic.or.tz>
+tz
+ac.tz
+co.tz
+go.tz
+hotel.tz
+info.tz
+me.tz
+mil.tz
+mobi.tz
+ne.tz
+or.tz
+sc.tz
+tv.tz
+
+// ua : https://hostmaster.ua/policy/?ua
+// Submitted by registry <dk@cctld.ua>
+ua
+// ua 2LD
+com.ua
+edu.ua
+gov.ua
+in.ua
+net.ua
+org.ua
+// ua geographic names
+// https://hostmaster.ua/2ld/
+cherkassy.ua
+cherkasy.ua
+chernigov.ua
+chernihiv.ua
+chernivtsi.ua
+chernovtsy.ua
+ck.ua
+cn.ua
+cr.ua
+crimea.ua
+cv.ua
+dn.ua
+dnepropetrovsk.ua
+dnipropetrovsk.ua
+donetsk.ua
+dp.ua
+if.ua
+ivano-frankivsk.ua
+kh.ua
+kharkiv.ua
+kharkov.ua
+kherson.ua
+khmelnitskiy.ua
+khmelnytskyi.ua
+kiev.ua
+kirovograd.ua
+km.ua
+kr.ua
+krym.ua
+ks.ua
+kv.ua
+kyiv.ua
+lg.ua
+lt.ua
+lugansk.ua
+lutsk.ua
+lv.ua
+lviv.ua
+mk.ua
+mykolaiv.ua
+nikolaev.ua
+od.ua
+odesa.ua
+odessa.ua
+pl.ua
+poltava.ua
+rivne.ua
+rovno.ua
+rv.ua
+sb.ua
+sebastopol.ua
+sevastopol.ua
+sm.ua
+sumy.ua
+te.ua
+ternopil.ua
+uz.ua
+uzhgorod.ua
+vinnica.ua
+vinnytsia.ua
+vn.ua
+volyn.ua
+yalta.ua
+zaporizhzhe.ua
+zaporizhzhia.ua
+zhitomir.ua
+zhytomyr.ua
+zp.ua
+zt.ua
+
+// ug : https://www.registry.co.ug/
+ug
+co.ug
+or.ug
+ac.ug
+sc.ug
+go.ug
+ne.ug
+com.ug
+org.ug
+
+// uk : https://en.wikipedia.org/wiki/.uk
+// Submitted by registry <Michael.Daly@nominet.org.uk>
+uk
+ac.uk
+co.uk
+gov.uk
+ltd.uk
+me.uk
+net.uk
+nhs.uk
+org.uk
+plc.uk
+police.uk
+*.sch.uk
+
+// us : https://en.wikipedia.org/wiki/.us
+us
+dni.us
+fed.us
+isa.us
+kids.us
+nsn.us
+// us geographic names
+ak.us
+al.us
+ar.us
+as.us
+az.us
+ca.us
+co.us
+ct.us
+dc.us
+de.us
+fl.us
+ga.us
+gu.us
+hi.us
+ia.us
+id.us
+il.us
+in.us
+ks.us
+ky.us
+la.us
+ma.us
+md.us
+me.us
+mi.us
+mn.us
+mo.us
+ms.us
+mt.us
+nc.us
+nd.us
+ne.us
+nh.us
+nj.us
+nm.us
+nv.us
+ny.us
+oh.us
+ok.us
+or.us
+pa.us
+pr.us
+ri.us
+sc.us
+sd.us
+tn.us
+tx.us
+ut.us
+vi.us
+vt.us
+va.us
+wa.us
+wi.us
+wv.us
+wy.us
+// The registrar notes several more specific domains available in each state,
+// such as state.*.us, dst.*.us, etc., but resolution of these is somewhat
+// haphazard; in some states these domains resolve as addresses, while in others
+// only subdomains are available, or even nothing at all. We include the
+// most common ones where it's clear that different sites are different
+// entities.
+k12.ak.us
+k12.al.us
+k12.ar.us
+k12.as.us
+k12.az.us
+k12.ca.us
+k12.co.us
+k12.ct.us
+k12.dc.us
+k12.de.us
+k12.fl.us
+k12.ga.us
+k12.gu.us
+// k12.hi.us  Bug 614565 - Hawaii has a state-wide DOE login
+k12.ia.us
+k12.id.us
+k12.il.us
+k12.in.us
+k12.ks.us
+k12.ky.us
+k12.la.us
+k12.ma.us
+k12.md.us
+k12.me.us
+k12.mi.us
+k12.mn.us
+k12.mo.us
+k12.ms.us
+k12.mt.us
+k12.nc.us
+// k12.nd.us  Bug 1028347 - Removed at request of Travis Rosso <trossow@nd.gov>
+k12.ne.us
+k12.nh.us
+k12.nj.us
+k12.nm.us
+k12.nv.us
+k12.ny.us
+k12.oh.us
+k12.ok.us
+k12.or.us
+k12.pa.us
+k12.pr.us
+// k12.ri.us  Removed at request of Kim Cournoyer <netsupport@staff.ri.net>
+k12.sc.us
+// k12.sd.us  Bug 934131 - Removed at request of James Booze <James.Booze@k12.sd.us>
+k12.tn.us
+k12.tx.us
+k12.ut.us
+k12.vi.us
+k12.vt.us
+k12.va.us
+k12.wa.us
+k12.wi.us
+// k12.wv.us  Bug 947705 - Removed at request of Verne Britton <verne@wvnet.edu>
+k12.wy.us
+cc.ak.us
+cc.al.us
+cc.ar.us
+cc.as.us
+cc.az.us
+cc.ca.us
+cc.co.us
+cc.ct.us
+cc.dc.us
+cc.de.us
+cc.fl.us
+cc.ga.us
+cc.gu.us
+cc.hi.us
+cc.ia.us
+cc.id.us
+cc.il.us
+cc.in.us
+cc.ks.us
+cc.ky.us
+cc.la.us
+cc.ma.us
+cc.md.us
+cc.me.us
+cc.mi.us
+cc.mn.us
+cc.mo.us
+cc.ms.us
+cc.mt.us
+cc.nc.us
+cc.nd.us
+cc.ne.us
+cc.nh.us
+cc.nj.us
+cc.nm.us
+cc.nv.us
+cc.ny.us
+cc.oh.us
+cc.ok.us
+cc.or.us
+cc.pa.us
+cc.pr.us
+cc.ri.us
+cc.sc.us
+cc.sd.us
+cc.tn.us
+cc.tx.us
+cc.ut.us
+cc.vi.us
+cc.vt.us
+cc.va.us
+cc.wa.us
+cc.wi.us
+cc.wv.us
+cc.wy.us
+lib.ak.us
+lib.al.us
+lib.ar.us
+lib.as.us
+lib.az.us
+lib.ca.us
+lib.co.us
+lib.ct.us
+lib.dc.us
+// lib.de.us  Issue #243 - Moved to Private section at request of Ed Moore <Ed.Moore@lib.de.us>
+lib.fl.us
+lib.ga.us
+lib.gu.us
+lib.hi.us
+lib.ia.us
+lib.id.us
+lib.il.us
+lib.in.us
+lib.ks.us
+lib.ky.us
+lib.la.us
+lib.ma.us
+lib.md.us
+lib.me.us
+lib.mi.us
+lib.mn.us
+lib.mo.us
+lib.ms.us
+lib.mt.us
+lib.nc.us
+lib.nd.us
+lib.ne.us
+lib.nh.us
+lib.nj.us
+lib.nm.us
+lib.nv.us
+lib.ny.us
+lib.oh.us
+lib.ok.us
+lib.or.us
+lib.pa.us
+lib.pr.us
+lib.ri.us
+lib.sc.us
+lib.sd.us
+lib.tn.us
+lib.tx.us
+lib.ut.us
+lib.vi.us
+lib.vt.us
+lib.va.us
+lib.wa.us
+lib.wi.us
+// lib.wv.us  Bug 941670 - Removed at request of Larry W Arnold <arnold@wvlc.lib.wv.us>
+lib.wy.us
+// k12.ma.us contains school districts in Massachusetts. The 4LDs are
+//  managed independently except for private (PVT), charter (CHTR) and
+//  parochial (PAROCH) schools.  Those are delegated directly to the
+//  5LD operators.   <k12-ma-hostmaster _ at _ rsuc.gweep.net>
+pvt.k12.ma.us
+chtr.k12.ma.us
+paroch.k12.ma.us
+// Merit Network, Inc. maintains the registry for =~ /(k12|cc|lib).mi.us/ and the following
+//    see also: http://domreg.merit.edu
+//    see also: whois -h whois.domreg.merit.edu help
+ann-arbor.mi.us
+cog.mi.us
+dst.mi.us
+eaton.mi.us
+gen.mi.us
+mus.mi.us
+tec.mi.us
+washtenaw.mi.us
+
+// uy : http://www.nic.org.uy/
+uy
+com.uy
+edu.uy
+gub.uy
+mil.uy
+net.uy
+org.uy
+
+// uz : http://www.reg.uz/
+uz
+co.uz
+com.uz
+net.uz
+org.uz
+
+// va : https://en.wikipedia.org/wiki/.va
+va
+
+// vc : https://en.wikipedia.org/wiki/.vc
+// Submitted by registry <kshah@ca.afilias.info>
+vc
+com.vc
+net.vc
+org.vc
+gov.vc
+mil.vc
+edu.vc
+
+// ve : https://registro.nic.ve/
+// Submitted by registry
+ve
+arts.ve
+co.ve
+com.ve
+e12.ve
+edu.ve
+firm.ve
+gob.ve
+gov.ve
+info.ve
+int.ve
+mil.ve
+net.ve
+org.ve
+rec.ve
+store.ve
+tec.ve
+web.ve
+
+// vg : https://en.wikipedia.org/wiki/.vg
+vg
+
+// vi : http://www.nic.vi/newdomainform.htm
+// http://www.nic.vi/Domain_Rules/body_domain_rules.html indicates some other
+// TLDs are "reserved", such as edu.vi and gov.vi, but doesn't actually say they
+// are available for registration (which they do not seem to be).
+vi
+co.vi
+com.vi
+k12.vi
+net.vi
+org.vi
+
+// vn : https://www.dot.vn/vnnic/vnnic/domainregistration.jsp
+vn
+com.vn
+net.vn
+org.vn
+edu.vn
+gov.vn
+int.vn
+ac.vn
+biz.vn
+info.vn
+name.vn
+pro.vn
+health.vn
+
+// vu : https://en.wikipedia.org/wiki/.vu
+// http://www.vunic.vu/
+vu
+com.vu
+edu.vu
+net.vu
+org.vu
+
+// wf : http://www.afnic.fr/medias/documents/AFNIC-naming-policy2012.pdf
+wf
+
+// ws : https://en.wikipedia.org/wiki/.ws
+// http://samoanic.ws/index.dhtml
+ws
+com.ws
+net.ws
+org.ws
+gov.ws
+edu.ws
+
+// yt : http://www.afnic.fr/medias/documents/AFNIC-naming-policy2012.pdf
+yt
+
+// IDN ccTLDs
+// When submitting patches, please maintain a sort by ISO 3166 ccTLD, then
+// U-label, and follow this format:
+// // A-Label ("<Latin renderings>", <language name>[, variant info]) : <ISO 3166 ccTLD>
+// // [sponsoring org]
+// U-Label
+
+// xn--mgbaam7a8h ("Emerat", Arabic) : AE
+// http://nic.ae/english/arabicdomain/rules.jsp
+امارات
+
+// xn--y9a3aq ("hye", Armenian) : AM
+// ISOC AM (operated by .am Registry)
+հայ
+
+// xn--54b7fta0cc ("Bangla", Bangla) : BD
+বাংলা
+
+// xn--90ae ("bg", Bulgarian) : BG
+бг
+
+// xn--90ais ("bel", Belarusian/Russian Cyrillic) : BY
+// Operated by .by registry
+бел
+
+// xn--fiqs8s ("Zhongguo/China", Chinese, Simplified) : CN
+// CNNIC
+// http://cnnic.cn/html/Dir/2005/10/11/3218.htm
+中国
+
+// xn--fiqz9s ("Zhongguo/China", Chinese, Traditional) : CN
+// CNNIC
+// http://cnnic.cn/html/Dir/2005/10/11/3218.htm
+中國
+
+// xn--lgbbat1ad8j ("Algeria/Al Jazair", Arabic) : DZ
+الجزائر
+
+// xn--wgbh1c ("Egypt/Masr", Arabic) : EG
+// http://www.dotmasr.eg/
+مصر
+
+// xn--e1a4c ("eu", Cyrillic) : EU
+// https://eurid.eu
+ею
+
+// xn--qxa6a ("eu", Greek) : EU
+// https://eurid.eu
+ευ
+
+// xn--mgbah1a3hjkrd ("Mauritania", Arabic) : MR
+موريتانيا
+
+// xn--node ("ge", Georgian Mkhedruli) : GE
+გე
+
+// xn--qxam ("el", Greek) : GR
+// Hellenic Ministry of Infrastructure, Transport, and Networks
+ελ
+
+// xn--j6w193g ("Hong Kong", Chinese) : HK
+// https://www.hkirc.hk
+// Submitted by registry <hk.tech@hkirc.hk>
+// https://www.hkirc.hk/content.jsp?id=30#!/34
+香港
+公司.香港
+教育.香港
+政府.香港
+個人.香港
+網絡.香港
+組織.香港
+
+// xn--2scrj9c ("Bharat", Kannada) : IN
+// India
+ಭಾರತ
+
+// xn--3hcrj9c ("Bharat", Oriya) : IN
+// India
+ଭାରତ
+
+// xn--45br5cyl ("Bharatam", Assamese) : IN
+// India
+ভাৰত
+
+// xn--h2breg3eve ("Bharatam", Sanskrit) : IN
+// India
+भारतम्
+
+// xn--h2brj9c8c ("Bharot", Santali) : IN
+// India
+भारोत
+
+// xn--mgbgu82a ("Bharat", Sindhi) : IN
+// India
+ڀارت
+
+// xn--rvc1e0am3e ("Bharatam", Malayalam) : IN
+// India
+ഭാരതം
+
+// xn--h2brj9c ("Bharat", Devanagari) : IN
+// India
+भारत
+
+// xn--mgbbh1a ("Bharat", Kashmiri) : IN
+// India
+بارت
+
+// xn--mgbbh1a71e ("Bharat", Arabic) : IN
+// India
+بھارت
+
+// xn--fpcrj9c3d ("Bharat", Telugu) : IN
+// India
+భారత్
+
+// xn--gecrj9c ("Bharat", Gujarati) : IN
+// India
+ભારત
+
+// xn--s9brj9c ("Bharat", Gurmukhi) : IN
+// India
+ਭਾਰਤ
+
+// xn--45brj9c ("Bharat", Bengali) : IN
+// India
+ভারত
+
+// xn--xkc2dl3a5ee0h ("India", Tamil) : IN
+// India
+இந்தியா
+
+// xn--mgba3a4f16a ("Iran", Persian) : IR
+ایران
+
+// xn--mgba3a4fra ("Iran", Arabic) : IR
+ايران
+
+// xn--mgbtx2b ("Iraq", Arabic) : IQ
+// Communications and Media Commission
+عراق
+
+// xn--mgbayh7gpa ("al-Ordon", Arabic) : JO
+// National Information Technology Center (NITC)
+// Royal Scientific Society, Al-Jubeiha
+الاردن
+
+// xn--3e0b707e ("Republic of Korea", Hangul) : KR
+한국
+
+// xn--80ao21a ("Kaz", Kazakh) : KZ
+қаз
+
+// xn--fzc2c9e2c ("Lanka", Sinhalese-Sinhala) : LK
+// https://nic.lk
+ලංකා
+
+// xn--xkc2al3hye2a ("Ilangai", Tamil) : LK
+// https://nic.lk
+இலங்கை
+
+// xn--mgbc0a9azcg ("Morocco/al-Maghrib", Arabic) : MA
+المغرب
+
+// xn--d1alf ("mkd", Macedonian) : MK
+// MARnet
+мкд
+
+// xn--l1acc ("mon", Mongolian) : MN
+мон
+
+// xn--mix891f ("Macao", Chinese, Traditional) : MO
+// MONIC / HNET Asia (Registry Operator for .mo)
+澳門
+
+// xn--mix082f ("Macao", Chinese, Simplified) : MO
+澳门
+
+// xn--mgbx4cd0ab ("Malaysia", Malay) : MY
+مليسيا
+
+// xn--mgb9awbf ("Oman", Arabic) : OM
+عمان
+
+// xn--mgbai9azgqp6j ("Pakistan", Urdu/Arabic) : PK
+پاکستان
+
+// xn--mgbai9a5eva00b ("Pakistan", Urdu/Arabic, variant) : PK
+پاكستان
+
+// xn--ygbi2ammx ("Falasteen", Arabic) : PS
+// The Palestinian National Internet Naming Authority (PNINA)
+// http://www.pnina.ps
+فلسطين
+
+// xn--90a3ac ("srb", Cyrillic) : RS
+// https://www.rnids.rs/en/domains/national-domains
+срб
+пр.срб
+орг.срб
+обр.срб
+од.срб
+упр.срб
+ак.срб
+
+// xn--p1ai ("rf", Russian-Cyrillic) : RU
+// https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf
+// Submitted by George Georgievsky <gug@cctld.ru>
+рф
+
+// xn--wgbl6a ("Qatar", Arabic) : QA
+// http://www.ict.gov.qa/
+قطر
+
+// xn--mgberp4a5d4ar ("AlSaudiah", Arabic) : SA
+// http://www.nic.net.sa/
+السعودية
+
+// xn--mgberp4a5d4a87g ("AlSaudiah", Arabic, variant)  : SA
+السعودیة
+
+// xn--mgbqly7c0a67fbc ("AlSaudiah", Arabic, variant) : SA
+السعودیۃ
+
+// xn--mgbqly7cvafr ("AlSaudiah", Arabic, variant) : SA
+السعوديه
+
+// xn--mgbpl2fh ("sudan", Arabic) : SD
+// Operated by .sd registry
+سودان
+
+// xn--yfro4i67o Singapore ("Singapore", Chinese) : SG
+新加坡
+
+// xn--clchc0ea0b2g2a9gcd ("Singapore", Tamil) : SG
+சிங்கப்பூர்
+
+// xn--ogbpf8fl ("Syria", Arabic) : SY
+سورية
+
+// xn--mgbtf8fl ("Syria", Arabic, variant) : SY
+سوريا
+
+// xn--o3cw4h ("Thai", Thai) : TH
+// http://www.thnic.co.th
+ไทย
+ศึกษา.ไทย
+ธุรกิจ.ไทย
+รัฐบาล.ไทย
+ทหาร.ไทย
+เน็ต.ไทย
+องค์กร.ไทย
+
+// xn--pgbs0dh ("Tunisia", Arabic) : TN
+// http://nic.tn
+تونس
+
+// xn--kpry57d ("Taiwan", Chinese, Traditional) : TW
+// http://www.twnic.net/english/dn/dn_07a.htm
+台灣
+
+// xn--kprw13d ("Taiwan", Chinese, Simplified) : TW
+// http://www.twnic.net/english/dn/dn_07a.htm
+台湾
+
+// xn--nnx388a ("Taiwan", Chinese, variant) : TW
+臺灣
+
+// xn--j1amh ("ukr", Cyrillic) : UA
+укр
+
+// xn--mgb2ddes ("AlYemen", Arabic) : YE
+اليمن
+
+// xxx : http://icmregistry.com
+xxx
+
+// ye : http://www.y.net.ye/services/domain_name.htm
+*.ye
+
+// za : https://www.zadna.org.za/content/page/domain-information/
+ac.za
+agric.za
+alt.za
+co.za
+edu.za
+gov.za
+grondar.za
+law.za
+mil.za
+net.za
+ngo.za
+nic.za
+nis.za
+nom.za
+org.za
+school.za
+tm.za
+web.za
+
+// zm : https://zicta.zm/
+// Submitted by registry <info@zicta.zm>
+zm
+ac.zm
+biz.zm
+co.zm
+com.zm
+edu.zm
+gov.zm
+info.zm
+mil.zm
+net.zm
+org.zm
+sch.zm
+
+// zw : https://www.potraz.gov.zw/
+// Confirmed by registry <bmtengwa@potraz.gov.zw> 2017-01-25
+zw
+ac.zw
+co.zw
+gov.zw
+mil.zw
+org.zw
+
+
+// newGTLDs
+
+// List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json on 2020-10-06T17:44:42Z
+// This list is auto-generated, don't edit it manually.
+// aaa : 2015-02-26 American Automobile Association, Inc.
+aaa
+
+// aarp : 2015-05-21 AARP
+aarp
+
+// abarth : 2015-07-30 Fiat Chrysler Automobiles N.V.
+abarth
+
+// abb : 2014-10-24 ABB Ltd
+abb
+
+// abbott : 2014-07-24 Abbott Laboratories, Inc.
+abbott
+
+// abbvie : 2015-07-30 AbbVie Inc.
+abbvie
+
+// abc : 2015-07-30 Disney Enterprises, Inc.
+abc
+
+// able : 2015-06-25 Able Inc.
+able
+
+// abogado : 2014-04-24 Minds + Machines Group Limited
+abogado
+
+// abudhabi : 2015-07-30 Abu Dhabi Systems and Information Centre
+abudhabi
+
+// academy : 2013-11-07 Binky Moon, LLC
+academy
+
+// accenture : 2014-08-15 Accenture plc
+accenture
+
+// accountant : 2014-11-20 dot Accountant Limited
+accountant
+
+// accountants : 2014-03-20 Binky Moon, LLC
+accountants
+
+// aco : 2015-01-08 ACO Severin Ahlmann GmbH & Co. KG
+aco
+
+// actor : 2013-12-12 Dog Beach, LLC
+actor
+
+// adac : 2015-07-16 Allgemeiner Deutscher Automobil-Club e.V. (ADAC)
+adac
+
+// ads : 2014-12-04 Charleston Road Registry Inc.
+ads
+
+// adult : 2014-10-16 ICM Registry AD LLC
+adult
+
+// aeg : 2015-03-19 Aktiebolaget Electrolux
+aeg
+
+// aetna : 2015-05-21 Aetna Life Insurance Company
+aetna
+
+// afamilycompany : 2015-07-23 Johnson Shareholdings, Inc.
+afamilycompany
+
+// afl : 2014-10-02 Australian Football League
+afl
+
+// africa : 2014-03-24 ZA Central Registry NPC trading as Registry.Africa
+africa
+
+// agakhan : 2015-04-23 Fondation Aga Khan (Aga Khan Foundation)
+agakhan
+
+// agency : 2013-11-14 Binky Moon, LLC
+agency
+
+// aig : 2014-12-18 American International Group, Inc.
+aig
+
+// airbus : 2015-07-30 Airbus S.A.S.
+airbus
+
+// airforce : 2014-03-06 Dog Beach, LLC
+airforce
+
+// airtel : 2014-10-24 Bharti Airtel Limited
+airtel
+
+// akdn : 2015-04-23 Fondation Aga Khan (Aga Khan Foundation)
+akdn
+
+// alfaromeo : 2015-07-31 Fiat Chrysler Automobiles N.V.
+alfaromeo
+
+// alibaba : 2015-01-15 Alibaba Group Holding Limited
+alibaba
+
+// alipay : 2015-01-15 Alibaba Group Holding Limited
+alipay
+
+// allfinanz : 2014-07-03 Allfinanz Deutsche Vermögensberatung Aktiengesellschaft
+allfinanz
+
+// allstate : 2015-07-31 Allstate Fire and Casualty Insurance Company
+allstate
+
+// ally : 2015-06-18 Ally Financial Inc.
+ally
+
+// alsace : 2014-07-02 Region Grand Est
+alsace
+
+// alstom : 2015-07-30 ALSTOM
+alstom
+
+// amazon : 2019-12-19 Amazon Registry Services, Inc.
+amazon
+
+// americanexpress : 2015-07-31 American Express Travel Related Services Company, Inc.
+americanexpress
+
+// americanfamily : 2015-07-23 AmFam, Inc.
+americanfamily
+
+// amex : 2015-07-31 American Express Travel Related Services Company, Inc.
+amex
+
+// amfam : 2015-07-23 AmFam, Inc.
+amfam
+
+// amica : 2015-05-28 Amica Mutual Insurance Company
+amica
+
+// amsterdam : 2014-07-24 Gemeente Amsterdam
+amsterdam
+
+// analytics : 2014-12-18 Campus IP LLC
+analytics
+
+// android : 2014-08-07 Charleston Road Registry Inc.
+android
+
+// anquan : 2015-01-08 Beijing Qihu Keji Co., Ltd.
+anquan
+
+// anz : 2015-07-31 Australia and New Zealand Banking Group Limited
+anz
+
+// aol : 2015-09-17 Oath Inc.
+aol
+
+// apartments : 2014-12-11 Binky Moon, LLC
+apartments
+
+// app : 2015-05-14 Charleston Road Registry Inc.
+app
+
+// apple : 2015-05-14 Apple Inc.
+apple
+
+// aquarelle : 2014-07-24 Aquarelle.com
+aquarelle
+
+// arab : 2015-11-12 League of Arab States
+arab
+
+// aramco : 2014-11-20 Aramco Services Company
+aramco
+
+// archi : 2014-02-06 Afilias Limited
+archi
+
+// army : 2014-03-06 Dog Beach, LLC
+army
+
+// art : 2016-03-24 UK Creative Ideas Limited
+art
+
+// arte : 2014-12-11 Association Relative à la Télévision Européenne G.E.I.E.
+arte
+
+// asda : 2015-07-31 Wal-Mart Stores, Inc.
+asda
+
+// associates : 2014-03-06 Binky Moon, LLC
+associates
+
+// athleta : 2015-07-30 The Gap, Inc.
+athleta
+
+// attorney : 2014-03-20 Dog Beach, LLC
+attorney
+
+// auction : 2014-03-20 Dog Beach, LLC
+auction
+
+// audi : 2015-05-21 AUDI Aktiengesellschaft
+audi
+
+// audible : 2015-06-25 Amazon Registry Services, Inc.
+audible
+
+// audio : 2014-03-20 UNR Corp.
+audio
+
+// auspost : 2015-08-13 Australian Postal Corporation
+auspost
+
+// author : 2014-12-18 Amazon Registry Services, Inc.
+author
+
+// auto : 2014-11-13 XYZ.COM LLC
+auto
+
+// autos : 2014-01-09 DERAutos, LLC
+autos
+
+// avianca : 2015-01-08 Avianca Holdings S.A.
+avianca
+
+// aws : 2015-06-25 Amazon Registry Services, Inc.
+aws
+
+// axa : 2013-12-19 AXA SA
+axa
+
+// azure : 2014-12-18 Microsoft Corporation
+azure
+
+// baby : 2015-04-09 XYZ.COM LLC
+baby
+
+// baidu : 2015-01-08 Baidu, Inc.
+baidu
+
+// banamex : 2015-07-30 Citigroup Inc.
+banamex
+
+// bananarepublic : 2015-07-31 The Gap, Inc.
+bananarepublic
+
+// band : 2014-06-12 Dog Beach, LLC
+band
+
+// bank : 2014-09-25 fTLD Registry Services LLC
+bank
+
+// bar : 2013-12-12 Punto 2012 Sociedad Anonima Promotora de Inversion de Capital Variable
+bar
+
+// barcelona : 2014-07-24 Municipi de Barcelona
+barcelona
+
+// barclaycard : 2014-11-20 Barclays Bank PLC
+barclaycard
+
+// barclays : 2014-11-20 Barclays Bank PLC
+barclays
+
+// barefoot : 2015-06-11 Gallo Vineyards, Inc.
+barefoot
+
+// bargains : 2013-11-14 Binky Moon, LLC
+bargains
+
+// baseball : 2015-10-29 MLB Advanced Media DH, LLC
+baseball
+
+// basketball : 2015-08-20 Fédération Internationale de Basketball (FIBA)
+basketball
+
+// bauhaus : 2014-04-17 Werkhaus GmbH
+bauhaus
+
+// bayern : 2014-01-23 Bayern Connect GmbH
+bayern
+
+// bbc : 2014-12-18 British Broadcasting Corporation
+bbc
+
+// bbt : 2015-07-23 BB&T Corporation
+bbt
+
+// bbva : 2014-10-02 BANCO BILBAO VIZCAYA ARGENTARIA, S.A.
+bbva
+
+// bcg : 2015-04-02 The Boston Consulting Group, Inc.
+bcg
+
+// bcn : 2014-07-24 Municipi de Barcelona
+bcn
+
+// beats : 2015-05-14 Beats Electronics, LLC
+beats
+
+// beauty : 2015-12-03 XYZ.COM LLC
+beauty
+
+// beer : 2014-01-09 Minds + Machines Group Limited
+beer
+
+// bentley : 2014-12-18 Bentley Motors Limited
+bentley
+
+// berlin : 2013-10-31 dotBERLIN GmbH & Co. KG
+berlin
+
+// best : 2013-12-19 BestTLD Pty Ltd
+best
+
+// bestbuy : 2015-07-31 BBY Solutions, Inc.
+bestbuy
+
+// bet : 2015-05-07 Afilias Limited
+bet
+
+// bharti : 2014-01-09 Bharti Enterprises (Holding) Private Limited
+bharti
+
+// bible : 2014-06-19 American Bible Society
+bible
+
+// bid : 2013-12-19 dot Bid Limited
+bid
+
+// bike : 2013-08-27 Binky Moon, LLC
+bike
+
+// bing : 2014-12-18 Microsoft Corporation
+bing
+
+// bingo : 2014-12-04 Binky Moon, LLC
+bingo
+
+// bio : 2014-03-06 Afilias Limited
+bio
+
+// black : 2014-01-16 Afilias Limited
+black
+
+// blackfriday : 2014-01-16 UNR Corp.
+blackfriday
+
+// blockbuster : 2015-07-30 Dish DBS Corporation
+blockbuster
+
+// blog : 2015-05-14 Knock Knock WHOIS There, LLC
+blog
+
+// bloomberg : 2014-07-17 Bloomberg IP Holdings LLC
+bloomberg
+
+// blue : 2013-11-07 Afilias Limited
+blue
+
+// bms : 2014-10-30 Bristol-Myers Squibb Company
+bms
+
+// bmw : 2014-01-09 Bayerische Motoren Werke Aktiengesellschaft
+bmw
+
+// bnpparibas : 2014-05-29 BNP Paribas
+bnpparibas
+
+// boats : 2014-12-04 DERBoats, LLC
+boats
+
+// boehringer : 2015-07-09 Boehringer Ingelheim International GmbH
+boehringer
+
+// bofa : 2015-07-31 Bank of America Corporation
+bofa
+
+// bom : 2014-10-16 Núcleo de Informação e Coordenação do Ponto BR - NIC.br
+bom
+
+// bond : 2014-06-05 ShortDot SA
+bond
+
+// boo : 2014-01-30 Charleston Road Registry Inc.
+boo
+
+// book : 2015-08-27 Amazon Registry Services, Inc.
+book
+
+// booking : 2015-07-16 Booking.com B.V.
+booking
+
+// bosch : 2015-06-18 Robert Bosch GMBH
+bosch
+
+// bostik : 2015-05-28 Bostik SA
+bostik
+
+// boston : 2015-12-10 Boston TLD Management, LLC
+boston
+
+// bot : 2014-12-18 Amazon Registry Services, Inc.
+bot
+
+// boutique : 2013-11-14 Binky Moon, LLC
+boutique
+
+// box : 2015-11-12 .BOX INC.
+box
+
+// bradesco : 2014-12-18 Banco Bradesco S.A.
+bradesco
+
+// bridgestone : 2014-12-18 Bridgestone Corporation
+bridgestone
+
+// broadway : 2014-12-22 Celebrate Broadway, Inc.
+broadway
+
+// broker : 2014-12-11 Dotbroker Registry Limited
+broker
+
+// brother : 2015-01-29 Brother Industries, Ltd.
+brother
+
+// brussels : 2014-02-06 DNS.be vzw
+brussels
+
+// budapest : 2013-11-21 Minds + Machines Group Limited
+budapest
+
+// bugatti : 2015-07-23 Bugatti International SA
+bugatti
+
+// build : 2013-11-07 Plan Bee LLC
+build
+
+// builders : 2013-11-07 Binky Moon, LLC
+builders
+
+// business : 2013-11-07 Binky Moon, LLC
+business
+
+// buy : 2014-12-18 Amazon Registry Services, Inc.
+buy
+
+// buzz : 2013-10-02 DOTSTRATEGY CO.
+buzz
+
+// bzh : 2014-02-27 Association www.bzh
+bzh
+
+// cab : 2013-10-24 Binky Moon, LLC
+cab
+
+// cafe : 2015-02-11 Binky Moon, LLC
+cafe
+
+// cal : 2014-07-24 Charleston Road Registry Inc.
+cal
+
+// call : 2014-12-18 Amazon Registry Services, Inc.
+call
+
+// calvinklein : 2015-07-30 PVH gTLD Holdings LLC
+calvinklein
+
+// cam : 2016-04-21 AC Webconnecting Holding B.V.
+cam
+
+// camera : 2013-08-27 Binky Moon, LLC
+camera
+
+// camp : 2013-11-07 Binky Moon, LLC
+camp
+
+// cancerresearch : 2014-05-15 Australian Cancer Research Foundation
+cancerresearch
+
+// canon : 2014-09-12 Canon Inc.
+canon
+
+// capetown : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
+capetown
+
+// capital : 2014-03-06 Binky Moon, LLC
+capital
+
+// capitalone : 2015-08-06 Capital One Financial Corporation
+capitalone
+
+// car : 2015-01-22 XYZ.COM LLC
+car
+
+// caravan : 2013-12-12 Caravan International, Inc.
+caravan
+
+// cards : 2013-12-05 Binky Moon, LLC
+cards
+
+// care : 2014-03-06 Binky Moon, LLC
+care
+
+// career : 2013-10-09 dotCareer LLC
+career
+
+// careers : 2013-10-02 Binky Moon, LLC
+careers
+
+// cars : 2014-11-13 XYZ.COM LLC
+cars
+
+// casa : 2013-11-21 Minds + Machines Group Limited
+casa
+
+// case : 2015-09-03 CNH Industrial N.V.
+case
+
+// caseih : 2015-09-03 CNH Industrial N.V.
+caseih
+
+// cash : 2014-03-06 Binky Moon, LLC
+cash
+
+// casino : 2014-12-18 Binky Moon, LLC
+casino
+
+// catering : 2013-12-05 Binky Moon, LLC
+catering
+
+// catholic : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+catholic
+
+// cba : 2014-06-26 COMMONWEALTH BANK OF AUSTRALIA
+cba
+
+// cbn : 2014-08-22 The Christian Broadcasting Network, Inc.
+cbn
+
+// cbre : 2015-07-02 CBRE, Inc.
+cbre
+
+// cbs : 2015-08-06 CBS Domains Inc.
+cbs
+
+// ceb : 2015-04-09 The Corporate Executive Board Company
+ceb
+
+// center : 2013-11-07 Binky Moon, LLC
+center
+
+// ceo : 2013-11-07 CEOTLD Pty Ltd
+ceo
+
+// cern : 2014-06-05 European Organization for Nuclear Research ("CERN")
+cern
+
+// cfa : 2014-08-28 CFA Institute
+cfa
+
+// cfd : 2014-12-11 DotCFD Registry Limited
+cfd
+
+// chanel : 2015-04-09 Chanel International B.V.
+chanel
+
+// channel : 2014-05-08 Charleston Road Registry Inc.
+channel
+
+// charity : 2018-04-11 Binky Moon, LLC
+charity
+
+// chase : 2015-04-30 JPMorgan Chase Bank, National Association
+chase
+
+// chat : 2014-12-04 Binky Moon, LLC
+chat
+
+// cheap : 2013-11-14 Binky Moon, LLC
+cheap
+
+// chintai : 2015-06-11 CHINTAI Corporation
+chintai
+
+// christmas : 2013-11-21 UNR Corp.
+christmas
+
+// chrome : 2014-07-24 Charleston Road Registry Inc.
+chrome
+
+// church : 2014-02-06 Binky Moon, LLC
+church
+
+// cipriani : 2015-02-19 Hotel Cipriani Srl
+cipriani
+
+// circle : 2014-12-18 Amazon Registry Services, Inc.
+circle
+
+// cisco : 2014-12-22 Cisco Technology, Inc.
+cisco
+
+// citadel : 2015-07-23 Citadel Domain LLC
+citadel
+
+// citi : 2015-07-30 Citigroup Inc.
+citi
+
+// citic : 2014-01-09 CITIC Group Corporation
+citic
+
+// city : 2014-05-29 Binky Moon, LLC
+city
+
+// cityeats : 2014-12-11 Lifestyle Domain Holdings, Inc.
+cityeats
+
+// claims : 2014-03-20 Binky Moon, LLC
+claims
+
+// cleaning : 2013-12-05 Binky Moon, LLC
+cleaning
+
+// click : 2014-06-05 UNR Corp.
+click
+
+// clinic : 2014-03-20 Binky Moon, LLC
+clinic
+
+// clinique : 2015-10-01 The Estée Lauder Companies Inc.
+clinique
+
+// clothing : 2013-08-27 Binky Moon, LLC
+clothing
+
+// cloud : 2015-04-16 Aruba PEC S.p.A.
+cloud
+
+// club : 2013-11-08 .CLUB DOMAINS, LLC
+club
+
+// clubmed : 2015-06-25 Club Méditerranée S.A.
+clubmed
+
+// coach : 2014-10-09 Binky Moon, LLC
+coach
+
+// codes : 2013-10-31 Binky Moon, LLC
+codes
+
+// coffee : 2013-10-17 Binky Moon, LLC
+coffee
+
+// college : 2014-01-16 XYZ.COM LLC
+college
+
+// cologne : 2014-02-05 dotKoeln GmbH
+cologne
+
+// comcast : 2015-07-23 Comcast IP Holdings I, LLC
+comcast
+
+// commbank : 2014-06-26 COMMONWEALTH BANK OF AUSTRALIA
+commbank
+
+// community : 2013-12-05 Binky Moon, LLC
+community
+
+// company : 2013-11-07 Binky Moon, LLC
+company
+
+// compare : 2015-10-08 Registry Services, LLC
+compare
+
+// computer : 2013-10-24 Binky Moon, LLC
+computer
+
+// comsec : 2015-01-08 VeriSign, Inc.
+comsec
+
+// condos : 2013-12-05 Binky Moon, LLC
+condos
+
+// construction : 2013-09-16 Binky Moon, LLC
+construction
+
+// consulting : 2013-12-05 Dog Beach, LLC
+consulting
+
+// contact : 2015-01-08 Dog Beach, LLC
+contact
+
+// contractors : 2013-09-10 Binky Moon, LLC
+contractors
+
+// cooking : 2013-11-21 Minds + Machines Group Limited
+cooking
+
+// cookingchannel : 2015-07-02 Lifestyle Domain Holdings, Inc.
+cookingchannel
+
+// cool : 2013-11-14 Binky Moon, LLC
+cool
+
+// corsica : 2014-09-25 Collectivité de Corse
+corsica
+
+// country : 2013-12-19 DotCountry LLC
+country
+
+// coupon : 2015-02-26 Amazon Registry Services, Inc.
+coupon
+
+// coupons : 2015-03-26 Binky Moon, LLC
+coupons
+
+// courses : 2014-12-04 OPEN UNIVERSITIES AUSTRALIA PTY LTD
+courses
+
+// cpa : 2019-06-10 American Institute of Certified Public Accountants
+cpa
+
+// credit : 2014-03-20 Binky Moon, LLC
+credit
+
+// creditcard : 2014-03-20 Binky Moon, LLC
+creditcard
+
+// creditunion : 2015-01-22 CUNA Performance Resources, LLC
+creditunion
+
+// cricket : 2014-10-09 dot Cricket Limited
+cricket
+
+// crown : 2014-10-24 Crown Equipment Corporation
+crown
+
+// crs : 2014-04-03 Federated Co-operatives Limited
+crs
+
+// cruise : 2015-12-10 Viking River Cruises (Bermuda) Ltd.
+cruise
+
+// cruises : 2013-12-05 Binky Moon, LLC
+cruises
+
+// csc : 2014-09-25 Alliance-One Services, Inc.
+csc
+
+// cuisinella : 2014-04-03 SCHMIDT GROUPE S.A.S.
+cuisinella
+
+// cymru : 2014-05-08 Nominet UK
+cymru
+
+// cyou : 2015-01-22 ShortDot SA
+cyou
+
+// dabur : 2014-02-06 Dabur India Limited
+dabur
+
+// dad : 2014-01-23 Charleston Road Registry Inc.
+dad
+
+// dance : 2013-10-24 Dog Beach, LLC
+dance
+
+// data : 2016-06-02 Dish DBS Corporation
+data
+
+// date : 2014-11-20 dot Date Limited
+date
+
+// dating : 2013-12-05 Binky Moon, LLC
+dating
+
+// datsun : 2014-03-27 NISSAN MOTOR CO., LTD.
+datsun
+
+// day : 2014-01-30 Charleston Road Registry Inc.
+day
+
+// dclk : 2014-11-20 Charleston Road Registry Inc.
+dclk
+
+// dds : 2015-05-07 Minds + Machines Group Limited
+dds
+
+// deal : 2015-06-25 Amazon Registry Services, Inc.
+deal
+
+// dealer : 2014-12-22 Intercap Registry Inc.
+dealer
+
+// deals : 2014-05-22 Binky Moon, LLC
+deals
+
+// degree : 2014-03-06 Dog Beach, LLC
+degree
+
+// delivery : 2014-09-11 Binky Moon, LLC
+delivery
+
+// dell : 2014-10-24 Dell Inc.
+dell
+
+// deloitte : 2015-07-31 Deloitte Touche Tohmatsu
+deloitte
+
+// delta : 2015-02-19 Delta Air Lines, Inc.
+delta
+
+// democrat : 2013-10-24 Dog Beach, LLC
+democrat
+
+// dental : 2014-03-20 Binky Moon, LLC
+dental
+
+// dentist : 2014-03-20 Dog Beach, LLC
+dentist
+
+// desi : 2013-11-14 Desi Networks LLC
+desi
+
+// design : 2014-11-07 Top Level Design, LLC
+design
+
+// dev : 2014-10-16 Charleston Road Registry Inc.
+dev
+
+// dhl : 2015-07-23 Deutsche Post AG
+dhl
+
+// diamonds : 2013-09-22 Binky Moon, LLC
+diamonds
+
+// diet : 2014-06-26 UNR Corp.
+diet
+
+// digital : 2014-03-06 Binky Moon, LLC
+digital
+
+// direct : 2014-04-10 Binky Moon, LLC
+direct
+
+// directory : 2013-09-20 Binky Moon, LLC
+directory
+
+// discount : 2014-03-06 Binky Moon, LLC
+discount
+
+// discover : 2015-07-23 Discover Financial Services
+discover
+
+// dish : 2015-07-30 Dish DBS Corporation
+dish
+
+// diy : 2015-11-05 Lifestyle Domain Holdings, Inc.
+diy
+
+// dnp : 2013-12-13 Dai Nippon Printing Co., Ltd.
+dnp
+
+// docs : 2014-10-16 Charleston Road Registry Inc.
+docs
+
+// doctor : 2016-06-02 Binky Moon, LLC
+doctor
+
+// dog : 2014-12-04 Binky Moon, LLC
+dog
+
+// domains : 2013-10-17 Binky Moon, LLC
+domains
+
+// dot : 2015-05-21 Dish DBS Corporation
+dot
+
+// download : 2014-11-20 dot Support Limited
+download
+
+// drive : 2015-03-05 Charleston Road Registry Inc.
+drive
+
+// dtv : 2015-06-04 Dish DBS Corporation
+dtv
+
+// dubai : 2015-01-01 Dubai Smart Government Department
+dubai
+
+// duck : 2015-07-23 Johnson Shareholdings, Inc.
+duck
+
+// dunlop : 2015-07-02 The Goodyear Tire & Rubber Company
+dunlop
+
+// dupont : 2015-06-25 E. I. du Pont de Nemours and Company
+dupont
+
+// durban : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
+durban
+
+// dvag : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
+dvag
+
+// dvr : 2016-05-26 DISH Technologies L.L.C.
+dvr
+
+// earth : 2014-12-04 Interlink Co., Ltd.
+earth
+
+// eat : 2014-01-23 Charleston Road Registry Inc.
+eat
+
+// eco : 2016-07-08 Big Room Inc.
+eco
+
+// edeka : 2014-12-18 EDEKA Verband kaufmännischer Genossenschaften e.V.
+edeka
+
+// education : 2013-11-07 Binky Moon, LLC
+education
+
+// email : 2013-10-31 Binky Moon, LLC
+email
+
+// emerck : 2014-04-03 Merck KGaA
+emerck
+
+// energy : 2014-09-11 Binky Moon, LLC
+energy
+
+// engineer : 2014-03-06 Dog Beach, LLC
+engineer
+
+// engineering : 2014-03-06 Binky Moon, LLC
+engineering
+
+// enterprises : 2013-09-20 Binky Moon, LLC
+enterprises
+
+// epson : 2014-12-04 Seiko Epson Corporation
+epson
+
+// equipment : 2013-08-27 Binky Moon, LLC
+equipment
+
+// ericsson : 2015-07-09 Telefonaktiebolaget L M Ericsson
+ericsson
+
+// erni : 2014-04-03 ERNI Group Holding AG
+erni
+
+// esq : 2014-05-08 Charleston Road Registry Inc.
+esq
+
+// estate : 2013-08-27 Binky Moon, LLC
+estate
+
+// etisalat : 2015-09-03 Emirates Telecommunications Corporation (trading as Etisalat)
+etisalat
+
+// eurovision : 2014-04-24 European Broadcasting Union (EBU)
+eurovision
+
+// eus : 2013-12-12 Puntueus Fundazioa
+eus
+
+// events : 2013-12-05 Binky Moon, LLC
+events
+
+// exchange : 2014-03-06 Binky Moon, LLC
+exchange
+
+// expert : 2013-11-21 Binky Moon, LLC
+expert
+
+// exposed : 2013-12-05 Binky Moon, LLC
+exposed
+
+// express : 2015-02-11 Binky Moon, LLC
+express
+
+// extraspace : 2015-05-14 Extra Space Storage LLC
+extraspace
+
+// fage : 2014-12-18 Fage International S.A.
+fage
+
+// fail : 2014-03-06 Binky Moon, LLC
+fail
+
+// fairwinds : 2014-11-13 FairWinds Partners, LLC
+fairwinds
+
+// faith : 2014-11-20 dot Faith Limited
+faith
+
+// family : 2015-04-02 Dog Beach, LLC
+family
+
+// fan : 2014-03-06 Dog Beach, LLC
+fan
+
+// fans : 2014-11-07 ZDNS International Limited
+fans
+
+// farm : 2013-11-07 Binky Moon, LLC
+farm
+
+// farmers : 2015-07-09 Farmers Insurance Exchange
+farmers
+
+// fashion : 2014-07-03 Minds + Machines Group Limited
+fashion
+
+// fast : 2014-12-18 Amazon Registry Services, Inc.
+fast
+
+// fedex : 2015-08-06 Federal Express Corporation
+fedex
+
+// feedback : 2013-12-19 Top Level Spectrum, Inc.
+feedback
+
+// ferrari : 2015-07-31 Fiat Chrysler Automobiles N.V.
+ferrari
+
+// ferrero : 2014-12-18 Ferrero Trading Lux S.A.
+ferrero
+
+// fiat : 2015-07-31 Fiat Chrysler Automobiles N.V.
+fiat
+
+// fidelity : 2015-07-30 Fidelity Brokerage Services LLC
+fidelity
+
+// fido : 2015-08-06 Rogers Communications Canada Inc.
+fido
+
+// film : 2015-01-08 Motion Picture Domain Registry Pty Ltd
+film
+
+// final : 2014-10-16 Núcleo de Informação e Coordenação do Ponto BR - NIC.br
+final
+
+// finance : 2014-03-20 Binky Moon, LLC
+finance
+
+// financial : 2014-03-06 Binky Moon, LLC
+financial
+
+// fire : 2015-06-25 Amazon Registry Services, Inc.
+fire
+
+// firestone : 2014-12-18 Bridgestone Licensing Services, Inc
+firestone
+
+// firmdale : 2014-03-27 Firmdale Holdings Limited
+firmdale
+
+// fish : 2013-12-12 Binky Moon, LLC
+fish
+
+// fishing : 2013-11-21 Minds + Machines Group Limited
+fishing
+
+// fit : 2014-11-07 Minds + Machines Group Limited
+fit
+
+// fitness : 2014-03-06 Binky Moon, LLC
+fitness
+
+// flickr : 2015-04-02 Flickr, Inc.
+flickr
+
+// flights : 2013-12-05 Binky Moon, LLC
+flights
+
+// flir : 2015-07-23 FLIR Systems, Inc.
+flir
+
+// florist : 2013-11-07 Binky Moon, LLC
+florist
+
+// flowers : 2014-10-09 UNR Corp.
+flowers
+
+// fly : 2014-05-08 Charleston Road Registry Inc.
+fly
+
+// foo : 2014-01-23 Charleston Road Registry Inc.
+foo
+
+// food : 2016-04-21 Lifestyle Domain Holdings, Inc.
+food
+
+// foodnetwork : 2015-07-02 Lifestyle Domain Holdings, Inc.
+foodnetwork
+
+// football : 2014-12-18 Binky Moon, LLC
+football
+
+// ford : 2014-11-13 Ford Motor Company
+ford
+
+// forex : 2014-12-11 Dotforex Registry Limited
+forex
+
+// forsale : 2014-05-22 Dog Beach, LLC
+forsale
+
+// forum : 2015-04-02 Fegistry, LLC
+forum
+
+// foundation : 2013-12-05 Binky Moon, LLC
+foundation
+
+// fox : 2015-09-11 FOX Registry, LLC
+fox
+
+// free : 2015-12-10 Amazon Registry Services, Inc.
+free
+
+// fresenius : 2015-07-30 Fresenius Immobilien-Verwaltungs-GmbH
+fresenius
+
+// frl : 2014-05-15 FRLregistry B.V.
+frl
+
+// frogans : 2013-12-19 OP3FT
+frogans
+
+// frontdoor : 2015-07-02 Lifestyle Domain Holdings, Inc.
+frontdoor
+
+// frontier : 2015-02-05 Frontier Communications Corporation
+frontier
+
+// ftr : 2015-07-16 Frontier Communications Corporation
+ftr
+
+// fujitsu : 2015-07-30 Fujitsu Limited
+fujitsu
+
+// fujixerox : 2015-07-23 Xerox DNHC LLC
+fujixerox
+
+// fun : 2016-01-14 DotSpace Inc.
+fun
+
+// fund : 2014-03-20 Binky Moon, LLC
+fund
+
+// furniture : 2014-03-20 Binky Moon, LLC
+furniture
+
+// futbol : 2013-09-20 Dog Beach, LLC
+futbol
+
+// fyi : 2015-04-02 Binky Moon, LLC
+fyi
+
+// gal : 2013-11-07 Asociación puntoGAL
+gal
+
+// gallery : 2013-09-13 Binky Moon, LLC
+gallery
+
+// gallo : 2015-06-11 Gallo Vineyards, Inc.
+gallo
+
+// gallup : 2015-02-19 Gallup, Inc.
+gallup
+
+// game : 2015-05-28 UNR Corp.
+game
+
+// games : 2015-05-28 Dog Beach, LLC
+games
+
+// gap : 2015-07-31 The Gap, Inc.
+gap
+
+// garden : 2014-06-26 Minds + Machines Group Limited
+garden
+
+// gay : 2019-05-23 Top Level Design, LLC
+gay
+
+// gbiz : 2014-07-17 Charleston Road Registry Inc.
+gbiz
+
+// gdn : 2014-07-31 Joint Stock Company "Navigation-information systems"
+gdn
+
+// gea : 2014-12-04 GEA Group Aktiengesellschaft
+gea
+
+// gent : 2014-01-23 COMBELL NV
+gent
+
+// genting : 2015-03-12 Resorts World Inc Pte. Ltd.
+genting
+
+// george : 2015-07-31 Wal-Mart Stores, Inc.
+george
+
+// ggee : 2014-01-09 GMO Internet, Inc.
+ggee
+
+// gift : 2013-10-17 DotGift, LLC
+gift
+
+// gifts : 2014-07-03 Binky Moon, LLC
+gifts
+
+// gives : 2014-03-06 Dog Beach, LLC
+gives
+
+// giving : 2014-11-13 Giving Limited
+giving
+
+// glade : 2015-07-23 Johnson Shareholdings, Inc.
+glade
+
+// glass : 2013-11-07 Binky Moon, LLC
+glass
+
+// gle : 2014-07-24 Charleston Road Registry Inc.
+gle
+
+// global : 2014-04-17 Dot Global Domain Registry Limited
+global
+
+// globo : 2013-12-19 Globo Comunicação e Participações S.A
+globo
+
+// gmail : 2014-05-01 Charleston Road Registry Inc.
+gmail
+
+// gmbh : 2016-01-29 Binky Moon, LLC
+gmbh
+
+// gmo : 2014-01-09 GMO Internet, Inc.
+gmo
+
+// gmx : 2014-04-24 1&1 Mail & Media GmbH
+gmx
+
+// godaddy : 2015-07-23 Go Daddy East, LLC
+godaddy
+
+// gold : 2015-01-22 Binky Moon, LLC
+gold
+
+// goldpoint : 2014-11-20 YODOBASHI CAMERA CO.,LTD.
+goldpoint
+
+// golf : 2014-12-18 Binky Moon, LLC
+golf
+
+// goo : 2014-12-18 NTT Resonant Inc.
+goo
+
+// goodyear : 2015-07-02 The Goodyear Tire & Rubber Company
+goodyear
+
+// goog : 2014-11-20 Charleston Road Registry Inc.
+goog
+
+// google : 2014-07-24 Charleston Road Registry Inc.
+google
+
+// gop : 2014-01-16 Republican State Leadership Committee, Inc.
+gop
+
+// got : 2014-12-18 Amazon Registry Services, Inc.
+got
+
+// grainger : 2015-05-07 Grainger Registry Services, LLC
+grainger
+
+// graphics : 2013-09-13 Binky Moon, LLC
+graphics
+
+// gratis : 2014-03-20 Binky Moon, LLC
+gratis
+
+// green : 2014-05-08 Afilias Limited
+green
+
+// gripe : 2014-03-06 Binky Moon, LLC
+gripe
+
+// grocery : 2016-06-16 Wal-Mart Stores, Inc.
+grocery
+
+// group : 2014-08-15 Binky Moon, LLC
+group
+
+// guardian : 2015-07-30 The Guardian Life Insurance Company of America
+guardian
+
+// gucci : 2014-11-13 Guccio Gucci S.p.a.
+gucci
+
+// guge : 2014-08-28 Charleston Road Registry Inc.
+guge
+
+// guide : 2013-09-13 Binky Moon, LLC
+guide
+
+// guitars : 2013-11-14 UNR Corp.
+guitars
+
+// guru : 2013-08-27 Binky Moon, LLC
+guru
+
+// hair : 2015-12-03 XYZ.COM LLC
+hair
+
+// hamburg : 2014-02-20 Hamburg Top-Level-Domain GmbH
+hamburg
+
+// hangout : 2014-11-13 Charleston Road Registry Inc.
+hangout
+
+// haus : 2013-12-05 Dog Beach, LLC
+haus
+
+// hbo : 2015-07-30 HBO Registry Services, Inc.
+hbo
+
+// hdfc : 2015-07-30 HOUSING DEVELOPMENT FINANCE CORPORATION LIMITED
+hdfc
+
+// hdfcbank : 2015-02-12 HDFC Bank Limited
+hdfcbank
+
+// health : 2015-02-11 DotHealth, LLC
+health
+
+// healthcare : 2014-06-12 Binky Moon, LLC
+healthcare
+
+// help : 2014-06-26 UNR Corp.
+help
+
+// helsinki : 2015-02-05 City of Helsinki
+helsinki
+
+// here : 2014-02-06 Charleston Road Registry Inc.
+here
+
+// hermes : 2014-07-10 HERMES INTERNATIONAL
+hermes
+
+// hgtv : 2015-07-02 Lifestyle Domain Holdings, Inc.
+hgtv
+
+// hiphop : 2014-03-06 UNR Corp.
+hiphop
+
+// hisamitsu : 2015-07-16 Hisamitsu Pharmaceutical Co.,Inc.
+hisamitsu
+
+// hitachi : 2014-10-31 Hitachi, Ltd.
+hitachi
+
+// hiv : 2014-03-13 UNR Corp.
+hiv
+
+// hkt : 2015-05-14 PCCW-HKT DataCom Services Limited
+hkt
+
+// hockey : 2015-03-19 Binky Moon, LLC
+hockey
+
+// holdings : 2013-08-27 Binky Moon, LLC
+holdings
+
+// holiday : 2013-11-07 Binky Moon, LLC
+holiday
+
+// homedepot : 2015-04-02 Home Depot Product Authority, LLC
+homedepot
+
+// homegoods : 2015-07-16 The TJX Companies, Inc.
+homegoods
+
+// homes : 2014-01-09 DERHomes, LLC
+homes
+
+// homesense : 2015-07-16 The TJX Companies, Inc.
+homesense
+
+// honda : 2014-12-18 Honda Motor Co., Ltd.
+honda
+
+// horse : 2013-11-21 Minds + Machines Group Limited
+horse
+
+// hospital : 2016-10-20 Binky Moon, LLC
+hospital
+
+// host : 2014-04-17 DotHost Inc.
+host
+
+// hosting : 2014-05-29 UNR Corp.
+hosting
+
+// hot : 2015-08-27 Amazon Registry Services, Inc.
+hot
+
+// hoteles : 2015-03-05 Travel Reservations SRL
+hoteles
+
+// hotels : 2016-04-07 Booking.com B.V.
+hotels
+
+// hotmail : 2014-12-18 Microsoft Corporation
+hotmail
+
+// house : 2013-11-07 Binky Moon, LLC
+house
+
+// how : 2014-01-23 Charleston Road Registry Inc.
+how
+
+// hsbc : 2014-10-24 HSBC Global Services (UK) Limited
+hsbc
+
+// hughes : 2015-07-30 Hughes Satellite Systems Corporation
+hughes
+
+// hyatt : 2015-07-30 Hyatt GTLD, L.L.C.
+hyatt
+
+// hyundai : 2015-07-09 Hyundai Motor Company
+hyundai
+
+// ibm : 2014-07-31 International Business Machines Corporation
+ibm
+
+// icbc : 2015-02-19 Industrial and Commercial Bank of China Limited
+icbc
+
+// ice : 2014-10-30 IntercontinentalExchange, Inc.
+ice
+
+// icu : 2015-01-08 ShortDot SA
+icu
+
+// ieee : 2015-07-23 IEEE Global LLC
+ieee
+
+// ifm : 2014-01-30 ifm electronic gmbh
+ifm
+
+// ikano : 2015-07-09 Ikano S.A.
+ikano
+
+// imamat : 2015-08-06 Fondation Aga Khan (Aga Khan Foundation)
+imamat
+
+// imdb : 2015-06-25 Amazon Registry Services, Inc.
+imdb
+
+// immo : 2014-07-10 Binky Moon, LLC
+immo
+
+// immobilien : 2013-11-07 Dog Beach, LLC
+immobilien
+
+// inc : 2018-03-10 Intercap Registry Inc.
+inc
+
+// industries : 2013-12-05 Binky Moon, LLC
+industries
+
+// infiniti : 2014-03-27 NISSAN MOTOR CO., LTD.
+infiniti
+
+// ing : 2014-01-23 Charleston Road Registry Inc.
+ing
+
+// ink : 2013-12-05 Top Level Design, LLC
+ink
+
+// institute : 2013-11-07 Binky Moon, LLC
+institute
+
+// insurance : 2015-02-19 fTLD Registry Services LLC
+insurance
+
+// insure : 2014-03-20 Binky Moon, LLC
+insure
+
+// intel : 2015-08-06 Intel Corporation
+intel
+
+// international : 2013-11-07 Binky Moon, LLC
+international
+
+// intuit : 2015-07-30 Intuit Administrative Services, Inc.
+intuit
+
+// investments : 2014-03-20 Binky Moon, LLC
+investments
+
+// ipiranga : 2014-08-28 Ipiranga Produtos de Petroleo S.A.
+ipiranga
+
+// irish : 2014-08-07 Binky Moon, LLC
+irish
+
+// ismaili : 2015-08-06 Fondation Aga Khan (Aga Khan Foundation)
+ismaili
+
+// ist : 2014-08-28 Istanbul Metropolitan Municipality
+ist
+
+// istanbul : 2014-08-28 Istanbul Metropolitan Municipality
+istanbul
+
+// itau : 2014-10-02 Itau Unibanco Holding S.A.
+itau
+
+// itv : 2015-07-09 ITV Services Limited
+itv
+
+// iveco : 2015-09-03 CNH Industrial N.V.
+iveco
+
+// jaguar : 2014-11-13 Jaguar Land Rover Ltd
+jaguar
+
+// java : 2014-06-19 Oracle Corporation
+java
+
+// jcb : 2014-11-20 JCB Co., Ltd.
+jcb
+
+// jcp : 2015-04-23 JCP Media, Inc.
+jcp
+
+// jeep : 2015-07-30 FCA US LLC.
+jeep
+
+// jetzt : 2014-01-09 Binky Moon, LLC
+jetzt
+
+// jewelry : 2015-03-05 Binky Moon, LLC
+jewelry
+
+// jio : 2015-04-02 Reliance Industries Limited
+jio
+
+// jll : 2015-04-02 Jones Lang LaSalle Incorporated
+jll
+
+// jmp : 2015-03-26 Matrix IP LLC
+jmp
+
+// jnj : 2015-06-18 Johnson & Johnson Services, Inc.
+jnj
+
+// joburg : 2014-03-24 ZA Central Registry NPC trading as ZA Central Registry
+joburg
+
+// jot : 2014-12-18 Amazon Registry Services, Inc.
+jot
+
+// joy : 2014-12-18 Amazon Registry Services, Inc.
+joy
+
+// jpmorgan : 2015-04-30 JPMorgan Chase Bank, National Association
+jpmorgan
+
+// jprs : 2014-09-18 Japan Registry Services Co., Ltd.
+jprs
+
+// juegos : 2014-03-20 UNR Corp.
+juegos
+
+// juniper : 2015-07-30 JUNIPER NETWORKS, INC.
+juniper
+
+// kaufen : 2013-11-07 Dog Beach, LLC
+kaufen
+
+// kddi : 2014-09-12 KDDI CORPORATION
+kddi
+
+// kerryhotels : 2015-04-30 Kerry Trading Co. Limited
+kerryhotels
+
+// kerrylogistics : 2015-04-09 Kerry Trading Co. Limited
+kerrylogistics
+
+// kerryproperties : 2015-04-09 Kerry Trading Co. Limited
+kerryproperties
+
+// kfh : 2014-12-04 Kuwait Finance House
+kfh
+
+// kia : 2015-07-09 KIA MOTORS CORPORATION
+kia
+
+// kim : 2013-09-23 Afilias Limited
+kim
+
+// kinder : 2014-11-07 Ferrero Trading Lux S.A.
+kinder
+
+// kindle : 2015-06-25 Amazon Registry Services, Inc.
+kindle
+
+// kitchen : 2013-09-20 Binky Moon, LLC
+kitchen
+
+// kiwi : 2013-09-20 DOT KIWI LIMITED
+kiwi
+
+// koeln : 2014-01-09 dotKoeln GmbH
+koeln
+
+// komatsu : 2015-01-08 Komatsu Ltd.
+komatsu
+
+// kosher : 2015-08-20 Kosher Marketing Assets LLC
+kosher
+
+// kpmg : 2015-04-23 KPMG International Cooperative (KPMG International Genossenschaft)
+kpmg
+
+// kpn : 2015-01-08 Koninklijke KPN N.V.
+kpn
+
+// krd : 2013-12-05 KRG Department of Information Technology
+krd
+
+// kred : 2013-12-19 KredTLD Pty Ltd
+kred
+
+// kuokgroup : 2015-04-09 Kerry Trading Co. Limited
+kuokgroup
+
+// kyoto : 2014-11-07 Academic Institution: Kyoto Jyoho Gakuen
+kyoto
+
+// lacaixa : 2014-01-09 Fundación Bancaria Caixa d’Estalvis i Pensions de Barcelona, “la Caixa”
+lacaixa
+
+// lamborghini : 2015-06-04 Automobili Lamborghini S.p.A.
+lamborghini
+
+// lamer : 2015-10-01 The Estée Lauder Companies Inc.
+lamer
+
+// lancaster : 2015-02-12 LANCASTER
+lancaster
+
+// lancia : 2015-07-31 Fiat Chrysler Automobiles N.V.
+lancia
+
+// land : 2013-09-10 Binky Moon, LLC
+land
+
+// landrover : 2014-11-13 Jaguar Land Rover Ltd
+landrover
+
+// lanxess : 2015-07-30 LANXESS Corporation
+lanxess
+
+// lasalle : 2015-04-02 Jones Lang LaSalle Incorporated
+lasalle
+
+// lat : 2014-10-16 ECOM-LAC Federaciòn de Latinoamèrica y el Caribe para Internet y el Comercio Electrònico
+lat
+
+// latino : 2015-07-30 Dish DBS Corporation
+latino
+
+// latrobe : 2014-06-16 La Trobe University
+latrobe
+
+// law : 2015-01-22 LW TLD Limited
+law
+
+// lawyer : 2014-03-20 Dog Beach, LLC
+lawyer
+
+// lds : 2014-03-20 IRI Domain Management, LLC
+lds
+
+// lease : 2014-03-06 Binky Moon, LLC
+lease
+
+// leclerc : 2014-08-07 A.C.D. LEC Association des Centres Distributeurs Edouard Leclerc
+leclerc
+
+// lefrak : 2015-07-16 LeFrak Organization, Inc.
+lefrak
+
+// legal : 2014-10-16 Binky Moon, LLC
+legal
+
+// lego : 2015-07-16 LEGO Juris A/S
+lego
+
+// lexus : 2015-04-23 TOYOTA MOTOR CORPORATION
+lexus
+
+// lgbt : 2014-05-08 Afilias Limited
+lgbt
+
+// lidl : 2014-09-18 Schwarz Domains und Services GmbH & Co. KG
+lidl
+
+// life : 2014-02-06 Binky Moon, LLC
+life
+
+// lifeinsurance : 2015-01-15 American Council of Life Insurers
+lifeinsurance
+
+// lifestyle : 2014-12-11 Lifestyle Domain Holdings, Inc.
+lifestyle
+
+// lighting : 2013-08-27 Binky Moon, LLC
+lighting
+
+// like : 2014-12-18 Amazon Registry Services, Inc.
+like
+
+// lilly : 2015-07-31 Eli Lilly and Company
+lilly
+
+// limited : 2014-03-06 Binky Moon, LLC
+limited
+
+// limo : 2013-10-17 Binky Moon, LLC
+limo
+
+// lincoln : 2014-11-13 Ford Motor Company
+lincoln
+
+// linde : 2014-12-04 Linde Aktiengesellschaft
+linde
+
+// link : 2013-11-14 UNR Corp.
+link
+
+// lipsy : 2015-06-25 Lipsy Ltd
+lipsy
+
+// live : 2014-12-04 Dog Beach, LLC
+live
+
+// living : 2015-07-30 Lifestyle Domain Holdings, Inc.
+living
+
+// lixil : 2015-03-19 LIXIL Group Corporation
+lixil
+
+// llc : 2017-12-14 Afilias Limited
+llc
+
+// llp : 2019-08-26 UNR Corp.
+llp
+
+// loan : 2014-11-20 dot Loan Limited
+loan
+
+// loans : 2014-03-20 Binky Moon, LLC
+loans
+
+// locker : 2015-06-04 Dish DBS Corporation
+locker
+
+// locus : 2015-06-25 Locus Analytics LLC
+locus
+
+// loft : 2015-07-30 Annco, Inc.
+loft
+
+// lol : 2015-01-30 UNR Corp.
+lol
+
+// london : 2013-11-14 Dot London Domains Limited
+london
+
+// lotte : 2014-11-07 Lotte Holdings Co., Ltd.
+lotte
+
+// lotto : 2014-04-10 Afilias Limited
+lotto
+
+// love : 2014-12-22 Merchant Law Group LLP
+love
+
+// lpl : 2015-07-30 LPL Holdings, Inc.
+lpl
+
+// lplfinancial : 2015-07-30 LPL Holdings, Inc.
+lplfinancial
+
+// ltd : 2014-09-25 Binky Moon, LLC
+ltd
+
+// ltda : 2014-04-17 InterNetX, Corp
+ltda
+
+// lundbeck : 2015-08-06 H. Lundbeck A/S
+lundbeck
+
+// lupin : 2014-11-07 LUPIN LIMITED
+lupin
+
+// luxe : 2014-01-09 Minds + Machines Group Limited
+luxe
+
+// luxury : 2013-10-17 Luxury Partners, LLC
+luxury
+
+// macys : 2015-07-31 Macys, Inc.
+macys
+
+// madrid : 2014-05-01 Comunidad de Madrid
+madrid
+
+// maif : 2014-10-02 Mutuelle Assurance Instituteur France (MAIF)
+maif
+
+// maison : 2013-12-05 Binky Moon, LLC
+maison
+
+// makeup : 2015-01-15 XYZ.COM LLC
+makeup
+
+// man : 2014-12-04 MAN SE
+man
+
+// management : 2013-11-07 Binky Moon, LLC
+management
+
+// mango : 2013-10-24 PUNTO FA S.L.
+mango
+
+// map : 2016-06-09 Charleston Road Registry Inc.
+map
+
+// market : 2014-03-06 Dog Beach, LLC
+market
+
+// marketing : 2013-11-07 Binky Moon, LLC
+marketing
+
+// markets : 2014-12-11 Dotmarkets Registry Limited
+markets
+
+// marriott : 2014-10-09 Marriott Worldwide Corporation
+marriott
+
+// marshalls : 2015-07-16 The TJX Companies, Inc.
+marshalls
+
+// maserati : 2015-07-31 Fiat Chrysler Automobiles N.V.
+maserati
+
+// mattel : 2015-08-06 Mattel Sites, Inc.
+mattel
+
+// mba : 2015-04-02 Binky Moon, LLC
+mba
+
+// mckinsey : 2015-07-31 McKinsey Holdings, Inc.
+mckinsey
+
+// med : 2015-08-06 Medistry LLC
+med
+
+// media : 2014-03-06 Binky Moon, LLC
+media
+
+// meet : 2014-01-16 Charleston Road Registry Inc.
+meet
+
+// melbourne : 2014-05-29 The Crown in right of the State of Victoria, represented by its Department of State Development, Business and Innovation
+melbourne
+
+// meme : 2014-01-30 Charleston Road Registry Inc.
+meme
+
+// memorial : 2014-10-16 Dog Beach, LLC
+memorial
+
+// men : 2015-02-26 Exclusive Registry Limited
+men
+
+// menu : 2013-09-11 Dot Menu Registry, LLC
+menu
+
+// merckmsd : 2016-07-14 MSD Registry Holdings, Inc.
+merckmsd
+
+// miami : 2013-12-19 Minds + Machines Group Limited
+miami
+
+// microsoft : 2014-12-18 Microsoft Corporation
+microsoft
+
+// mini : 2014-01-09 Bayerische Motoren Werke Aktiengesellschaft
+mini
+
+// mint : 2015-07-30 Intuit Administrative Services, Inc.
+mint
+
+// mit : 2015-07-02 Massachusetts Institute of Technology
+mit
+
+// mitsubishi : 2015-07-23 Mitsubishi Corporation
+mitsubishi
+
+// mlb : 2015-05-21 MLB Advanced Media DH, LLC
+mlb
+
+// mls : 2015-04-23 The Canadian Real Estate Association
+mls
+
+// mma : 2014-11-07 MMA IARD
+mma
+
+// mobile : 2016-06-02 Dish DBS Corporation
+mobile
+
+// moda : 2013-11-07 Dog Beach, LLC
+moda
+
+// moe : 2013-11-13 Interlink Co., Ltd.
+moe
+
+// moi : 2014-12-18 Amazon Registry Services, Inc.
+moi
+
+// mom : 2015-04-16 UNR Corp.
+mom
+
+// monash : 2013-09-30 Monash University
+monash
+
+// money : 2014-10-16 Binky Moon, LLC
+money
+
+// monster : 2015-09-11 XYZ.COM LLC
+monster
+
+// mormon : 2013-12-05 IRI Domain Management, LLC
+mormon
+
+// mortgage : 2014-03-20 Dog Beach, LLC
+mortgage
+
+// moscow : 2013-12-19 Foundation for Assistance for Internet Technologies and Infrastructure Development (FAITID)
+moscow
+
+// moto : 2015-06-04 Motorola Trademark Holdings, LLC
+moto
+
+// motorcycles : 2014-01-09 DERMotorcycles, LLC
+motorcycles
+
+// mov : 2014-01-30 Charleston Road Registry Inc.
+mov
+
+// movie : 2015-02-05 Binky Moon, LLC
+movie
+
+// msd : 2015-07-23 MSD Registry Holdings, Inc.
+msd
+
+// mtn : 2014-12-04 MTN Dubai Limited
+mtn
+
+// mtr : 2015-03-12 MTR Corporation Limited
+mtr
+
+// mutual : 2015-04-02 Northwestern Mutual MU TLD Registry, LLC
+mutual
+
+// nab : 2015-08-20 National Australia Bank Limited
+nab
+
+// nagoya : 2013-10-24 GMO Registry, Inc.
+nagoya
+
+// nationwide : 2015-07-23 Nationwide Mutual Insurance Company
+nationwide
+
+// natura : 2015-03-12 NATURA COSMÉTICOS S.A.
+natura
+
+// navy : 2014-03-06 Dog Beach, LLC
+navy
+
+// nba : 2015-07-31 NBA REGISTRY, LLC
+nba
+
+// nec : 2015-01-08 NEC Corporation
+nec
+
+// netbank : 2014-06-26 COMMONWEALTH BANK OF AUSTRALIA
+netbank
+
+// netflix : 2015-06-18 Netflix, Inc.
+netflix
+
+// network : 2013-11-14 Binky Moon, LLC
+network
+
+// neustar : 2013-12-05 NeuStar, Inc.
+neustar
+
+// new : 2014-01-30 Charleston Road Registry Inc.
+new
+
+// newholland : 2015-09-03 CNH Industrial N.V.
+newholland
+
+// news : 2014-12-18 Dog Beach, LLC
+news
+
+// next : 2015-06-18 Next plc
+next
+
+// nextdirect : 2015-06-18 Next plc
+nextdirect
+
+// nexus : 2014-07-24 Charleston Road Registry Inc.
+nexus
+
+// nfl : 2015-07-23 NFL Reg Ops LLC
+nfl
+
+// ngo : 2014-03-06 Public Interest Registry
+ngo
+
+// nhk : 2014-02-13 Japan Broadcasting Corporation (NHK)
+nhk
+
+// nico : 2014-12-04 DWANGO Co., Ltd.
+nico
+
+// nike : 2015-07-23 NIKE, Inc.
+nike
+
+// nikon : 2015-05-21 NIKON CORPORATION
+nikon
+
+// ninja : 2013-11-07 Dog Beach, LLC
+ninja
+
+// nissan : 2014-03-27 NISSAN MOTOR CO., LTD.
+nissan
+
+// nissay : 2015-10-29 Nippon Life Insurance Company
+nissay
+
+// nokia : 2015-01-08 Nokia Corporation
+nokia
+
+// northwesternmutual : 2015-06-18 Northwestern Mutual Registry, LLC
+northwesternmutual
+
+// norton : 2014-12-04 NortonLifeLock Inc.
+norton
+
+// now : 2015-06-25 Amazon Registry Services, Inc.
+now
+
+// nowruz : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
+nowruz
+
+// nowtv : 2015-05-14 Starbucks (HK) Limited
+nowtv
+
+// nra : 2014-05-22 NRA Holdings Company, INC.
+nra
+
+// nrw : 2013-11-21 Minds + Machines GmbH
+nrw
+
+// ntt : 2014-10-31 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
+ntt
+
+// nyc : 2014-01-23 The City of New York by and through the New York City Department of Information Technology & Telecommunications
+nyc
+
+// obi : 2014-09-25 OBI Group Holding SE & Co. KGaA
+obi
+
+// observer : 2015-04-30 Top Level Spectrum, Inc.
+observer
+
+// off : 2015-07-23 Johnson Shareholdings, Inc.
+off
+
+// office : 2015-03-12 Microsoft Corporation
+office
+
+// okinawa : 2013-12-05 BRregistry, Inc.
+okinawa
+
+// olayan : 2015-05-14 Crescent Holding GmbH
+olayan
+
+// olayangroup : 2015-05-14 Crescent Holding GmbH
+olayangroup
+
+// oldnavy : 2015-07-31 The Gap, Inc.
+oldnavy
+
+// ollo : 2015-06-04 Dish DBS Corporation
+ollo
+
+// omega : 2015-01-08 The Swatch Group Ltd
+omega
+
+// one : 2014-11-07 One.com A/S
+one
+
+// ong : 2014-03-06 Public Interest Registry
+ong
+
+// onl : 2013-09-16 I-Registry Ltd.
+onl
+
+// online : 2015-01-15 DotOnline Inc.
+online
+
+// onyourside : 2015-07-23 Nationwide Mutual Insurance Company
+onyourside
+
+// ooo : 2014-01-09 INFIBEAM AVENUES LIMITED
+ooo
+
+// open : 2015-07-31 American Express Travel Related Services Company, Inc.
+open
+
+// oracle : 2014-06-19 Oracle Corporation
+oracle
+
+// orange : 2015-03-12 Orange Brand Services Limited
+orange
+
+// organic : 2014-03-27 Afilias Limited
+organic
+
+// origins : 2015-10-01 The Estée Lauder Companies Inc.
+origins
+
+// osaka : 2014-09-04 Osaka Registry Co., Ltd.
+osaka
+
+// otsuka : 2013-10-11 Otsuka Holdings Co., Ltd.
+otsuka
+
+// ott : 2015-06-04 Dish DBS Corporation
+ott
+
+// ovh : 2014-01-16 MédiaBC
+ovh
+
+// page : 2014-12-04 Charleston Road Registry Inc.
+page
+
+// panasonic : 2015-07-30 Panasonic Corporation
+panasonic
+
+// paris : 2014-01-30 City of Paris
+paris
+
+// pars : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
+pars
+
+// partners : 2013-12-05 Binky Moon, LLC
+partners
+
+// parts : 2013-12-05 Binky Moon, LLC
+parts
+
+// party : 2014-09-11 Blue Sky Registry Limited
+party
+
+// passagens : 2015-03-05 Travel Reservations SRL
+passagens
+
+// pay : 2015-08-27 Amazon Registry Services, Inc.
+pay
+
+// pccw : 2015-05-14 PCCW Enterprises Limited
+pccw
+
+// pet : 2015-05-07 Afilias Limited
+pet
+
+// pfizer : 2015-09-11 Pfizer Inc.
+pfizer
+
+// pharmacy : 2014-06-19 National Association of Boards of Pharmacy
+pharmacy
+
+// phd : 2016-07-28 Charleston Road Registry Inc.
+phd
+
+// philips : 2014-11-07 Koninklijke Philips N.V.
+philips
+
+// phone : 2016-06-02 Dish DBS Corporation
+phone
+
+// photo : 2013-11-14 UNR Corp.
+photo
+
+// photography : 2013-09-20 Binky Moon, LLC
+photography
+
+// photos : 2013-10-17 Binky Moon, LLC
+photos
+
+// physio : 2014-05-01 PhysBiz Pty Ltd
+physio
+
+// pics : 2013-11-14 UNR Corp.
+pics
+
+// pictet : 2014-06-26 Pictet Europe S.A.
+pictet
+
+// pictures : 2014-03-06 Binky Moon, LLC
+pictures
+
+// pid : 2015-01-08 Top Level Spectrum, Inc.
+pid
+
+// pin : 2014-12-18 Amazon Registry Services, Inc.
+pin
+
+// ping : 2015-06-11 Ping Registry Provider, Inc.
+ping
+
+// pink : 2013-10-01 Afilias Limited
+pink
+
+// pioneer : 2015-07-16 Pioneer Corporation
+pioneer
+
+// pizza : 2014-06-26 Binky Moon, LLC
+pizza
+
+// place : 2014-04-24 Binky Moon, LLC
+place
+
+// play : 2015-03-05 Charleston Road Registry Inc.
+play
+
+// playstation : 2015-07-02 Sony Interactive Entertainment Inc.
+playstation
+
+// plumbing : 2013-09-10 Binky Moon, LLC
+plumbing
+
+// plus : 2015-02-05 Binky Moon, LLC
+plus
+
+// pnc : 2015-07-02 PNC Domain Co., LLC
+pnc
+
+// pohl : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
+pohl
+
+// poker : 2014-07-03 Afilias Limited
+poker
+
+// politie : 2015-08-20 Politie Nederland
+politie
+
+// porn : 2014-10-16 ICM Registry PN LLC
+porn
+
+// pramerica : 2015-07-30 Prudential Financial, Inc.
+pramerica
+
+// praxi : 2013-12-05 Praxi S.p.A.
+praxi
+
+// press : 2014-04-03 DotPress Inc.
+press
+
+// prime : 2015-06-25 Amazon Registry Services, Inc.
+prime
+
+// prod : 2014-01-23 Charleston Road Registry Inc.
+prod
+
+// productions : 2013-12-05 Binky Moon, LLC
+productions
+
+// prof : 2014-07-24 Charleston Road Registry Inc.
+prof
+
+// progressive : 2015-07-23 Progressive Casualty Insurance Company
+progressive
+
+// promo : 2014-12-18 Afilias Limited
+promo
+
+// properties : 2013-12-05 Binky Moon, LLC
+properties
+
+// property : 2014-05-22 UNR Corp.
+property
+
+// protection : 2015-04-23 XYZ.COM LLC
+protection
+
+// pru : 2015-07-30 Prudential Financial, Inc.
+pru
+
+// prudential : 2015-07-30 Prudential Financial, Inc.
+prudential
+
+// pub : 2013-12-12 Dog Beach, LLC
+pub
+
+// pwc : 2015-10-29 PricewaterhouseCoopers LLP
+pwc
+
+// qpon : 2013-11-14 dotCOOL, Inc.
+qpon
+
+// quebec : 2013-12-19 PointQuébec Inc
+quebec
+
+// quest : 2015-03-26 XYZ.COM LLC
+quest
+
+// qvc : 2015-07-30 QVC, Inc.
+qvc
+
+// racing : 2014-12-04 Premier Registry Limited
+racing
+
+// radio : 2016-07-21 European Broadcasting Union (EBU)
+radio
+
+// raid : 2015-07-23 Johnson Shareholdings, Inc.
+raid
+
+// read : 2014-12-18 Amazon Registry Services, Inc.
+read
+
+// realestate : 2015-09-11 dotRealEstate LLC
+realestate
+
+// realtor : 2014-05-29 Real Estate Domains LLC
+realtor
+
+// realty : 2015-03-19 Fegistry, LLC
+realty
+
+// recipes : 2013-10-17 Binky Moon, LLC
+recipes
+
+// red : 2013-11-07 Afilias Limited
+red
+
+// redstone : 2014-10-31 Redstone Haute Couture Co., Ltd.
+redstone
+
+// redumbrella : 2015-03-26 Travelers TLD, LLC
+redumbrella
+
+// rehab : 2014-03-06 Dog Beach, LLC
+rehab
+
+// reise : 2014-03-13 Binky Moon, LLC
+reise
+
+// reisen : 2014-03-06 Binky Moon, LLC
+reisen
+
+// reit : 2014-09-04 National Association of Real Estate Investment Trusts, Inc.
+reit
+
+// reliance : 2015-04-02 Reliance Industries Limited
+reliance
+
+// ren : 2013-12-12 ZDNS International Limited
+ren
+
+// rent : 2014-12-04 XYZ.COM LLC
+rent
+
+// rentals : 2013-12-05 Binky Moon, LLC
+rentals
+
+// repair : 2013-11-07 Binky Moon, LLC
+repair
+
+// report : 2013-12-05 Binky Moon, LLC
+report
+
+// republican : 2014-03-20 Dog Beach, LLC
+republican
+
+// rest : 2013-12-19 Punto 2012 Sociedad Anonima Promotora de Inversion de Capital Variable
+rest
+
+// restaurant : 2014-07-03 Binky Moon, LLC
+restaurant
+
+// review : 2014-11-20 dot Review Limited
+review
+
+// reviews : 2013-09-13 Dog Beach, LLC
+reviews
+
+// rexroth : 2015-06-18 Robert Bosch GMBH
+rexroth
+
+// rich : 2013-11-21 I-Registry Ltd.
+rich
+
+// richardli : 2015-05-14 Pacific Century Asset Management (HK) Limited
+richardli
+
+// ricoh : 2014-11-20 Ricoh Company, Ltd.
+ricoh
+
+// ril : 2015-04-02 Reliance Industries Limited
+ril
+
+// rio : 2014-02-27 Empresa Municipal de Informática SA - IPLANRIO
+rio
+
+// rip : 2014-07-10 Dog Beach, LLC
+rip
+
+// rmit : 2015-11-19 Royal Melbourne Institute of Technology
+rmit
+
+// rocher : 2014-12-18 Ferrero Trading Lux S.A.
+rocher
+
+// rocks : 2013-11-14 Dog Beach, LLC
+rocks
+
+// rodeo : 2013-12-19 Minds + Machines Group Limited
+rodeo
+
+// rogers : 2015-08-06 Rogers Communications Canada Inc.
+rogers
+
+// room : 2014-12-18 Amazon Registry Services, Inc.
+room
+
+// rsvp : 2014-05-08 Charleston Road Registry Inc.
+rsvp
+
+// rugby : 2016-12-15 World Rugby Strategic Developments Limited
+rugby
+
+// ruhr : 2013-10-02 regiodot GmbH & Co. KG
+ruhr
+
+// run : 2015-03-19 Binky Moon, LLC
+run
+
+// rwe : 2015-04-02 RWE AG
+rwe
+
+// ryukyu : 2014-01-09 BRregistry, Inc.
+ryukyu
+
+// saarland : 2013-12-12 dotSaarland GmbH
+saarland
+
+// safe : 2014-12-18 Amazon Registry Services, Inc.
+safe
+
+// safety : 2015-01-08 Safety Registry Services, LLC.
+safety
+
+// sakura : 2014-12-18 SAKURA Internet Inc.
+sakura
+
+// sale : 2014-10-16 Dog Beach, LLC
+sale
+
+// salon : 2014-12-11 Binky Moon, LLC
+salon
+
+// samsclub : 2015-07-31 Wal-Mart Stores, Inc.
+samsclub
+
+// samsung : 2014-04-03 SAMSUNG SDS CO., LTD
+samsung
+
+// sandvik : 2014-11-13 Sandvik AB
+sandvik
+
+// sandvikcoromant : 2014-11-07 Sandvik AB
+sandvikcoromant
+
+// sanofi : 2014-10-09 Sanofi
+sanofi
+
+// sap : 2014-03-27 SAP AG
+sap
+
+// sarl : 2014-07-03 Binky Moon, LLC
+sarl
+
+// sas : 2015-04-02 Research IP LLC
+sas
+
+// save : 2015-06-25 Amazon Registry Services, Inc.
+save
+
+// saxo : 2014-10-31 Saxo Bank A/S
+saxo
+
+// sbi : 2015-03-12 STATE BANK OF INDIA
+sbi
+
+// sbs : 2014-11-07 SPECIAL BROADCASTING SERVICE CORPORATION
+sbs
+
+// sca : 2014-03-13 SVENSKA CELLULOSA AKTIEBOLAGET SCA (publ)
+sca
+
+// scb : 2014-02-20 The Siam Commercial Bank Public Company Limited ("SCB")
+scb
+
+// schaeffler : 2015-08-06 Schaeffler Technologies AG & Co. KG
+schaeffler
+
+// schmidt : 2014-04-03 SCHMIDT GROUPE S.A.S.
+schmidt
+
+// scholarships : 2014-04-24 Scholarships.com, LLC
+scholarships
+
+// school : 2014-12-18 Binky Moon, LLC
+school
+
+// schule : 2014-03-06 Binky Moon, LLC
+schule
+
+// schwarz : 2014-09-18 Schwarz Domains und Services GmbH & Co. KG
+schwarz
+
+// science : 2014-09-11 dot Science Limited
+science
+
+// scjohnson : 2015-07-23 Johnson Shareholdings, Inc.
+scjohnson
+
+// scot : 2014-01-23 Dot Scot Registry Limited
+scot
+
+// search : 2016-06-09 Charleston Road Registry Inc.
+search
+
+// seat : 2014-05-22 SEAT, S.A. (Sociedad Unipersonal)
+seat
+
+// secure : 2015-08-27 Amazon Registry Services, Inc.
+secure
+
+// security : 2015-05-14 XYZ.COM LLC
+security
+
+// seek : 2014-12-04 Seek Limited
+seek
+
+// select : 2015-10-08 Registry Services, LLC
+select
+
+// sener : 2014-10-24 Sener Ingeniería y Sistemas, S.A.
+sener
+
+// services : 2014-02-27 Binky Moon, LLC
+services
+
+// ses : 2015-07-23 SES
+ses
+
+// seven : 2015-08-06 Seven West Media Ltd
+seven
+
+// sew : 2014-07-17 SEW-EURODRIVE GmbH & Co KG
+sew
+
+// sex : 2014-11-13 ICM Registry SX LLC
+sex
+
+// sexy : 2013-09-11 UNR Corp.
+sexy
+
+// sfr : 2015-08-13 Societe Francaise du Radiotelephone - SFR
+sfr
+
+// shangrila : 2015-09-03 Shangri‐La International Hotel Management Limited
+shangrila
+
+// sharp : 2014-05-01 Sharp Corporation
+sharp
+
+// shaw : 2015-04-23 Shaw Cablesystems G.P.
+shaw
+
+// shell : 2015-07-30 Shell Information Technology International Inc
+shell
+
+// shia : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
+shia
+
+// shiksha : 2013-11-14 Afilias Limited
+shiksha
+
+// shoes : 2013-10-02 Binky Moon, LLC
+shoes
+
+// shop : 2016-04-08 GMO Registry, Inc.
+shop
+
+// shopping : 2016-03-31 Binky Moon, LLC
+shopping
+
+// shouji : 2015-01-08 Beijing Qihu Keji Co., Ltd.
+shouji
+
+// show : 2015-03-05 Binky Moon, LLC
+show
+
+// showtime : 2015-08-06 CBS Domains Inc.
+showtime
+
+// shriram : 2014-01-23 Shriram Capital Ltd.
+shriram
+
+// silk : 2015-06-25 Amazon Registry Services, Inc.
+silk
+
+// sina : 2015-03-12 Sina Corporation
+sina
+
+// singles : 2013-08-27 Binky Moon, LLC
+singles
+
+// site : 2015-01-15 DotSite Inc.
+site
+
+// ski : 2015-04-09 Afilias Limited
+ski
+
+// skin : 2015-01-15 XYZ.COM LLC
+skin
+
+// sky : 2014-06-19 Sky International AG
+sky
+
+// skype : 2014-12-18 Microsoft Corporation
+skype
+
+// sling : 2015-07-30 DISH Technologies L.L.C.
+sling
+
+// smart : 2015-07-09 Smart Communications, Inc. (SMART)
+smart
+
+// smile : 2014-12-18 Amazon Registry Services, Inc.
+smile
+
+// sncf : 2015-02-19 Société Nationale des Chemins de fer Francais S N C F
+sncf
+
+// soccer : 2015-03-26 Binky Moon, LLC
+soccer
+
+// social : 2013-11-07 Dog Beach, LLC
+social
+
+// softbank : 2015-07-02 SoftBank Group Corp.
+softbank
+
+// software : 2014-03-20 Dog Beach, LLC
+software
+
+// sohu : 2013-12-19 Sohu.com Limited
+sohu
+
+// solar : 2013-11-07 Binky Moon, LLC
+solar
+
+// solutions : 2013-11-07 Binky Moon, LLC
+solutions
+
+// song : 2015-02-26 Amazon Registry Services, Inc.
+song
+
+// sony : 2015-01-08 Sony Corporation
+sony
+
+// soy : 2014-01-23 Charleston Road Registry Inc.
+soy
+
+// spa : 2019-09-19 Asia Spa and Wellness Promotion Council Limited
+spa
+
+// space : 2014-04-03 DotSpace Inc.
+space
+
+// sport : 2017-11-16 Global Association of International Sports Federations (GAISF)
+sport
+
+// spot : 2015-02-26 Amazon Registry Services, Inc.
+spot
+
+// spreadbetting : 2014-12-11 Dotspreadbetting Registry Limited
+spreadbetting
+
+// srl : 2015-05-07 InterNetX, Corp
+srl
+
+// stada : 2014-11-13 STADA Arzneimittel AG
+stada
+
+// staples : 2015-07-30 Staples, Inc.
+staples
+
+// star : 2015-01-08 Star India Private Limited
+star
+
+// statebank : 2015-03-12 STATE BANK OF INDIA
+statebank
+
+// statefarm : 2015-07-30 State Farm Mutual Automobile Insurance Company
+statefarm
+
+// stc : 2014-10-09 Saudi Telecom Company
+stc
+
+// stcgroup : 2014-10-09 Saudi Telecom Company
+stcgroup
+
+// stockholm : 2014-12-18 Stockholms kommun
+stockholm
+
+// storage : 2014-12-22 XYZ.COM LLC
+storage
+
+// store : 2015-04-09 DotStore Inc.
+store
+
+// stream : 2016-01-08 dot Stream Limited
+stream
+
+// studio : 2015-02-11 Dog Beach, LLC
+studio
+
+// study : 2014-12-11 OPEN UNIVERSITIES AUSTRALIA PTY LTD
+study
+
+// style : 2014-12-04 Binky Moon, LLC
+style
+
+// sucks : 2014-12-22 Vox Populi Registry Ltd.
+sucks
+
+// supplies : 2013-12-19 Binky Moon, LLC
+supplies
+
+// supply : 2013-12-19 Binky Moon, LLC
+supply
+
+// support : 2013-10-24 Binky Moon, LLC
+support
+
+// surf : 2014-01-09 Minds + Machines Group Limited
+surf
+
+// surgery : 2014-03-20 Binky Moon, LLC
+surgery
+
+// suzuki : 2014-02-20 SUZUKI MOTOR CORPORATION
+suzuki
+
+// swatch : 2015-01-08 The Swatch Group Ltd
+swatch
+
+// swiftcover : 2015-07-23 Swiftcover Insurance Services Limited
+swiftcover
+
+// swiss : 2014-10-16 Swiss Confederation
+swiss
+
+// sydney : 2014-09-18 State of New South Wales, Department of Premier and Cabinet
+sydney
+
+// systems : 2013-11-07 Binky Moon, LLC
+systems
+
+// tab : 2014-12-04 Tabcorp Holdings Limited
+tab
+
+// taipei : 2014-07-10 Taipei City Government
+taipei
+
+// talk : 2015-04-09 Amazon Registry Services, Inc.
+talk
+
+// taobao : 2015-01-15 Alibaba Group Holding Limited
+taobao
+
+// target : 2015-07-31 Target Domain Holdings, LLC
+target
+
+// tatamotors : 2015-03-12 Tata Motors Ltd
+tatamotors
+
+// tatar : 2014-04-24 Limited Liability Company "Coordination Center of Regional Domain of Tatarstan Republic"
+tatar
+
+// tattoo : 2013-08-30 UNR Corp.
+tattoo
+
+// tax : 2014-03-20 Binky Moon, LLC
+tax
+
+// taxi : 2015-03-19 Binky Moon, LLC
+taxi
+
+// tci : 2014-09-12 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
+tci
+
+// tdk : 2015-06-11 TDK Corporation
+tdk
+
+// team : 2015-03-05 Binky Moon, LLC
+team
+
+// tech : 2015-01-30 Personals TLD Inc.
+tech
+
+// technology : 2013-09-13 Binky Moon, LLC
+technology
+
+// temasek : 2014-08-07 Temasek Holdings (Private) Limited
+temasek
+
+// tennis : 2014-12-04 Binky Moon, LLC
+tennis
+
+// teva : 2015-07-02 Teva Pharmaceutical Industries Limited
+teva
+
+// thd : 2015-04-02 Home Depot Product Authority, LLC
+thd
+
+// theater : 2015-03-19 Binky Moon, LLC
+theater
+
+// theatre : 2015-05-07 XYZ.COM LLC
+theatre
+
+// tiaa : 2015-07-23 Teachers Insurance and Annuity Association of America
+tiaa
+
+// tickets : 2015-02-05 Accent Media Limited
+tickets
+
+// tienda : 2013-11-14 Binky Moon, LLC
+tienda
+
+// tiffany : 2015-01-30 Tiffany and Company
+tiffany
+
+// tips : 2013-09-20 Binky Moon, LLC
+tips
+
+// tires : 2014-11-07 Binky Moon, LLC
+tires
+
+// tirol : 2014-04-24 punkt Tirol GmbH
+tirol
+
+// tjmaxx : 2015-07-16 The TJX Companies, Inc.
+tjmaxx
+
+// tjx : 2015-07-16 The TJX Companies, Inc.
+tjx
+
+// tkmaxx : 2015-07-16 The TJX Companies, Inc.
+tkmaxx
+
+// tmall : 2015-01-15 Alibaba Group Holding Limited
+tmall
+
+// today : 2013-09-20 Binky Moon, LLC
+today
+
+// tokyo : 2013-11-13 GMO Registry, Inc.
+tokyo
+
+// tools : 2013-11-21 Binky Moon, LLC
+tools
+
+// top : 2014-03-20 .TOP Registry
+top
+
+// toray : 2014-12-18 Toray Industries, Inc.
+toray
+
+// toshiba : 2014-04-10 TOSHIBA Corporation
+toshiba
+
+// total : 2015-08-06 Total SA
+total
+
+// tours : 2015-01-22 Binky Moon, LLC
+tours
+
+// town : 2014-03-06 Binky Moon, LLC
+town
+
+// toyota : 2015-04-23 TOYOTA MOTOR CORPORATION
+toyota
+
+// toys : 2014-03-06 Binky Moon, LLC
+toys
+
+// trade : 2014-01-23 Elite Registry Limited
+trade
+
+// trading : 2014-12-11 Dottrading Registry Limited
+trading
+
+// training : 2013-11-07 Binky Moon, LLC
+training
+
+// travel : 2015-10-09 Dog Beach, LLC
+travel
+
+// travelchannel : 2015-07-02 Lifestyle Domain Holdings, Inc.
+travelchannel
+
+// travelers : 2015-03-26 Travelers TLD, LLC
+travelers
+
+// travelersinsurance : 2015-03-26 Travelers TLD, LLC
+travelersinsurance
+
+// trust : 2014-10-16 NCC Group Domain Services, Inc.
+trust
+
+// trv : 2015-03-26 Travelers TLD, LLC
+trv
+
+// tube : 2015-06-11 Latin American Telecom LLC
+tube
+
+// tui : 2014-07-03 TUI AG
+tui
+
+// tunes : 2015-02-26 Amazon Registry Services, Inc.
+tunes
+
+// tushu : 2014-12-18 Amazon Registry Services, Inc.
+tushu
+
+// tvs : 2015-02-19 T V SUNDRAM IYENGAR  & SONS LIMITED
+tvs
+
+// ubank : 2015-08-20 National Australia Bank Limited
+ubank
+
+// ubs : 2014-12-11 UBS AG
+ubs
+
+// unicom : 2015-10-15 China United Network Communications Corporation Limited
+unicom
+
+// university : 2014-03-06 Binky Moon, LLC
+university
+
+// uno : 2013-09-11 DotSite Inc.
+uno
+
+// uol : 2014-05-01 UBN INTERNET LTDA.
+uol
+
+// ups : 2015-06-25 UPS Market Driver, Inc.
+ups
+
+// vacations : 2013-12-05 Binky Moon, LLC
+vacations
+
+// vana : 2014-12-11 Lifestyle Domain Holdings, Inc.
+vana
+
+// vanguard : 2015-09-03 The Vanguard Group, Inc.
+vanguard
+
+// vegas : 2014-01-16 Dot Vegas, Inc.
+vegas
+
+// ventures : 2013-08-27 Binky Moon, LLC
+ventures
+
+// verisign : 2015-08-13 VeriSign, Inc.
+verisign
+
+// versicherung : 2014-03-20 tldbox GmbH
+versicherung
+
+// vet : 2014-03-06 Dog Beach, LLC
+vet
+
+// viajes : 2013-10-17 Binky Moon, LLC
+viajes
+
+// video : 2014-10-16 Dog Beach, LLC
+video
+
+// vig : 2015-05-14 VIENNA INSURANCE GROUP AG Wiener Versicherung Gruppe
+vig
+
+// viking : 2015-04-02 Viking River Cruises (Bermuda) Ltd.
+viking
+
+// villas : 2013-12-05 Binky Moon, LLC
+villas
+
+// vin : 2015-06-18 Binky Moon, LLC
+vin
+
+// vip : 2015-01-22 Minds + Machines Group Limited
+vip
+
+// virgin : 2014-09-25 Virgin Enterprises Limited
+virgin
+
+// visa : 2015-07-30 Visa Worldwide Pte. Limited
+visa
+
+// vision : 2013-12-05 Binky Moon, LLC
+vision
+
+// viva : 2014-11-07 Saudi Telecom Company
+viva
+
+// vivo : 2015-07-31 Telefonica Brasil S.A.
+vivo
+
+// vlaanderen : 2014-02-06 DNS.be vzw
+vlaanderen
+
+// vodka : 2013-12-19 Minds + Machines Group Limited
+vodka
+
+// volkswagen : 2015-05-14 Volkswagen Group of America Inc.
+volkswagen
+
+// volvo : 2015-11-12 Volvo Holding Sverige Aktiebolag
+volvo
+
+// vote : 2013-11-21 Monolith Registry LLC
+vote
+
+// voting : 2013-11-13 Valuetainment Corp.
+voting
+
+// voto : 2013-11-21 Monolith Registry LLC
+voto
+
+// voyage : 2013-08-27 Binky Moon, LLC
+voyage
+
+// vuelos : 2015-03-05 Travel Reservations SRL
+vuelos
+
+// wales : 2014-05-08 Nominet UK
+wales
+
+// walmart : 2015-07-31 Wal-Mart Stores, Inc.
+walmart
+
+// walter : 2014-11-13 Sandvik AB
+walter
+
+// wang : 2013-10-24 Zodiac Wang Limited
+wang
+
+// wanggou : 2014-12-18 Amazon Registry Services, Inc.
+wanggou
+
+// watch : 2013-11-14 Binky Moon, LLC
+watch
+
+// watches : 2014-12-22 Richemont DNS Inc.
+watches
+
+// weather : 2015-01-08 International Business Machines Corporation
+weather
+
+// weatherchannel : 2015-03-12 International Business Machines Corporation
+weatherchannel
+
+// webcam : 2014-01-23 dot Webcam Limited
+webcam
+
+// weber : 2015-06-04 Saint-Gobain Weber SA
+weber
+
+// website : 2014-04-03 DotWebsite Inc.
+website
+
+// wedding : 2014-04-24 Minds + Machines Group Limited
+wedding
+
+// weibo : 2015-03-05 Sina Corporation
+weibo
+
+// weir : 2015-01-29 Weir Group IP Limited
+weir
+
+// whoswho : 2014-02-20 Who's Who Registry
+whoswho
+
+// wien : 2013-10-28 punkt.wien GmbH
+wien
+
+// wiki : 2013-11-07 Top Level Design, LLC
+wiki
+
+// williamhill : 2014-03-13 William Hill Organization Limited
+williamhill
+
+// win : 2014-11-20 First Registry Limited
+win
+
+// windows : 2014-12-18 Microsoft Corporation
+windows
+
+// wine : 2015-06-18 Binky Moon, LLC
+wine
+
+// winners : 2015-07-16 The TJX Companies, Inc.
+winners
+
+// wme : 2014-02-13 William Morris Endeavor Entertainment, LLC
+wme
+
+// wolterskluwer : 2015-08-06 Wolters Kluwer N.V.
+wolterskluwer
+
+// woodside : 2015-07-09 Woodside Petroleum Limited
+woodside
+
+// work : 2013-12-19 Minds + Machines Group Limited
+work
+
+// works : 2013-11-14 Binky Moon, LLC
+works
+
+// world : 2014-06-12 Binky Moon, LLC
+world
+
+// wow : 2015-10-08 Amazon Registry Services, Inc.
+wow
+
+// wtc : 2013-12-19 World Trade Centers Association, Inc.
+wtc
+
+// wtf : 2014-03-06 Binky Moon, LLC
+wtf
+
+// xbox : 2014-12-18 Microsoft Corporation
+xbox
+
+// xerox : 2014-10-24 Xerox DNHC LLC
+xerox
+
+// xfinity : 2015-07-09 Comcast IP Holdings I, LLC
+xfinity
+
+// xihuan : 2015-01-08 Beijing Qihu Keji Co., Ltd.
+xihuan
+
+// xin : 2014-12-11 Elegant Leader Limited
+xin
+
+// xn--11b4c3d : 2015-01-15 VeriSign Sarl
+कॉम
+
+// xn--1ck2e1b : 2015-02-26 Amazon Registry Services, Inc.
+セール
+
+// xn--1qqw23a : 2014-01-09 Guangzhou YU Wei Information Technology Co., Ltd.
+佛山
+
+// xn--30rr7y : 2014-06-12 Excellent First Limited
+慈善
+
+// xn--3bst00m : 2013-09-13 Eagle Horizon Limited
+集团
+
+// xn--3ds443g : 2013-09-08 TLD REGISTRY LIMITED OY
+在线
+
+// xn--3oq18vl8pn36a : 2015-07-02 Volkswagen (China) Investment Co., Ltd.
+大众汽车
+
+// xn--3pxu8k : 2015-01-15 VeriSign Sarl
+点看
+
+// xn--42c2d9a : 2015-01-15 VeriSign Sarl
+คอม
+
+// xn--45q11c : 2013-11-21 Zodiac Gemini Ltd
+八卦
+
+// xn--4gbrim : 2013-10-04 Fans TLD Limited
+موقع
+
+// xn--55qw42g : 2013-11-08 China Organizational Name Administration Center
+公益
+
+// xn--55qx5d : 2013-11-14 China Internet Network Information Center (CNNIC)
+公司
+
+// xn--5su34j936bgsg : 2015-09-03 Shangri‐La International Hotel Management Limited
+香格里拉
+
+// xn--5tzm5g : 2014-12-22 Global Website TLD Asia Limited
+网站
+
+// xn--6frz82g : 2013-09-23 Afilias Limited
+移动
+
+// xn--6qq986b3xl : 2013-09-13 Tycoon Treasure Limited
+我爱你
+
+// xn--80adxhks : 2013-12-19 Foundation for Assistance for Internet Technologies and Infrastructure Development (FAITID)
+москва
+
+// xn--80aqecdr1a : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+католик
+
+// xn--80asehdb : 2013-07-14 CORE Association
+онлайн
+
+// xn--80aswg : 2013-07-14 CORE Association
+сайт
+
+// xn--8y0a063a : 2015-03-26 China United Network Communications Corporation Limited
+联通
+
+// xn--9dbq2a : 2015-01-15 VeriSign Sarl
+קום
+
+// xn--9et52u : 2014-06-12 RISE VICTORY LIMITED
+时尚
+
+// xn--9krt00a : 2015-03-12 Sina Corporation
+微博
+
+// xn--b4w605ferd : 2014-08-07 Temasek Holdings (Private) Limited
+淡马锡
+
+// xn--bck1b9a5dre4c : 2015-02-26 Amazon Registry Services, Inc.
+ファッション
+
+// xn--c1avg : 2013-11-14 Public Interest Registry
+орг
+
+// xn--c2br7g : 2015-01-15 VeriSign Sarl
+नेट
+
+// xn--cck2b3b : 2015-02-26 Amazon Registry Services, Inc.
+ストア
+
+// xn--cckwcxetd : 2019-12-19 Amazon Registry Services, Inc.
+アマゾン
+
+// xn--cg4bki : 2013-09-27 SAMSUNG SDS CO., LTD
+삼성
+
+// xn--czr694b : 2014-01-16 Internet DotTrademark Organisation Limited
+商标
+
+// xn--czrs0t : 2013-12-19 Binky Moon, LLC
+商店
+
+// xn--czru2d : 2013-11-21 Zodiac Aquarius Limited
+商城
+
+// xn--d1acj3b : 2013-11-20 The Foundation for Network Initiatives “The Smart Internet”
+дети
+
+// xn--eckvdtc9d : 2014-12-18 Amazon Registry Services, Inc.
+ポイント
+
+// xn--efvy88h : 2014-08-22 Guangzhou YU Wei Information Technology Co., Ltd.
+新闻
+
+// xn--fct429k : 2015-04-09 Amazon Registry Services, Inc.
+家電
+
+// xn--fhbei : 2015-01-15 VeriSign Sarl
+كوم
+
+// xn--fiq228c5hs : 2013-09-08 TLD REGISTRY LIMITED OY
+中文网
+
+// xn--fiq64b : 2013-10-14 CITIC Group Corporation
+中信
+
+// xn--fjq720a : 2014-05-22 Binky Moon, LLC
+娱乐
+
+// xn--flw351e : 2014-07-31 Charleston Road Registry Inc.
+谷歌
+
+// xn--fzys8d69uvgm : 2015-05-14 PCCW Enterprises Limited
+電訊盈科
+
+// xn--g2xx48c : 2015-01-30 Minds + Machines Group Limited
+购物
+
+// xn--gckr3f0f : 2015-02-26 Amazon Registry Services, Inc.
+クラウド
+
+// xn--gk3at1e : 2015-10-08 Amazon Registry Services, Inc.
+通販
+
+// xn--hxt814e : 2014-05-15 Zodiac Taurus Limited
+网店
+
+// xn--i1b6b1a6a2e : 2013-11-14 Public Interest Registry
+संगठन
+
+// xn--imr513n : 2014-12-11 Internet DotTrademark Organisation Limited
+餐厅
+
+// xn--io0a7i : 2013-11-14 China Internet Network Information Center (CNNIC)
+网络
+
+// xn--j1aef : 2015-01-15 VeriSign Sarl
+ком
+
+// xn--jlq480n2rg : 2019-12-19 Amazon Registry Services, Inc.
+亚马逊
+
+// xn--jlq61u9w7b : 2015-01-08 Nokia Corporation
+诺基亚
+
+// xn--jvr189m : 2015-02-26 Amazon Registry Services, Inc.
+食品
+
+// xn--kcrx77d1x4a : 2014-11-07 Koninklijke Philips N.V.
+飞利浦
+
+// xn--kput3i : 2014-02-13 Beijing RITT-Net Technology Development Co., Ltd
+手机
+
+// xn--mgba3a3ejt : 2014-11-20 Aramco Services Company
+ارامكو
+
+// xn--mgba7c0bbn0a : 2015-05-14 Crescent Holding GmbH
+العليان
+
+// xn--mgbaakc7dvf : 2015-09-03 Emirates Telecommunications Corporation (trading as Etisalat)
+اتصالات
+
+// xn--mgbab2bd : 2013-10-31 CORE Association
+بازار
+
+// xn--mgbca7dzdo : 2015-07-30 Abu Dhabi Systems and Information Centre
+ابوظبي
+
+// xn--mgbi4ecexp : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+كاثوليك
+
+// xn--mgbt3dhd : 2014-09-04 Asia Green IT System Bilgisayar San. ve Tic. Ltd. Sti.
+همراه
+
+// xn--mk1bu44c : 2015-01-15 VeriSign Sarl
+닷컴
+
+// xn--mxtq1m : 2014-03-06 Net-Chinese Co., Ltd.
+政府
+
+// xn--ngbc5azd : 2013-07-13 International Domain Registry Pty. Ltd.
+شبكة
+
+// xn--ngbe9e0a : 2014-12-04 Kuwait Finance House
+بيتك
+
+// xn--ngbrx : 2015-11-12 League of Arab States
+عرب
+
+// xn--nqv7f : 2013-11-14 Public Interest Registry
+机构
+
+// xn--nqv7fs00ema : 2013-11-14 Public Interest Registry
+组织机构
+
+// xn--nyqy26a : 2014-11-07 Stable Tone Limited
+健康
+
+// xn--otu796d : 2017-08-06 Jiang Yu Liang Cai Technology Company Limited
+招聘
+
+// xn--p1acf : 2013-12-12 Rusnames Limited
+рус
+
+// xn--pssy2u : 2015-01-15 VeriSign Sarl
+大拿
+
+// xn--q9jyb4c : 2013-09-17 Charleston Road Registry Inc.
+みんな
+
+// xn--qcka1pmc : 2014-07-31 Charleston Road Registry Inc.
+グーグル
+
+// xn--rhqv96g : 2013-09-11 Stable Tone Limited
+世界
+
+// xn--rovu88b : 2015-02-26 Amazon Registry Services, Inc.
+書籍
+
+// xn--ses554g : 2014-01-16 KNET Co., Ltd.
+网址
+
+// xn--t60b56a : 2015-01-15 VeriSign Sarl
+닷넷
+
+// xn--tckwe : 2015-01-15 VeriSign Sarl
+コム
+
+// xn--tiq49xqyj : 2015-10-21 Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical Council for Social Communication)
+天主教
+
+// xn--unup4y : 2013-07-14 Binky Moon, LLC
+游戏
+
+// xn--vermgensberater-ctb : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
+vermögensberater
+
+// xn--vermgensberatung-pwb : 2014-06-23 Deutsche Vermögensberatung Aktiengesellschaft DVAG
+vermögensberatung
+
+// xn--vhquv : 2013-08-27 Binky Moon, LLC
+企业
+
+// xn--vuq861b : 2014-10-16 Beijing Tele-info Network Technology Co., Ltd.
+信息
+
+// xn--w4r85el8fhu5dnra : 2015-04-30 Kerry Trading Co. Limited
+嘉里大酒店
+
+// xn--w4rs40l : 2015-07-30 Kerry Trading Co. Limited
+嘉里
+
+// xn--xhq521b : 2013-11-14 Guangzhou YU Wei Information Technology Co., Ltd.
+广东
+
+// xn--zfr164b : 2013-11-08 China Organizational Name Administration Center
+政务
+
+// xyz : 2013-12-05 XYZ.COM LLC
+xyz
+
+// yachts : 2014-01-09 DERYachts, LLC
+yachts
+
+// yahoo : 2015-04-02 Yahoo! Domain Services Inc.
+yahoo
+
+// yamaxun : 2014-12-18 Amazon Registry Services, Inc.
+yamaxun
+
+// yandex : 2014-04-10 Yandex Europe B.V.
+yandex
+
+// yodobashi : 2014-11-20 YODOBASHI CAMERA CO.,LTD.
+yodobashi
+
+// yoga : 2014-05-29 Minds + Machines Group Limited
+yoga
+
+// yokohama : 2013-12-12 GMO Registry, Inc.
+yokohama
+
+// you : 2015-04-09 Amazon Registry Services, Inc.
+you
+
+// youtube : 2014-05-01 Charleston Road Registry Inc.
+youtube
+
+// yun : 2015-01-08 Beijing Qihu Keji Co., Ltd.
+yun
+
+// zappos : 2015-06-25 Amazon Registry Services, Inc.
+zappos
+
+// zara : 2014-11-07 Industria de Diseño Textil, S.A. (INDITEX, S.A.)
+zara
+
+// zero : 2014-12-18 Amazon Registry Services, Inc.
+zero
+
+// zip : 2014-05-08 Charleston Road Registry Inc.
+zip
+
+// zone : 2013-11-14 Binky Moon, LLC
+zone
+
+// zuerich : 2014-11-07 Kanton Zürich (Canton of Zurich)
+zuerich
+
+
+// ===END ICANN DOMAINS===
+// ===BEGIN PRIVATE DOMAINS===
+// (Note: these are in alphabetical order by company name)
+
+// 1GB LLC : https://www.1gb.ua/
+// Submitted by 1GB LLC <noc@1gb.com.ua>
+cc.ua
+inf.ua
+ltd.ua
+
+// 611coin : https://611project.org/
+611.to
+
+// Adobe : https://www.adobe.com/
+// Submitted by Ian Boston <boston@adobe.com>
+adobeaemcloud.com
+adobeaemcloud.net
+*.dev.adobeaemcloud.com
+
+// Agnat sp. z o.o. : https://domena.pl
+// Submitted by Przemyslaw Plewa <it-admin@domena.pl>
+beep.pl
+
+// alboto.ca : http://alboto.ca
+// Submitted by Anton Avramov <avramov@alboto.ca>
+barsy.ca
+
+// Alces Software Ltd : http://alces-software.com
+// Submitted by Mark J. Titorenko <mark.titorenko@alces-software.com>
+*.compute.estate
+*.alces.network
+
+// all-inkl.com : https://all-inkl.com
+// Submitted by Werner Kaltofen <wk@all-inkl.com>
+kasserver.com
+
+// Algorithmia, Inc. : algorithmia.com
+// Submitted by Eli Perelman <eperelman@algorithmia.io>
+*.algorithmia.com
+!teams.algorithmia.com
+!test.algorithmia.com
+
+// Altervista: https://www.altervista.org
+// Submitted by Carlo Cannas <tech_staff@altervista.it>
+altervista.org
+
+// alwaysdata : https://www.alwaysdata.com
+// Submitted by Cyril <admin@alwaysdata.com>
+alwaysdata.net
+
+// Amazon CloudFront : https://aws.amazon.com/cloudfront/
+// Submitted by Donavan Miller <donavanm@amazon.com>
+cloudfront.net
+
+// Amazon Elastic Compute Cloud : https://aws.amazon.com/ec2/
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+*.compute.amazonaws.com
+*.compute-1.amazonaws.com
+*.compute.amazonaws.com.cn
+us-east-1.amazonaws.com
+
+// Amazon Elastic Beanstalk : https://aws.amazon.com/elasticbeanstalk/
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+cn-north-1.eb.amazonaws.com.cn
+cn-northwest-1.eb.amazonaws.com.cn
+elasticbeanstalk.com
+ap-northeast-1.elasticbeanstalk.com
+ap-northeast-2.elasticbeanstalk.com
+ap-northeast-3.elasticbeanstalk.com
+ap-south-1.elasticbeanstalk.com
+ap-southeast-1.elasticbeanstalk.com
+ap-southeast-2.elasticbeanstalk.com
+ca-central-1.elasticbeanstalk.com
+eu-central-1.elasticbeanstalk.com
+eu-west-1.elasticbeanstalk.com
+eu-west-2.elasticbeanstalk.com
+eu-west-3.elasticbeanstalk.com
+sa-east-1.elasticbeanstalk.com
+us-east-1.elasticbeanstalk.com
+us-east-2.elasticbeanstalk.com
+us-gov-west-1.elasticbeanstalk.com
+us-west-1.elasticbeanstalk.com
+us-west-2.elasticbeanstalk.com
+
+// Amazon Elastic Load Balancing : https://aws.amazon.com/elasticloadbalancing/
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+*.elb.amazonaws.com
+*.elb.amazonaws.com.cn
+
+// Amazon S3 : https://aws.amazon.com/s3/
+// Submitted by Luke Wells <psl-maintainers@amazon.com>
+s3.amazonaws.com
+s3-ap-northeast-1.amazonaws.com
+s3-ap-northeast-2.amazonaws.com
+s3-ap-south-1.amazonaws.com
+s3-ap-southeast-1.amazonaws.com
+s3-ap-southeast-2.amazonaws.com
+s3-ca-central-1.amazonaws.com
+s3-eu-central-1.amazonaws.com
+s3-eu-west-1.amazonaws.com
+s3-eu-west-2.amazonaws.com
+s3-eu-west-3.amazonaws.com
+s3-external-1.amazonaws.com
+s3-fips-us-gov-west-1.amazonaws.com
+s3-sa-east-1.amazonaws.com
+s3-us-gov-west-1.amazonaws.com
+s3-us-east-2.amazonaws.com
+s3-us-west-1.amazonaws.com
+s3-us-west-2.amazonaws.com
+s3.ap-northeast-2.amazonaws.com
+s3.ap-south-1.amazonaws.com
+s3.cn-north-1.amazonaws.com.cn
+s3.ca-central-1.amazonaws.com
+s3.eu-central-1.amazonaws.com
+s3.eu-west-2.amazonaws.com
+s3.eu-west-3.amazonaws.com
+s3.us-east-2.amazonaws.com
+s3.dualstack.ap-northeast-1.amazonaws.com
+s3.dualstack.ap-northeast-2.amazonaws.com
+s3.dualstack.ap-south-1.amazonaws.com
+s3.dualstack.ap-southeast-1.amazonaws.com
+s3.dualstack.ap-southeast-2.amazonaws.com
+s3.dualstack.ca-central-1.amazonaws.com
+s3.dualstack.eu-central-1.amazonaws.com
+s3.dualstack.eu-west-1.amazonaws.com
+s3.dualstack.eu-west-2.amazonaws.com
+s3.dualstack.eu-west-3.amazonaws.com
+s3.dualstack.sa-east-1.amazonaws.com
+s3.dualstack.us-east-1.amazonaws.com
+s3.dualstack.us-east-2.amazonaws.com
+s3-website-us-east-1.amazonaws.com
+s3-website-us-west-1.amazonaws.com
+s3-website-us-west-2.amazonaws.com
+s3-website-ap-northeast-1.amazonaws.com
+s3-website-ap-southeast-1.amazonaws.com
+s3-website-ap-southeast-2.amazonaws.com
+s3-website-eu-west-1.amazonaws.com
+s3-website-sa-east-1.amazonaws.com
+s3-website.ap-northeast-2.amazonaws.com
+s3-website.ap-south-1.amazonaws.com
+s3-website.ca-central-1.amazonaws.com
+s3-website.eu-central-1.amazonaws.com
+s3-website.eu-west-2.amazonaws.com
+s3-website.eu-west-3.amazonaws.com
+s3-website.us-east-2.amazonaws.com
+
+// Amsterdam Wireless: https://www.amsterdamwireless.nl/
+// Submitted by Imre Jonk <hostmaster@amsterdamwireless.nl>
+amsw.nl
+
+// Amune : https://amune.org/
+// Submitted by Team Amune <cert@amune.org>
+t3l3p0rt.net
+tele.amune.org
+
+// Apigee : https://apigee.com/
+// Submitted by Apigee Security Team <security@apigee.com>
+apigee.io
+
+// Aptible : https://www.aptible.com/
+// Submitted by Thomas Orozco <thomas@aptible.com>
+on-aptible.com
+
+// ASEINet : https://www.aseinet.com/
+// Submitted by Asei SEKIGUCHI <mail@aseinet.com>
+user.aseinet.ne.jp
+gv.vc
+d.gv.vc
+
+// Asociación Amigos de la Informática "Euskalamiga" : http://encounter.eus/
+// Submitted by Hector Martin <marcan@euskalencounter.org>
+user.party.eus
+
+// Association potager.org : https://potager.org/
+// Submitted by Lunar <jardiniers@potager.org>
+pimienta.org
+poivron.org
+potager.org
+sweetpepper.org
+
+// ASUSTOR Inc. : http://www.asustor.com
+// Submitted by Vincent Tseng <vincenttseng@asustor.com>
+myasustor.com
+
+// AVM : https://avm.de
+// Submitted by Andreas Weise <a.weise@avm.de>
+myfritz.net
+
+// AW AdvisorWebsites.com Software Inc : https://advisorwebsites.com
+// Submitted by James Kennedy <domains@advisorwebsites.com>
+*.awdev.ca
+*.advisor.ws
+
+// b-data GmbH : https://www.b-data.io
+// Submitted by Olivier Benz <olivier.benz@b-data.ch>
+b-data.io
+
+// backplane : https://www.backplane.io
+// Submitted by Anthony Voutas <anthony@backplane.io>
+backplaneapp.io
+
+// Balena : https://www.balena.io
+// Submitted by Petros Angelatos <petrosagg@balena.io>
+balena-devices.com
+
+// Banzai Cloud
+// Submitted by Janos Matyas <info@banzaicloud.com>
+*.banzai.cloud
+app.banzaicloud.io
+*.backyards.banzaicloud.io
+
+
+// BetaInABox
+// Submitted by Adrian <adrian@betainabox.com>
+betainabox.com
+
+// BinaryLane : http://www.binarylane.com
+// Submitted by Nathan O'Sullivan <nathan@mammoth.com.au>
+bnr.la
+
+// Blackbaud, Inc. : https://www.blackbaud.com
+// Submitted by Paul Crowder <paul.crowder@blackbaud.com>
+blackbaudcdn.net
+
+// Boomla : https://boomla.com
+// Submitted by Tibor Halter <thalter@boomla.com>
+boomla.net
+
+// Boxfuse : https://boxfuse.com
+// Submitted by Axel Fontaine <axel@boxfuse.com>
+boxfuse.io
+
+// bplaced : https://www.bplaced.net/
+// Submitted by Miroslav Bozic <security@bplaced.net>
+square7.ch
+bplaced.com
+bplaced.de
+square7.de
+bplaced.net
+square7.net
+
+// BrowserSafetyMark
+// Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>
+browsersafetymark.io
+
+// Bytemark Hosting : https://www.bytemark.co.uk
+// Submitted by Paul Cammish <paul.cammish@bytemark.co.uk>
+uk0.bigv.io
+dh.bytemark.co.uk
+vm.bytemark.co.uk
+
+// callidomus : https://www.callidomus.com/
+// Submitted by Marcus Popp <admin@callidomus.com>
+mycd.eu
+
+// Carrd : https://carrd.co
+// Submitted by AJ <aj@carrd.co>
+carrd.co
+crd.co
+uwu.ai
+
+// CentralNic : http://www.centralnic.com/names/domains
+// Submitted by registry <gavin.brown@centralnic.com>
+ae.org
+br.com
+cn.com
+com.de
+com.se
+de.com
+eu.com
+gb.net
+hu.net
+jp.net
+jpn.com
+mex.com
+ru.com
+sa.com
+se.net
+uk.com
+uk.net
+us.com
+za.bz
+za.com
+
+// No longer operated by CentralNic, these entries should be adopted and/or removed by current operators
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+ar.com
+gb.com
+hu.com
+kr.com
+no.com
+qc.com
+uy.com
+
+// Africa.com Web Solutions Ltd : https://registry.africa.com
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+africa.com
+
+// iDOT Services Limited : http://www.domain.gr.com
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+gr.com
+
+// Radix FZC : http://domains.in.net
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+in.net
+web.in
+
+// US REGISTRY LLC : http://us.org
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+us.org
+
+// co.com Registry, LLC : https://registry.co.com
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+co.com
+
+// Roar Domains LLC : https://roar.basketball/
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+aus.basketball
+nz.basketball
+
+// BRS Media : https://brsmedia.com/
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+radio.am
+radio.fm
+
+// Globe Hosting SRL : https://www.globehosting.com/
+// Submitted by Gavin Brown <gavin.brown@centralnic.com>
+co.ro
+shop.ro
+
+// c.la : http://www.c.la/
+c.la
+
+// certmgr.org : https://certmgr.org
+// Submitted by B. Blechschmidt <hostmaster@certmgr.org>
+certmgr.org
+
+// Citrix : https://citrix.com
+// Submitted by Alex Stoddard <alex.stoddard@citrix.com>
+xenapponazure.com
+
+// Civilized Discourse Construction Kit, Inc. : https://www.discourse.org/
+// Submitted by Rishabh Nambiar & Michael Brown <team@discourse.org>
+discourse.group
+discourse.team
+
+// ClearVox : http://www.clearvox.nl/
+// Submitted by Leon Rowland <leon@clearvox.nl>
+virtueeldomein.nl
+
+// Clever Cloud : https://www.clever-cloud.com/
+// Submitted by Quentin Adam <noc@clever-cloud.com>
+cleverapps.io
+
+// Clerk : https://www.clerk.dev
+// Submitted by Colin Sidoti <colin@clerk.dev>
+*.lcl.dev
+*.stg.dev
+
+// Clic2000 : https://clic2000.fr
+// Submitted by Mathilde Blanchemanche <mathilde@clic2000.fr>
+clic2000.net
+
+// Cloud66 : https://www.cloud66.com/
+// Submitted by Khash Sajadi <khash@cloud66.com>
+c66.me
+cloud66.ws
+cloud66.zone
+
+// CloudAccess.net : https://www.cloudaccess.net/
+// Submitted by Pawel Panek <noc@cloudaccess.net>
+jdevcloud.com
+wpdevcloud.com
+cloudaccess.host
+freesite.host
+cloudaccess.net
+
+// cloudControl : https://www.cloudcontrol.com/
+// Submitted by Tobias Wilken <tw@cloudcontrol.com>
+cloudcontrolled.com
+cloudcontrolapp.com
+
+// Cloudera, Inc. : https://www.cloudera.com/
+// Submitted by Philip Langdale <security@cloudera.com>
+cloudera.site
+
+// Cloudflare, Inc. : https://www.cloudflare.com/
+// Submitted by Cloudflare Team <publicsuffixlist@cloudflare.com>
+pages.dev
+trycloudflare.com
+workers.dev
+
+// Clovyr : https://clovyr.io
+// Submitted by Patrick Nielsen <patrick@clovyr.io>
+wnext.app
+
+// co.ca : http://registry.co.ca/
+co.ca
+
+// Co & Co : https://co-co.nl/
+// Submitted by Govert Versluis <govert@co-co.nl>
+*.otap.co
+
+// i-registry s.r.o. : http://www.i-registry.cz/
+// Submitted by Martin Semrad <semrad@i-registry.cz>
+co.cz
+
+// CDN77.com : http://www.cdn77.com
+// Submitted by Jan Krpes <jan.krpes@cdn77.com>
+c.cdn77.org
+cdn77-ssl.net
+r.cdn77.net
+rsc.cdn77.org
+ssl.origin.cdn77-secure.org
+
+// Cloud DNS Ltd : http://www.cloudns.net
+// Submitted by Aleksander Hristov <noc@cloudns.net>
+cloudns.asia
+cloudns.biz
+cloudns.club
+cloudns.cc
+cloudns.eu
+cloudns.in
+cloudns.info
+cloudns.org
+cloudns.pro
+cloudns.pw
+cloudns.us
+
+// Cloudeity Inc : https://cloudeity.com
+// Submitted by Stefan Dimitrov <contact@cloudeity.com>
+cloudeity.net
+
+// CNPY : https://cnpy.gdn
+// Submitted by Angelo Gladding <angelo@lahacker.net>
+cnpy.gdn
+
+// CoDNS B.V.
+co.nl
+co.no
+
+// Combell.com : https://www.combell.com
+// Submitted by Thomas Wouters <thomas.wouters@combellgroup.com>
+webhosting.be
+hosting-cluster.nl
+
+// Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/
+// Submitted by George Georgievsky <gug@cctld.ru>
+ac.ru
+edu.ru
+gov.ru
+int.ru
+mil.ru
+test.ru
+
+// COSIMO GmbH : http://www.cosimo.de
+// Submitted by Rene Marticke <rmarticke@cosimo.de>
+dyn.cosidns.de
+dynamisches-dns.de
+dnsupdater.de
+internet-dns.de
+l-o-g-i-n.de
+dynamic-dns.info
+feste-ip.net
+knx-server.net
+static-access.net
+
+// Craynic, s.r.o. : http://www.craynic.com/
+// Submitted by Ales Krajnik <ales.krajnik@craynic.com>
+realm.cz
+
+// Cryptonomic : https://cryptonomic.net/
+// Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>
+*.cryptonomic.net
+
+// Cupcake : https://cupcake.io/
+// Submitted by Jonathan Rudenberg <jonathan@cupcake.io>
+cupcake.is
+
+// Curv UG : https://curv-labs.de/
+// Submitted by Marvin Wiesner <Marvin@curv-labs.de>
+curv.dev
+
+// Customer OCI - Oracle Dyn https://cloud.oracle.com/home https://dyn.com/dns/
+// Submitted by Gregory Drake <support@dyn.com>
+// Note: This is intended to also include customer-oci.com due to wildcards implicitly including the current label
+*.customer-oci.com
+*.oci.customer-oci.com
+*.ocp.customer-oci.com
+*.ocs.customer-oci.com
+
+// cyon GmbH : https://www.cyon.ch/
+// Submitted by Dominic Luechinger <dol@cyon.ch>
+cyon.link
+cyon.site
+
+// Danger Science Group: https://dangerscience.com/
+// Submitted by Skylar MacDonald <skylar@dangerscience.com>
+fnwk.site
+folionetwork.site
+platform0.app
+
+// Daplie, Inc : https://daplie.com
+// Submitted by AJ ONeal <aj@daplie.com>
+daplie.me
+localhost.daplie.me
+
+// Datto, Inc. : https://www.datto.com/
+// Submitted by Philipp Heckel <ph@datto.com>
+dattolocal.com
+dattorelay.com
+dattoweb.com
+mydatto.com
+dattolocal.net
+mydatto.net
+
+// Dansk.net : http://www.dansk.net/
+// Submitted by Anani Voule <digital@digital.co.dk>
+biz.dk
+co.dk
+firm.dk
+reg.dk
+store.dk
+
+// dappnode.io : https://dappnode.io/
+// Submitted by Abel Boldu / DAppNode Team <community@dappnode.io>
+dyndns.dappnode.io
+
+// dapps.earth : https://dapps.earth/
+// Submitted by Daniil Burdakov <icqkill@gmail.com>
+*.dapps.earth
+*.bzz.dapps.earth
+
+// Dark, Inc. : https://darklang.com
+// Submitted by Paul Biggar <ops@darklang.com>
+builtwithdark.com
+
+// Datawire, Inc : https://www.datawire.io
+// Submitted by Richard Li <secalert@datawire.io>
+edgestack.me
+
+// Debian : https://www.debian.org/
+// Submitted by Peter Palfrader / Debian Sysadmin Team <dsa-publicsuffixlist@debian.org>
+debian.net
+
+// deSEC : https://desec.io/
+// Submitted by Peter Thomassen <peter@desec.io>
+dedyn.io
+
+// DNS Africa Ltd https://dns.business
+// Submitted by Calvin Browne <calvin@dns.business>
+jozi.biz
+
+// DNShome : https://www.dnshome.de/
+// Submitted by Norbert Auler <mail@dnshome.de>
+dnshome.de
+
+// DotArai : https://www.dotarai.com/
+// Submitted by Atsadawat Netcharadsang <atsadawat@dotarai.co.th>
+online.th
+shop.th
+
+// DrayTek Corp. : https://www.draytek.com/
+// Submitted by Paul Fang <mis@draytek.com>
+drayddns.com
+
+// DreamHost : http://www.dreamhost.com/
+// Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>
+dreamhosters.com
+
+// Drobo : http://www.drobo.com/
+// Submitted by Ricardo Padilha <rpadilha@drobo.com>
+mydrobo.com
+
+// Drud Holdings, LLC. : https://www.drud.com/
+// Submitted by Kevin Bridges <kevin@drud.com>
+drud.io
+drud.us
+
+// DuckDNS : http://www.duckdns.org/
+// Submitted by Richard Harper <richard@duckdns.org>
+duckdns.org
+
+// Bip : https://bip.sh
+// Submitted by Joel Kennedy <joel@bip.sh>
+bip.sh
+
+// bitbridge.net : Submitted by Craig Welch, abeliidev@gmail.com
+bitbridge.net
+
+// dy.fi : http://dy.fi/
+// Submitted by Heikki Hannikainen <hessu@hes.iki.fi>
+dy.fi
+tunk.org
+
+// DynDNS.com : http://www.dyndns.com/services/dns/dyndns/
+dyndns-at-home.com
+dyndns-at-work.com
+dyndns-blog.com
+dyndns-free.com
+dyndns-home.com
+dyndns-ip.com
+dyndns-mail.com
+dyndns-office.com
+dyndns-pics.com
+dyndns-remote.com
+dyndns-server.com
+dyndns-web.com
+dyndns-wiki.com
+dyndns-work.com
+dyndns.biz
+dyndns.info
+dyndns.org
+dyndns.tv
+at-band-camp.net
+ath.cx
+barrel-of-knowledge.info
+barrell-of-knowledge.info
+better-than.tv
+blogdns.com
+blogdns.net
+blogdns.org
+blogsite.org
+boldlygoingnowhere.org
+broke-it.net
+buyshouses.net
+cechire.com
+dnsalias.com
+dnsalias.net
+dnsalias.org
+dnsdojo.com
+dnsdojo.net
+dnsdojo.org
+does-it.net
+doesntexist.com
+doesntexist.org
+dontexist.com
+dontexist.net
+dontexist.org
+doomdns.com
+doomdns.org
+dvrdns.org
+dyn-o-saur.com
+dynalias.com
+dynalias.net
+dynalias.org
+dynathome.net
+dyndns.ws
+endofinternet.net
+endofinternet.org
+endoftheinternet.org
+est-a-la-maison.com
+est-a-la-masion.com
+est-le-patron.com
+est-mon-blogueur.com
+for-better.biz
+for-more.biz
+for-our.info
+for-some.biz
+for-the.biz
+forgot.her.name
+forgot.his.name
+from-ak.com
+from-al.com
+from-ar.com
+from-az.net
+from-ca.com
+from-co.net
+from-ct.com
+from-dc.com
+from-de.com
+from-fl.com
+from-ga.com
+from-hi.com
+from-ia.com
+from-id.com
+from-il.com
+from-in.com
+from-ks.com
+from-ky.com
+from-la.net
+from-ma.com
+from-md.com
+from-me.org
+from-mi.com
+from-mn.com
+from-mo.com
+from-ms.com
+from-mt.com
+from-nc.com
+from-nd.com
+from-ne.com
+from-nh.com
+from-nj.com
+from-nm.com
+from-nv.com
+from-ny.net
+from-oh.com
+from-ok.com
+from-or.com
+from-pa.com
+from-pr.com
+from-ri.com
+from-sc.com
+from-sd.com
+from-tn.com
+from-tx.com
+from-ut.com
+from-va.com
+from-vt.com
+from-wa.com
+from-wi.com
+from-wv.com
+from-wy.com
+ftpaccess.cc
+fuettertdasnetz.de
+game-host.org
+game-server.cc
+getmyip.com
+gets-it.net
+go.dyndns.org
+gotdns.com
+gotdns.org
+groks-the.info
+groks-this.info
+ham-radio-op.net
+here-for-more.info
+hobby-site.com
+hobby-site.org
+home.dyndns.org
+homedns.org
+homeftp.net
+homeftp.org
+homeip.net
+homelinux.com
+homelinux.net
+homelinux.org
+homeunix.com
+homeunix.net
+homeunix.org
+iamallama.com
+in-the-band.net
+is-a-anarchist.com
+is-a-blogger.com
+is-a-bookkeeper.com
+is-a-bruinsfan.org
+is-a-bulls-fan.com
+is-a-candidate.org
+is-a-caterer.com
+is-a-celticsfan.org
+is-a-chef.com
+is-a-chef.net
+is-a-chef.org
+is-a-conservative.com
+is-a-cpa.com
+is-a-cubicle-slave.com
+is-a-democrat.com
+is-a-designer.com
+is-a-doctor.com
+is-a-financialadvisor.com
+is-a-geek.com
+is-a-geek.net
+is-a-geek.org
+is-a-green.com
+is-a-guru.com
+is-a-hard-worker.com
+is-a-hunter.com
+is-a-knight.org
+is-a-landscaper.com
+is-a-lawyer.com
+is-a-liberal.com
+is-a-libertarian.com
+is-a-linux-user.org
+is-a-llama.com
+is-a-musician.com
+is-a-nascarfan.com
+is-a-nurse.com
+is-a-painter.com
+is-a-patsfan.org
+is-a-personaltrainer.com
+is-a-photographer.com
+is-a-player.com
+is-a-republican.com
+is-a-rockstar.com
+is-a-socialist.com
+is-a-soxfan.org
+is-a-student.com
+is-a-teacher.com
+is-a-techie.com
+is-a-therapist.com
+is-an-accountant.com
+is-an-actor.com
+is-an-actress.com
+is-an-anarchist.com
+is-an-artist.com
+is-an-engineer.com
+is-an-entertainer.com
+is-by.us
+is-certified.com
+is-found.org
+is-gone.com
+is-into-anime.com
+is-into-cars.com
+is-into-cartoons.com
+is-into-games.com
+is-leet.com
+is-lost.org
+is-not-certified.com
+is-saved.org
+is-slick.com
+is-uberleet.com
+is-very-bad.org
+is-very-evil.org
+is-very-good.org
+is-very-nice.org
+is-very-sweet.org
+is-with-theband.com
+isa-geek.com
+isa-geek.net
+isa-geek.org
+isa-hockeynut.com
+issmarterthanyou.com
+isteingeek.de
+istmein.de
+kicks-ass.net
+kicks-ass.org
+knowsitall.info
+land-4-sale.us
+lebtimnetz.de
+leitungsen.de
+likes-pie.com
+likescandy.com
+merseine.nu
+mine.nu
+misconfused.org
+mypets.ws
+myphotos.cc
+neat-url.com
+office-on-the.net
+on-the-web.tv
+podzone.net
+podzone.org
+readmyblog.org
+saves-the-whales.com
+scrapper-site.net
+scrapping.cc
+selfip.biz
+selfip.com
+selfip.info
+selfip.net
+selfip.org
+sells-for-less.com
+sells-for-u.com
+sells-it.net
+sellsyourhome.org
+servebbs.com
+servebbs.net
+servebbs.org
+serveftp.net
+serveftp.org
+servegame.org
+shacknet.nu
+simple-url.com
+space-to-rent.com
+stuff-4-sale.org
+stuff-4-sale.us
+teaches-yoga.com
+thruhere.net
+traeumtgerade.de
+webhop.biz
+webhop.info
+webhop.net
+webhop.org
+worse-than.tv
+writesthisblog.com
+
+// ddnss.de : https://www.ddnss.de/
+// Submitted by Robert Niedziela <webmaster@ddnss.de>
+ddnss.de
+dyn.ddnss.de
+dyndns.ddnss.de
+dyndns1.de
+dyn-ip24.de
+home-webserver.de
+dyn.home-webserver.de
+myhome-server.de
+ddnss.org
+
+// Definima : http://www.definima.com/
+// Submitted by Maxence Bitterli <maxence@definima.com>
+definima.net
+definima.io
+
+// dnstrace.pro : https://dnstrace.pro/
+// Submitted by Chris Partridge <chris@partridge.tech>
+bci.dnstrace.pro
+
+// Dynu.com : https://www.dynu.com/
+// Submitted by Sue Ye <sue@dynu.com>
+ddnsfree.com
+ddnsgeek.com
+giize.com
+gleeze.com
+kozow.com
+loseyourip.com
+ooguy.com
+theworkpc.com
+casacam.net
+dynu.net
+accesscam.org
+camdvr.org
+freeddns.org
+mywire.org
+webredirect.org
+myddns.rocks
+blogsite.xyz
+
+// dynv6 : https://dynv6.com
+// Submitted by Dominik Menke <dom@digineo.de>
+dynv6.net
+
+// E4YOU spol. s.r.o. : https://e4you.cz/
+// Submitted by Vladimir Dudr <info@e4you.cz>
+e4.cz
+
+// En root‽ : https://en-root.org
+// Submitted by Emmanuel Raviart <emmanuel@raviart.com>
+en-root.fr
+
+// Enalean SAS: https://www.enalean.com
+// Submitted by Thomas Cottier <thomas.cottier@enalean.com>
+mytuleap.com
+
+// ECG Robotics, Inc: https://ecgrobotics.org
+// Submitted by <frc1533@ecgrobotics.org>
+onred.one
+staging.onred.one
+
+// Enonic : http://enonic.com/
+// Submitted by Erik Kaareng-Sunde <esu@enonic.com>
+enonic.io
+customer.enonic.io
+
+// EU.org https://eu.org/
+// Submitted by Pierre Beyssac <hostmaster@eu.org>
+eu.org
+al.eu.org
+asso.eu.org
+at.eu.org
+au.eu.org
+be.eu.org
+bg.eu.org
+ca.eu.org
+cd.eu.org
+ch.eu.org
+cn.eu.org
+cy.eu.org
+cz.eu.org
+de.eu.org
+dk.eu.org
+edu.eu.org
+ee.eu.org
+es.eu.org
+fi.eu.org
+fr.eu.org
+gr.eu.org
+hr.eu.org
+hu.eu.org
+ie.eu.org
+il.eu.org
+in.eu.org
+int.eu.org
+is.eu.org
+it.eu.org
+jp.eu.org
+kr.eu.org
+lt.eu.org
+lu.eu.org
+lv.eu.org
+mc.eu.org
+me.eu.org
+mk.eu.org
+mt.eu.org
+my.eu.org
+net.eu.org
+ng.eu.org
+nl.eu.org
+no.eu.org
+nz.eu.org
+paris.eu.org
+pl.eu.org
+pt.eu.org
+q-a.eu.org
+ro.eu.org
+ru.eu.org
+se.eu.org
+si.eu.org
+sk.eu.org
+tr.eu.org
+uk.eu.org
+us.eu.org
+
+// Evennode : http://www.evennode.com/
+// Submitted by Michal Kralik <support@evennode.com>
+eu-1.evennode.com
+eu-2.evennode.com
+eu-3.evennode.com
+eu-4.evennode.com
+us-1.evennode.com
+us-2.evennode.com
+us-3.evennode.com
+us-4.evennode.com
+
+// eDirect Corp. : https://hosting.url.com.tw/
+// Submitted by C.S. chang <cschang@corp.url.com.tw>
+twmail.cc
+twmail.net
+twmail.org
+mymailer.com.tw
+url.tw
+
+// Fabrica Technologies, Inc. : https://www.fabrica.dev/
+// Submitted by Eric Jiang <eric@fabrica.dev>
+onfabrica.com
+
+// Facebook, Inc.
+// Submitted by Peter Ruibal <public-suffix@fb.com>
+apps.fbsbx.com
+
+// FAITID : https://faitid.org/
+// Submitted by Maxim Alzoba <tech.contact@faitid.org>
+// https://www.flexireg.net/stat_info
+ru.net
+adygeya.ru
+bashkiria.ru
+bir.ru
+cbg.ru
+com.ru
+dagestan.ru
+grozny.ru
+kalmykia.ru
+kustanai.ru
+marine.ru
+mordovia.ru
+msk.ru
+mytis.ru
+nalchik.ru
+nov.ru
+pyatigorsk.ru
+spb.ru
+vladikavkaz.ru
+vladimir.ru
+abkhazia.su
+adygeya.su
+aktyubinsk.su
+arkhangelsk.su
+armenia.su
+ashgabad.su
+azerbaijan.su
+balashov.su
+bashkiria.su
+bryansk.su
+bukhara.su
+chimkent.su
+dagestan.su
+east-kazakhstan.su
+exnet.su
+georgia.su
+grozny.su
+ivanovo.su
+jambyl.su
+kalmykia.su
+kaluga.su
+karacol.su
+karaganda.su
+karelia.su
+khakassia.su
+krasnodar.su
+kurgan.su
+kustanai.su
+lenug.su
+mangyshlak.su
+mordovia.su
+msk.su
+murmansk.su
+nalchik.su
+navoi.su
+north-kazakhstan.su
+nov.su
+obninsk.su
+penza.su
+pokrovsk.su
+sochi.su
+spb.su
+tashkent.su
+termez.su
+togliatti.su
+troitsk.su
+tselinograd.su
+tula.su
+tuva.su
+vladikavkaz.su
+vladimir.su
+vologda.su
+
+// Fancy Bits, LLC : http://getchannels.com
+// Submitted by Aman Gupta <aman@getchannels.com>
+channelsdvr.net
+u.channelsdvr.net
+
+// Fastly Inc. : http://www.fastly.com/
+// Submitted by Fastly Security <security@fastly.com>
+fastly-terrarium.com
+fastlylb.net
+map.fastlylb.net
+freetls.fastly.net
+map.fastly.net
+a.prod.fastly.net
+global.prod.fastly.net
+a.ssl.fastly.net
+b.ssl.fastly.net
+global.ssl.fastly.net
+
+// FASTVPS EESTI OU : https://fastvps.ru/
+// Submitted by Likhachev Vasiliy <lihachev@fastvps.ru>
+fastvps-server.com
+fastvps.host
+myfast.host
+fastvps.site
+myfast.space
+
+// Featherhead : https://featherhead.xyz/
+// Submitted by Simon Menke <simon@featherhead.xyz>
+fhapp.xyz
+
+// Fedora : https://fedoraproject.org/
+// submitted by Patrick Uiterwijk <puiterwijk@fedoraproject.org>
+fedorainfracloud.org
+fedorapeople.org
+cloud.fedoraproject.org
+app.os.fedoraproject.org
+app.os.stg.fedoraproject.org
+
+// FearWorks Media Ltd. : https://fearworksmedia.co.uk
+// submitted by Keith Fairley <domains@fearworksmedia.co.uk>
+conn.uk
+copro.uk
+couk.me
+ukco.me
+
+// Fermax : https://fermax.com/
+// submitted by Koen Van Isterdael <k.vanisterdael@fermax.be>
+mydobiss.com
+
+// Filegear Inc. : https://www.filegear.com
+// Submitted by Jason Zhu <jason@owtware.com>
+filegear.me
+filegear-au.me
+filegear-de.me
+filegear-gb.me
+filegear-ie.me
+filegear-jp.me
+filegear-sg.me
+
+// Firebase, Inc.
+// Submitted by Chris Raynor <chris@firebase.com>
+firebaseapp.com
+
+// fly.io: https://fly.io
+// Submitted by Kurt Mackey <kurt@fly.io>
+fly.dev
+edgeapp.net
+shw.io
+
+// Flynn : https://flynn.io
+// Submitted by Jonathan Rudenberg <jonathan@flynn.io>
+flynnhosting.net
+
+// Frederik Braun https://frederik-braun.com
+// Submitted by Frederik Braun <fb@frederik-braun.com>
+0e.vc
+
+// Freebox : http://www.freebox.fr
+// Submitted by Romain Fliedel <rfliedel@freebox.fr>
+freebox-os.com
+freeboxos.com
+fbx-os.fr
+fbxos.fr
+freebox-os.fr
+freeboxos.fr
+
+// freedesktop.org : https://www.freedesktop.org
+// Submitted by Daniel Stone <daniel@fooishbar.org>
+freedesktop.org
+
+// FunkFeuer - Verein zur Förderung freier Netze : https://www.funkfeuer.at
+// Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>
+wien.funkfeuer.at
+
+// Futureweb OG : http://www.futureweb.at
+// Submitted by Andreas Schnederle-Wagner <schnederle@futureweb.at>
+*.futurecms.at
+*.ex.futurecms.at
+*.in.futurecms.at
+futurehosting.at
+futuremailing.at
+*.ex.ortsinfo.at
+*.kunden.ortsinfo.at
+*.statics.cloud
+
+// GDS : https://www.gov.uk/service-manual/operations/operating-servicegovuk-subdomains
+// Submitted by David Illsley <david.illsley@digital.cabinet-office.gov.uk>
+service.gov.uk
+
+// Gehirn Inc. : https://www.gehirn.co.jp/
+// Submitted by Kohei YOSHIDA <tech@gehirn.co.jp>
+gehirn.ne.jp
+usercontent.jp
+
+// Gentlent, Inc. : https://www.gentlent.com
+// Submitted by Tom Klein <tom@gentlent.com>
+gentapps.com
+gentlentapis.com
+lab.ms
+
+// GitHub, Inc.
+// Submitted by Patrick Toomey <security@github.com>
+github.io
+githubusercontent.com
+
+// GitLab, Inc.
+// Submitted by Alex Hanselka <alex@gitlab.com>
+gitlab.io
+
+// Gitplac.si - https://gitplac.si
+// Submitted by Aljaž Starc <me@aljaxus.eu>
+gitapp.si
+gitpage.si
+
+// Glitch, Inc : https://glitch.com
+// Submitted by Mads Hartmann <mads@glitch.com>
+glitch.me
+
+// GMO Pepabo, Inc. : https://pepabo.com/
+// Submitted by dojineko <admin@pepabo.com>
+lolipop.io
+
+// GOV.UK Platform as a Service : https://www.cloud.service.gov.uk/
+// Submitted by Tom Whitwell <tom.whitwell@digital.cabinet-office.gov.uk>
+cloudapps.digital
+london.cloudapps.digital
+
+// GOV.UK Pay : https://www.payments.service.gov.uk/
+// Submitted by Richard Baker <richard.baker@digital.cabinet-office.gov.uk>
+pymnt.uk
+
+// UKHomeOffice : https://www.gov.uk/government/organisations/home-office
+// Submitted by Jon Shanks <jon.shanks@digital.homeoffice.gov.uk>
+homeoffice.gov.uk
+
+// GlobeHosting, Inc.
+// Submitted by Zoltan Egresi <egresi@globehosting.com>
+ro.im
+
+// GoIP DNS Services : http://www.goip.de
+// Submitted by Christian Poulter <milchstrasse@goip.de>
+goip.de
+
+// Google, Inc.
+// Submitted by Eduardo Vela <evn@google.com>
+run.app
+a.run.app
+web.app
+*.0emm.com
+appspot.com
+*.r.appspot.com
+blogspot.ae
+blogspot.al
+blogspot.am
+blogspot.ba
+blogspot.be
+blogspot.bg
+blogspot.bj
+blogspot.ca
+blogspot.cf
+blogspot.ch
+blogspot.cl
+blogspot.co.at
+blogspot.co.id
+blogspot.co.il
+blogspot.co.ke
+blogspot.co.nz
+blogspot.co.uk
+blogspot.co.za
+blogspot.com
+blogspot.com.ar
+blogspot.com.au
+blogspot.com.br
+blogspot.com.by
+blogspot.com.co
+blogspot.com.cy
+blogspot.com.ee
+blogspot.com.eg
+blogspot.com.es
+blogspot.com.mt
+blogspot.com.ng
+blogspot.com.tr
+blogspot.com.uy
+blogspot.cv
+blogspot.cz
+blogspot.de
+blogspot.dk
+blogspot.fi
+blogspot.fr
+blogspot.gr
+blogspot.hk
+blogspot.hr
+blogspot.hu
+blogspot.ie
+blogspot.in
+blogspot.is
+blogspot.it
+blogspot.jp
+blogspot.kr
+blogspot.li
+blogspot.lt
+blogspot.lu
+blogspot.md
+blogspot.mk
+blogspot.mr
+blogspot.mx
+blogspot.my
+blogspot.nl
+blogspot.no
+blogspot.pe
+blogspot.pt
+blogspot.qa
+blogspot.re
+blogspot.ro
+blogspot.rs
+blogspot.ru
+blogspot.se
+blogspot.sg
+blogspot.si
+blogspot.sk
+blogspot.sn
+blogspot.td
+blogspot.tw
+blogspot.ug
+blogspot.vn
+cloudfunctions.net
+cloud.goog
+codespot.com
+googleapis.com
+googlecode.com
+pagespeedmobilizer.com
+publishproxy.com
+translate.goog
+withgoogle.com
+withyoutube.com
+
+// Aaron Marais' Gitlab pages: https://lab.aaronleem.co.za
+// Submitted by Aaron Marais <its_me@aaronleem.co.za>
+graphox.us
+
+// Group 53, LLC : https://www.group53.com
+// Submitted by Tyler Todd <noc@nova53.net>
+awsmppl.com
+
+// Hakaran group: http://hakaran.cz
+// Submited by Arseniy Sokolov <security@hakaran.cz>
+fin.ci
+free.hr
+caa.li
+ua.rs
+conf.se
+
+// Handshake : https://handshake.org
+// Submitted by Mike Damm <md@md.vc>
+hs.zone
+hs.run
+
+// Hashbang : https://hashbang.sh
+hashbang.sh
+
+// Hasura : https://hasura.io
+// Submitted by Shahidh K Muhammed <shahidh@hasura.io>
+hasura.app
+hasura-app.io
+
+// Hepforge : https://www.hepforge.org
+// Submitted by David Grellscheid <admin@hepforge.org>
+hepforge.org
+
+// Heroku : https://www.heroku.com/
+// Submitted by Tom Maher <tmaher@heroku.com>
+herokuapp.com
+herokussl.com
+
+// Hibernating Rhinos
+// Submitted by Oren Eini <oren@ravendb.net>
+myravendb.com
+ravendb.community
+ravendb.me
+development.run
+ravendb.run
+
+// HOSTBIP REGISTRY : https://www.hostbip.com/
+// Submitted by Atanunu Igbunuroghene <publicsuffixlist@hostbip.com>
+bpl.biz
+orx.biz
+ng.city
+biz.gl
+ng.ink
+col.ng
+firm.ng
+gen.ng
+ltd.ng
+ngo.ng
+ng.school
+sch.so
+
+// HostyHosting (hostyhosting.com)
+hostyhosting.io
+
+// Häkkinen.fi
+// Submitted by Eero Häkkinen <Eero+psl@Häkkinen.fi>
+häkkinen.fi
+
+// Ici la Lune : http://www.icilalune.com/
+// Submitted by Simon Morvan <simon@icilalune.com>
+*.moonscale.io
+moonscale.net
+
+// iki.fi
+// Submitted by Hannu Aronsson <haa@iki.fi>
+iki.fi
+
+// Individual Network Berlin e.V. : https://www.in-berlin.de/
+// Submitted by Christian Seitz <chris@in-berlin.de>
+dyn-berlin.de
+in-berlin.de
+in-brb.de
+in-butter.de
+in-dsl.de
+in-dsl.net
+in-dsl.org
+in-vpn.de
+in-vpn.net
+in-vpn.org
+
+// info.at : http://www.info.at/
+biz.at
+info.at
+
+// info.cx : http://info.cx
+// Submitted by Jacob Slater <whois@igloo.to>
+info.cx
+
+// Interlegis : http://www.interlegis.leg.br
+// Submitted by Gabriel Ferreira <registrobr@interlegis.leg.br>
+ac.leg.br
+al.leg.br
+am.leg.br
+ap.leg.br
+ba.leg.br
+ce.leg.br
+df.leg.br
+es.leg.br
+go.leg.br
+ma.leg.br
+mg.leg.br
+ms.leg.br
+mt.leg.br
+pa.leg.br
+pb.leg.br
+pe.leg.br
+pi.leg.br
+pr.leg.br
+rj.leg.br
+rn.leg.br
+ro.leg.br
+rr.leg.br
+rs.leg.br
+sc.leg.br
+se.leg.br
+sp.leg.br
+to.leg.br
+
+// intermetrics GmbH : https://pixolino.com/
+// Submitted by Wolfgang Schwarz <admin@intermetrics.de>
+pixolino.com
+
+// Internet-Pro, LLP: https://netangels.ru/
+// Submited by Vasiliy Sheredeko <piphon@gmail.com>
+na4u.ru
+
+// IPiFony Systems, Inc. : https://www.ipifony.com/
+// Submitted by Matthew Hardeman <mhardeman@ipifony.com>
+ipifony.net
+
+// IServ GmbH : https://iserv.eu
+// Submitted by Kim-Alexander Brodowski <info@iserv.eu>
+mein-iserv.de
+schulserver.de
+test-iserv.de
+iserv.dev
+
+// I-O DATA DEVICE, INC. : http://www.iodata.com/
+// Submitted by Yuji Minagawa <domains-admin@iodata.jp>
+iobb.net
+
+//Jelastic, Inc. : https://jelastic.com/
+// Submited by Ihor Kolodyuk <ik@jelastic.com>
+appengine.flow.ch
+vip.jelastic.cloud
+jele.cloud
+jele.club
+dopaas.com
+hidora.com
+jcloud.ik-server.com
+demo.jelastic.com
+paas.massivegrid.com
+j.scaleforce.com.cy
+jelastic.dogado.eu
+fi.cloudplatform.fi
+paas.datacenter.fi
+jele.host
+mircloud.host
+jele.io
+cloudjiffy.net
+jls-sto1.elastx.net
+jelastic.saveincloud.net
+jelastic.regruhosting.ru
+jele.site
+jelastic.team
+j.layershift.co.uk
+
+// Jino : https://www.jino.ru
+// Submitted by Sergey Ulyashin <ulyashin@jino.ru>
+myjino.ru
+*.hosting.myjino.ru
+*.landing.myjino.ru
+*.spectrum.myjino.ru
+*.vps.myjino.ru
+
+// Joyent : https://www.joyent.com/
+// Submitted by Brian Bennett <brian.bennett@joyent.com>
+*.triton.zone
+*.cns.joyent.com
+
+// JS.ORG : http://dns.js.org
+// Submitted by Stefan Keim <admin@js.org>
+js.org
+
+// KaasHosting : http://www.kaashosting.nl/
+// Submitted by Wouter Bakker <hostmaster@kaashosting.nl>
+kaas.gg
+khplay.nl
+
+// Keyweb AG : https://www.keyweb.de
+// Submitted by Martin Dannehl <postmaster@keymachine.de>
+keymachine.de
+
+// KingHost : https://king.host
+// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>
+kinghost.net
+uni5.net
+
+// KnightPoint Systems, LLC : http://www.knightpoint.com/
+// Submitted by Roy Keene <rkeene@knightpoint.com>
+knightpoint.systems
+
+// KUROKU LTD : https://kuroku.ltd/
+// Submitted by DisposaBoy <security@oya.to>
+oya.to
+
+// .KRD : http://nic.krd/data/krd/Registration%20Policy.pdf
+co.krd
+edu.krd
+
+// LCube - Professional hosting e.K. : https://www.lcube-webhosting.de
+// Submitted by Lars Laehn <info@lcube.de>
+git-repos.de
+lcube-server.de
+svn-repos.de
+
+// Leadpages : https://www.leadpages.net
+// Submitted by Greg Dallavalle <domains@leadpages.net>
+leadpages.co
+lpages.co
+lpusercontent.com
+
+// Lelux.fi : https://lelux.fi/
+// Submitted by Lelux Admin <publisuffix@lelux.site>
+lelux.site
+
+// Lifetime Hosting : https://Lifetime.Hosting/
+// Submitted by Mike Fillator <support@lifetime.hosting>
+co.business
+co.education
+co.events
+co.financial
+co.network
+co.place
+co.technology
+
+// Lightmaker Property Manager, Inc. : https://app.lmpm.com/
+// Submitted by Greg Holland <greg.holland@lmpm.com>
+app.lmpm.com
+
+// Linki Tools UG : https://linki.tools
+// Submitted by Paulo Matos <pmatos@linki.tools>
+linkitools.space
+
+// linkyard ldt: https://www.linkyard.ch/
+// Submitted by Mario Siegenthaler <mario.siegenthaler@linkyard.ch>
+linkyard.cloud
+linkyard-cloud.ch
+
+// Linode : https://linode.com
+// Submitted by <security@linode.com>
+members.linode.com
+*.nodebalancer.linode.com
+*.linodeobjects.com
+
+// LiquidNet Ltd : http://www.liquidnetlimited.com/
+// Submitted by Victor Velchev <admin@liquidnetlimited.com>
+we.bs
+
+// localzone.xyz
+// Submitted by Kenny Niehage <hello@yahe.sh>
+localzone.xyz
+
+// Log'in Line : https://www.loginline.com/
+// Submitted by Rémi Mach <remi.mach@loginline.com>
+loginline.app
+loginline.dev
+loginline.io
+loginline.services
+loginline.site
+
+// LubMAN UMCS Sp. z o.o : https://lubman.pl/
+// Submitted by Ireneusz Maliszewski <ireneusz.maliszewski@lubman.pl>
+krasnik.pl
+leczna.pl
+lubartow.pl
+lublin.pl
+poniatowa.pl
+swidnik.pl
+
+// Lug.org.uk : https://lug.org.uk
+// Submitted by Jon Spriggs <admin@lug.org.uk>
+uklugs.org
+glug.org.uk
+lug.org.uk
+lugs.org.uk
+
+// Lukanet Ltd : https://lukanet.com
+// Submitted by Anton Avramov <register@lukanet.com>
+barsy.bg
+barsy.co.uk
+barsyonline.co.uk
+barsycenter.com
+barsyonline.com
+barsy.club
+barsy.de
+barsy.eu
+barsy.in
+barsy.info
+barsy.io
+barsy.me
+barsy.menu
+barsy.mobi
+barsy.net
+barsy.online
+barsy.org
+barsy.pro
+barsy.pub
+barsy.shop
+barsy.site
+barsy.support
+barsy.uk
+
+// Magento Commerce
+// Submitted by Damien Tournoud <dtournoud@magento.cloud>
+*.magentosite.cloud
+
+// May First - People Link : https://mayfirst.org/
+// Submitted by Jamie McClelland <info@mayfirst.org>
+mayfirst.info
+mayfirst.org
+
+// Mail.Ru Group : https://hb.cldmail.ru
+// Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>
+hb.cldmail.ru
+
+// mcpe.me : https://mcpe.me
+// Submitted by Noa Heyl <hi@noa.dev>
+mcpe.me
+
+// McHost : https://mchost.ru
+// Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>
+mcdir.ru
+vps.mcdir.ru
+
+// Memset hosting : https://www.memset.com
+// Submitted by Tom Whitwell <domains@memset.com>
+miniserver.com
+memset.net
+
+// MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
+// Submitted by Zdeněk Šustr <zdenek.sustr@cesnet.cz>
+*.cloud.metacentrum.cz
+custom.metacentrum.cz
+
+// MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/
+// Submitted by Radim Janča <janca@cesnet.cz>
+flt.cloud.muni.cz
+usr.cloud.muni.cz
+
+// Meteor Development Group : https://www.meteor.com/hosting
+// Submitted by Pierre Carrier <pierre@meteor.com>
+meteorapp.com
+eu.meteorapp.com
+
+// Michau Enterprises Limited : http://www.co.pl/
+co.pl
+
+// Microsoft Corporation : http://microsoft.com
+// Submitted by Mostafa Elzeiny <moelzein@microsoft.com>
+*.azurecontainer.io
+azurewebsites.net
+azure-mobile.net
+cloudapp.net
+
+// minion.systems : http://minion.systems
+// Submitted by Robert Böttinger <r@minion.systems>
+csx.cc
+
+// MobileEducation, LLC : https://joinforte.com
+// Submitted by Grayson Martin <grayson.martin@mobileeducation.us>
+forte.id
+
+// Mozilla Corporation : https://mozilla.com
+// Submitted by Ben Francis <bfrancis@mozilla.com>
+mozilla-iot.org
+
+// Mozilla Foundation : https://mozilla.org/
+// Submitted by glob <glob@mozilla.com>
+bmoattachments.org
+
+// MSK-IX : https://www.msk-ix.ru/
+// Submitted by Khannanov Roman <r.khannanov@msk-ix.ru>
+net.ru
+org.ru
+pp.ru
+
+// Mythic Beasts : https://www.mythic-beasts.com
+// Submitted by Paul Cammish <kelduum@mythic-beasts.com>
+hostedpi.com
+customer.mythic-beasts.com
+lynx.mythic-beasts.com
+ocelot.mythic-beasts.com
+onza.mythic-beasts.com
+sphinx.mythic-beasts.com
+vs.mythic-beasts.com
+x.mythic-beasts.com
+yali.mythic-beasts.com
+cust.retrosnub.co.uk
+
+// Nabu Casa : https://www.nabucasa.com
+// Submitted by Paulus Schoutsen <infra@nabucasa.com>
+ui.nabu.casa
+
+// Names.of.London : https://names.of.london/
+// Submitted by James Stevens <registry@names.of.london> or <james@jrcs.net>
+pony.club
+of.fashion
+on.fashion
+of.football
+in.london
+of.london
+for.men
+and.mom
+for.mom
+for.one
+for.sale
+of.work
+to.work
+
+// NCTU.ME : https://nctu.me/
+// Submitted by Tocknicsu <admin@nctu.me>
+nctu.me
+
+// Netlify : https://www.netlify.com
+// Submitted by Jessica Parsons <jessica@netlify.com>
+netlify.app
+
+// Neustar Inc.
+// Submitted by Trung Tran <Trung.Tran@neustar.biz>
+4u.com
+
+// ngrok : https://ngrok.com/
+// Submitted by Alan Shreve <alan@ngrok.com>
+ngrok.io
+
+// Nimbus Hosting Ltd. : https://www.nimbushosting.co.uk/
+// Submitted by Nicholas Ford <nick@nimbushosting.co.uk>
+nh-serv.co.uk
+
+// NFSN, Inc. : https://www.NearlyFreeSpeech.NET/
+// Submitted by Jeff Wheelhouse <support@nearlyfreespeech.net>
+nfshost.com
+
+// Now-DNS : https://now-dns.com
+// Submitted by Steve Russell <steve@now-dns.com>
+dnsking.ch
+mypi.co
+n4t.co
+001www.com
+ddnslive.com
+myiphost.com
+forumz.info
+16-b.it
+32-b.it
+64-b.it
+soundcast.me
+tcp4.me
+dnsup.net
+hicam.net
+now-dns.net
+ownip.net
+vpndns.net
+dynserv.org
+now-dns.org
+x443.pw
+now-dns.top
+ntdll.top
+freeddns.us
+crafting.xyz
+zapto.xyz
+
+// nsupdate.info : https://www.nsupdate.info/
+// Submitted by Thomas Waldmann <info@nsupdate.info>
+nsupdate.info
+nerdpol.ovh
+
+// No-IP.com : https://noip.com/
+// Submitted by Deven Reza <publicsuffixlist@noip.com>
+blogsyte.com
+brasilia.me
+cable-modem.org
+ciscofreak.com
+collegefan.org
+couchpotatofries.org
+damnserver.com
+ddns.me
+ditchyourip.com
+dnsfor.me
+dnsiskinky.com
+dvrcam.info
+dynns.com
+eating-organic.net
+fantasyleague.cc
+geekgalaxy.com
+golffan.us
+health-carereform.com
+homesecuritymac.com
+homesecuritypc.com
+hopto.me
+ilovecollege.info
+loginto.me
+mlbfan.org
+mmafan.biz
+myactivedirectory.com
+mydissent.net
+myeffect.net
+mymediapc.net
+mypsx.net
+mysecuritycamera.com
+mysecuritycamera.net
+mysecuritycamera.org
+net-freaks.com
+nflfan.org
+nhlfan.net
+no-ip.ca
+no-ip.co.uk
+no-ip.net
+noip.us
+onthewifi.com
+pgafan.net
+point2this.com
+pointto.us
+privatizehealthinsurance.net
+quicksytes.com
+read-books.org
+securitytactics.com
+serveexchange.com
+servehumour.com
+servep2p.com
+servesarcasm.com
+stufftoread.com
+ufcfan.org
+unusualperson.com
+workisboring.com
+3utilities.com
+bounceme.net
+ddns.net
+ddnsking.com
+gotdns.ch
+hopto.org
+myftp.biz
+myftp.org
+myvnc.com
+no-ip.biz
+no-ip.info
+no-ip.org
+noip.me
+redirectme.net
+servebeer.com
+serveblog.net
+servecounterstrike.com
+serveftp.com
+servegame.com
+servehalflife.com
+servehttp.com
+serveirc.com
+serveminecraft.net
+servemp3.com
+servepics.com
+servequake.com
+sytes.net
+webhop.me
+zapto.org
+
+// NodeArt : https://nodeart.io
+// Submitted by Konstantin Nosov <Nosov@nodeart.io>
+stage.nodeart.io
+
+// Nodum B.V. : https://nodum.io/
+// Submitted by Wietse Wind <hello+publicsuffixlist@nodum.io>
+nodum.co
+nodum.io
+
+// Nucleos Inc. : https://nucleos.com
+// Submitted by Piotr Zduniak <piotr@nucleos.com>
+pcloud.host
+
+// NYC.mn : http://www.information.nyc.mn
+// Submitted by Matthew Brown <mattbrown@nyc.mn>
+nyc.mn
+
+// NymNom : https://nymnom.com/
+// Submitted by NymNom <psl@nymnom.com>
+nom.ae
+nom.af
+nom.ai
+nom.al
+nym.by
+nom.bz
+nym.bz
+nom.cl
+nym.ec
+nom.gd
+nom.ge
+nom.gl
+nym.gr
+nom.gt
+nym.gy
+nym.hk
+nom.hn
+nym.ie
+nom.im
+nom.ke
+nym.kz
+nym.la
+nym.lc
+nom.li
+nym.li
+nym.lt
+nym.lu
+nom.lv
+nym.me
+nom.mk
+nym.mn
+nym.mx
+nom.nu
+nym.nz
+nym.pe
+nym.pt
+nom.pw
+nom.qa
+nym.ro
+nom.rs
+nom.si
+nym.sk
+nom.st
+nym.su
+nym.sx
+nom.tj
+nym.tw
+nom.ug
+nom.uy
+nom.vc
+nom.vg
+
+// Observable, Inc. : https://observablehq.com
+// Submitted by Mike Bostock <dns@observablehq.com>
+static.observableusercontent.com
+
+// Octopodal Solutions, LLC. : https://ulterius.io/
+// Submitted by Andrew Sampson <andrew@ulterius.io>
+cya.gg
+
+// OMG.LOL : <https://omg.lol>
+// Submitted by Adam Newbold <adam@omg.lol>
+omg.lol
+
+// Omnibond Systems, LLC. : https://www.omnibond.com
+// Submitted by Cole Estep <cole@omnibond.com>
+cloudycluster.net
+
+// OmniWe Limited: https://omniwe.com
+// Submitted by Vicary Archangel <vicary@omniwe.com>
+omniwe.site
+
+// One Fold Media : http://www.onefoldmedia.com/
+// Submitted by Eddie Jones <eddie@onefoldmedia.com>
+nid.io
+
+// Open Social : https://www.getopensocial.com/
+// Submitted by Alexander Varwijk <security@getopensocial.com>
+opensocial.site
+
+// OpenCraft GmbH : http://opencraft.com/
+// Submitted by Sven Marnach <sven@opencraft.com>
+opencraft.hosting
+
+// Opera Software, A.S.A.
+// Submitted by Yngve Pettersen <yngve@opera.com>
+operaunite.com
+
+// Oursky Limited : https://skygear.io/
+// Submited by Skygear Developer <hello@skygear.io>
+skygearapp.com
+
+// OutSystems
+// Submitted by Duarte Santos <domain-admin@outsystemscloud.com>
+outsystemscloud.com
+
+// OwnProvider GmbH: http://www.ownprovider.com
+// Submitted by Jan Moennich <jan.moennich@ownprovider.com>
+ownprovider.com
+own.pm
+
+// OwO : https://whats-th.is/
+// Submitted by Dean Sheather <dean@deansheather.com>
+*.owo.codes
+
+// OX : http://www.ox.rs
+// Submitted by Adam Grand <webmaster@mail.ox.rs>
+ox.rs
+
+// oy.lc
+// Submitted by Charly Coste <changaco@changaco.oy.lc>
+oy.lc
+
+// Pagefog : https://pagefog.com/
+// Submitted by Derek Myers <derek@pagefog.com>
+pgfog.com
+
+// Pagefront : https://www.pagefronthq.com/
+// Submitted by Jason Kriss <jason@pagefronthq.com>
+pagefrontapp.com
+
+// PageXL : https://pagexl.com
+// Submitted by Yann Guichard <yann@pagexl.com>
+pagexl.com
+
+// pcarrier.ca Software Inc: https://pcarrier.ca/
+// Submitted by Pierre Carrier <pc@rrier.ca>
+bar0.net
+bar1.net
+bar2.net
+rdv.to
+
+// .pl domains (grandfathered)
+art.pl
+gliwice.pl
+krakow.pl
+poznan.pl
+wroc.pl
+zakopane.pl
+
+// Pantheon Systems, Inc. : https://pantheon.io/
+// Submitted by Gary Dylina <gary@pantheon.io>
+pantheonsite.io
+gotpantheon.com
+
+// Peplink | Pepwave : http://peplink.com/
+// Submitted by Steve Leung <steveleung@peplink.com>
+mypep.link
+
+// Perspecta : https://perspecta.com/
+// Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>
+perspecta.cloud
+
+// Planet-Work : https://www.planet-work.com/
+// Submitted by Frédéric VANNIÈRE <f.vanniere@planet-work.com>
+on-web.fr
+
+// Platform.sh : https://platform.sh
+// Submitted by Nikola Kotur <nikola@platform.sh>
+bc.platform.sh
+ent.platform.sh
+eu.platform.sh
+us.platform.sh
+*.platformsh.site
+
+// Platter: https://platter.dev
+// Submitted by Patrick Flor <patrick@platter.dev>
+platter-app.com
+platter-app.dev
+platterp.us
+
+// Plesk : https://www.plesk.com/
+// Submitted by Anton Akhtyamov <program-managers@plesk.com>
+pdns.page
+plesk.page
+pleskns.com
+
+// Port53 : https://port53.io/
+// Submitted by Maximilian Schieder <maxi@zeug.co>
+dyn53.io
+
+// Positive Codes Technology Company : http://co.bn/faq.html
+// Submitted by Zulfais <pc@co.bn>
+co.bn
+
+// prgmr.com : https://prgmr.com/
+// Submitted by Sarah Newman <owner@prgmr.com>
+xen.prgmr.com
+
+// priv.at : http://www.nic.priv.at/
+// Submitted by registry <lendl@nic.at>
+priv.at
+
+// privacytools.io : https://www.privacytools.io/
+// Submitted by Jonah Aragon <jonah@privacytools.io>
+prvcy.page
+
+// Protocol Labs : https://protocol.ai/
+// Submitted by Michael Burns <noc@protocol.ai>
+*.dweb.link
+
+// Protonet GmbH : http://protonet.io
+// Submitted by Martin Meier <admin@protonet.io>
+protonet.io
+
+// Publication Presse Communication SARL : https://ppcom.fr
+// Submitted by Yaacov Akiba Slama <admin@chirurgiens-dentistes-en-france.fr>
+chirurgiens-dentistes-en-france.fr
+byen.site
+
+// pubtls.org: https://www.pubtls.org
+// Submitted by Kor Nielsen <kor@pubtls.org>
+pubtls.org
+
+// Qualifio : https://qualifio.com/
+// Submitted by Xavier De Cock <xdecock@gmail.com>
+qualifioapp.com
+
+// QuickBackend: https://www.quickbackend.com
+// Submitted by Dani Biro <dani@pymet.com>
+qbuser.com
+
+// Redstar Consultants : https://www.redstarconsultants.com/
+// Submitted by Jons Slemmer <jons@redstarconsultants.com>
+instantcloud.cn
+
+// Russian Academy of Sciences
+// Submitted by Tech Support <support@rasnet.ru>
+ras.ru
+
+// QA2
+// Submitted by Daniel Dent (https://www.danieldent.com/)
+qa2.com
+
+// QCX
+// Submitted by Cassandra Beelen <cassandra@beelen.one>
+qcx.io
+*.sys.qcx.io
+
+// QNAP System Inc : https://www.qnap.com
+// Submitted by Nick Chang <nickchang@qnap.com>
+dev-myqnapcloud.com
+alpha-myqnapcloud.com
+myqnapcloud.com
+
+// Quip : https://quip.com
+// Submitted by Patrick Linehan <plinehan@quip.com>
+*.quipelements.com
+
+// Qutheory LLC : http://qutheory.io
+// Submitted by Jonas Schwartz <jonas@qutheory.io>
+vapor.cloud
+vaporcloud.io
+
+// Rackmaze LLC : https://www.rackmaze.com
+// Submitted by Kirill Pertsev <kika@rackmaze.com>
+rackmaze.com
+rackmaze.net
+
+// Rakuten Games, Inc : https://dev.viberplay.io
+// Submitted by Joshua Zhang <public-suffix@rgames.jp>
+g.vbrplsbx.io
+
+// Rancher Labs, Inc : https://rancher.com
+// Submitted by Vincent Fiduccia <domains@rancher.com>
+*.on-k3s.io
+*.on-rancher.cloud
+*.on-rio.io
+
+// Read The Docs, Inc : https://www.readthedocs.org
+// Submitted by David Fischer <team@readthedocs.org>
+readthedocs.io
+
+// Red Hat, Inc. OpenShift : https://openshift.redhat.com/
+// Submitted by Tim Kramer <tkramer@rhcloud.com>
+rhcloud.com
+
+// Render : https://render.com
+// Submitted by Anurag Goel <dev@render.com>
+app.render.com
+onrender.com
+
+// Repl.it : https://repl.it
+// Submitted by Mason Clayton <mason@repl.it>
+repl.co
+repl.run
+
+// Resin.io : https://resin.io
+// Submitted by Tim Perry <tim@resin.io>
+resindevice.io
+devices.resinstaging.io
+
+// RethinkDB : https://www.rethinkdb.com/
+// Submitted by Chris Kastorff <info@rethinkdb.com>
+hzc.io
+
+// Revitalised Limited : http://www.revitalised.co.uk
+// Submitted by Jack Price <jack@revitalised.co.uk>
+wellbeingzone.eu
+ptplus.fit
+wellbeingzone.co.uk
+
+// Rochester Institute of Technology : http://www.rit.edu/
+// Submitted by Jennifer Herting <jchits@rit.edu>
+git-pages.rit.edu
+
+// Sandstorm Development Group, Inc. : https://sandcats.io/
+// Submitted by Asheesh Laroia <asheesh@sandstorm.io>
+sandcats.io
+
+// SBE network solutions GmbH : https://www.sbe.de/
+// Submitted by Norman Meilick <nm@sbe.de>
+logoip.de
+logoip.com
+
+// schokokeks.org GbR : https://schokokeks.org/
+// Submitted by Hanno Böck <hanno@schokokeks.org>
+schokokeks.net
+
+// Scottish Government: https://www.gov.scot
+// Submitted by Martin Ellis <martin.ellis@gov.scot>
+gov.scot
+
+// Scry Security : http://www.scrysec.com
+// Submitted by Shante Adam <shante@skyhat.io>
+scrysec.com
+
+// Securepoint GmbH : https://www.securepoint.de
+// Submitted by Erik Anders <erik.anders@securepoint.de>
+firewall-gateway.com
+firewall-gateway.de
+my-gateway.de
+my-router.de
+spdns.de
+spdns.eu
+firewall-gateway.net
+my-firewall.org
+myfirewall.org
+spdns.org
+
+// Seidat : https://www.seidat.com
+// Submitted by Artem Kondratev <accounts@seidat.com>
+seidat.net
+
+// Senseering GmbH : https://www.senseering.de
+// Submitted by Felix Mönckemeyer <f.moenckemeyer@senseering.de>
+senseering.net
+
+// Service Online LLC : http://drs.ua/
+// Submitted by Serhii Bulakh <support@drs.ua>
+biz.ua
+co.ua
+pp.ua
+
+// ShiftEdit : https://shiftedit.net/
+// Submitted by Adam Jimenez <adam@shiftcreate.com>
+shiftedit.io
+
+// Shopblocks : http://www.shopblocks.com/
+// Submitted by Alex Bowers <alex@shopblocks.com>
+myshopblocks.com
+
+// Shopit : https://www.shopitcommerce.com/
+// Submitted by Craig McMahon <craig@shopitcommerce.com>
+shopitsite.com
+
+// shopware AG : https://shopware.com
+// Submitted by Jens Küper <cloud@shopware.com>
+shopware.store
+
+// Siemens Mobility GmbH
+// Submitted by Oliver Graebner <security@mo-siemens.io>
+mo-siemens.io
+
+// SinaAppEngine : http://sae.sina.com.cn/
+// Submitted by SinaAppEngine <saesupport@sinacloud.com>
+1kapp.com
+appchizi.com
+applinzi.com
+sinaapp.com
+vipsinaapp.com
+
+// Siteleaf : https://www.siteleaf.com/
+// Submitted by Skylar Challand <support@siteleaf.com>
+siteleaf.net
+
+// Skyhat : http://www.skyhat.io
+// Submitted by Shante Adam <shante@skyhat.io>
+bounty-full.com
+alpha.bounty-full.com
+beta.bounty-full.com
+
+// Small Technology Foundation : https://small-tech.org
+// Submitted by Aral Balkan <aral@small-tech.org>
+small-web.org
+
+// Stackhero : https://www.stackhero.io
+// Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>
+stackhero-network.com
+
+// staticland : https://static.land
+// Submitted by Seth Vincent <sethvincent@gmail.com>
+static.land
+dev.static.land
+sites.static.land
+
+// Sony Interactive Entertainment LLC : https://sie.com/
+// Submitted by David Coles <david.coles@sony.com>
+playstation-cloud.com
+
+// SourceLair PC : https://www.sourcelair.com
+// Submitted by Antonis Kalipetis <akalipetis@sourcelair.com>
+apps.lair.io
+*.stolos.io
+
+// SpaceKit : https://www.spacekit.io/
+// Submitted by Reza Akhavan <spacekit.io@gmail.com>
+spacekit.io
+
+// SpeedPartner GmbH: https://www.speedpartner.de/
+// Submitted by Stefan Neufeind <info@speedpartner.de>
+customer.speedpartner.de
+
+// Standard Library : https://stdlib.com
+// Submitted by Jacob Lee <jacob@stdlib.com>
+api.stdlib.com
+
+// Storj Labs Inc. : https://storj.io/
+// Submitted by Philip Hutchins <hostmaster@storj.io>
+storj.farm
+
+// Studenten Net Twente : http://www.snt.utwente.nl/
+// Submitted by Silke Hofstra <syscom@snt.utwente.nl>
+utwente.io
+
+// Student-Run Computing Facility : https://www.srcf.net/
+// Submitted by Edwin Balani <sysadmins@srcf.net>
+soc.srcf.net
+user.srcf.net
+
+// Sub 6 Limited: http://www.sub6.com
+// Submitted by Dan Miller <dm@sub6.com>
+temp-dns.com
+
+// Swisscom Application Cloud: https://developer.swisscom.com
+// Submitted by Matthias.Winzeler <matthias.winzeler@swisscom.com>
+applicationcloud.io
+scapp.io
+
+// Symfony, SAS : https://symfony.com/
+// Submitted by Fabien Potencier <fabien@symfony.com>
+*.s5y.io
+*.sensiosite.cloud
+
+// Syncloud : https://syncloud.org
+// Submitted by Boris Rybalkin <syncloud@syncloud.it>
+syncloud.it
+
+// Synology, Inc. : https://www.synology.com/
+// Submitted by Rony Weng <ronyweng@synology.com>
+diskstation.me
+dscloud.biz
+dscloud.me
+dscloud.mobi
+dsmynas.com
+dsmynas.net
+dsmynas.org
+familyds.com
+familyds.net
+familyds.org
+i234.me
+myds.me
+synology.me
+vpnplus.to
+direct.quickconnect.to
+
+// TAIFUN Software AG : http://taifun-software.de
+// Submitted by Bjoern Henke <dev-server@taifun-software.de>
+taifun-dns.de
+
+// TASK geographical domains (www.task.gda.pl/uslugi/dns)
+gda.pl
+gdansk.pl
+gdynia.pl
+med.pl
+sopot.pl
+
+// Teckids e.V. : https://www.teckids.org
+// Submitted by Dominik George <dominik.george@teckids.org>
+edugit.org
+
+// Telebit : https://telebit.cloud
+// Submitted by AJ ONeal <aj@telebit.cloud>
+telebit.app
+telebit.io
+*.telebit.xyz
+
+// The Gwiddle Foundation : https://gwiddlefoundation.org.uk
+// Submitted by Joshua Bayfield <joshua.bayfield@gwiddlefoundation.org.uk>
+gwiddle.co.uk
+
+// Thingdust AG : https://thingdust.com/
+// Submitted by Adrian Imboden <adi@thingdust.com>
+thingdustdata.com
+cust.dev.thingdust.io
+cust.disrec.thingdust.io
+cust.prod.thingdust.io
+cust.testing.thingdust.io
+*.firenet.ch
+*.svc.firenet.ch
+
+// Tlon.io : https://tlon.io
+// Submitted by Mark Staarink <mark@tlon.io>
+arvo.network
+azimuth.network
+
+// TownNews.com : http://www.townnews.com
+// Submitted by Dustin Ward <dward@townnews.com>
+bloxcms.com
+townnews-staging.com
+
+// TrafficPlex GmbH : https://www.trafficplex.de/
+// Submitted by Phillipp Röll <phillipp.roell@trafficplex.de>
+12hp.at
+2ix.at
+4lima.at
+lima-city.at
+12hp.ch
+2ix.ch
+4lima.ch
+lima-city.ch
+trafficplex.cloud
+de.cool
+12hp.de
+2ix.de
+4lima.de
+lima-city.de
+1337.pictures
+clan.rip
+lima-city.rocks
+webspace.rocks
+lima.zone
+
+// TransIP : https://www.transip.nl
+// Submitted by Rory Breuk <rbreuk@transip.nl>
+*.transurl.be
+*.transurl.eu
+*.transurl.nl
+
+// TuxFamily : http://tuxfamily.org
+// Submitted by TuxFamily administrators <adm@staff.tuxfamily.org>
+tuxfamily.org
+
+// TwoDNS : https://www.twodns.de/
+// Submitted by TwoDNS-Support <support@two-dns.de>
+dd-dns.de
+diskstation.eu
+diskstation.org
+dray-dns.de
+draydns.de
+dyn-vpn.de
+dynvpn.de
+mein-vigor.de
+my-vigor.de
+my-wan.de
+syno-ds.de
+synology-diskstation.de
+synology-ds.de
+
+// Uberspace : https://uberspace.de
+// Submitted by Moritz Werner <mwerner@jonaspasche.com>
+uber.space
+*.uberspace.de
+
+// UDR Limited : http://www.udr.hk.com
+// Submitted by registry <hostmaster@udr.hk.com>
+hk.com
+hk.org
+ltd.hk
+inc.hk
+
+// United Gameserver GmbH : https://united-gameserver.de
+// Submitted by Stefan Schwarz <sysadm@united-gameserver.de>
+virtualuser.de
+virtual-user.de
+
+// urown.net : https://urown.net
+// Submitted by Hostmaster <hostmaster@urown.net>
+urown.cloud
+dnsupdate.info
+
+// .US
+// Submitted by Ed Moore <Ed.Moore@lib.de.us>
+lib.de.us
+
+// VeryPositive SIA : http://very.lv
+// Submitted by Danko Aleksejevs <danko@very.lv>
+2038.io
+
+// Vercel, Inc : https://vercel.com/
+// Submitted by Connor Davis <security@vercel.com>
+vercel.app
+vercel.dev
+now.sh
+
+// Viprinet Europe GmbH : http://www.viprinet.com
+// Submitted by Simon Kissel <hostmaster@viprinet.com>
+router.management
+
+// Virtual-Info : https://www.virtual-info.info/
+// Submitted by Adnan RIHAN <hostmaster@v-info.info>
+v-info.info
+
+// Voorloper.com: https://voorloper.com
+// Submitted by Nathan van Bakel <info@voorloper.com>
+voorloper.cloud
+
+// Voxel.sh DNS : https://voxel.sh/dns/
+// Submitted by Mia Rehlinger <dns@voxel.sh>
+neko.am
+nyaa.am
+be.ax
+cat.ax
+es.ax
+eu.ax
+gg.ax
+mc.ax
+us.ax
+xy.ax
+nl.ci
+xx.gl
+app.gp
+blog.gt
+de.gt
+to.gt
+be.gy
+cc.hn
+blog.kg
+io.kg
+jp.kg
+tv.kg
+uk.kg
+us.kg
+de.ls
+at.md
+de.md
+jp.md
+to.md
+uwu.nu
+indie.porn
+vxl.sh
+ch.tc
+me.tc
+we.tc
+nyan.to
+at.vg
+blog.vu
+dev.vu
+me.vu
+
+// V.UA Domain Administrator : https://domain.v.ua/
+// Submitted by Serhii Rostilo <sergey@rostilo.kiev.ua>
+v.ua
+
+// Waffle Computer Inc., Ltd. : https://docs.waffleinfo.com
+// Submitted by Masayuki Note <masa@blade.wafflecell.com>
+wafflecell.com
+
+// WebHare bv: https://www.webhare.com/
+// Submitted by Arnold Hendriks <info@webhare.com>
+*.webhare.dev
+
+// WeDeploy by Liferay, Inc. : https://www.wedeploy.com
+// Submitted by Henrique Vicente <security@wedeploy.com>
+wedeploy.io
+wedeploy.me
+wedeploy.sh
+
+// Western Digital Technologies, Inc : https://www.wdc.com
+// Submitted by Jung Jin <jungseok.jin@wdc.com>
+remotewd.com
+
+// WIARD Enterprises : https://wiardweb.com
+// Submitted by Kidd Hustle <kiddhustle@wiardweb.com>
+pages.wiardweb.com
+
+// Wikimedia Labs : https://wikitech.wikimedia.org
+// Submitted by Arturo Borrero Gonzalez <aborrero@wikimedia.org>
+wmflabs.org
+toolforge.org
+wmcloud.org
+
+// WISP : https://wisp.gg
+// Submitted by Stepan Fedotov <stepan@wisp.gg>
+panel.gg
+daemon.panel.gg
+
+// WoltLab GmbH : https://www.woltlab.com
+// Submitted by Tim Düsterhus <security@woltlab.cloud>
+myforum.community
+community-pro.de
+diskussionsbereich.de
+community-pro.net
+meinforum.net
+
+// www.com.vc : http://www.com.vc
+// Submitted by Li Hui <lihui@sinopub.com>
+cn.vu
+
+// XenonCloud GbR: https://xenoncloud.net
+// Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>
+half.host
+
+// XnBay Technology : http://www.xnbay.com/
+// Submitted by XnBay Developer <developer.xncloud@gmail.com>
+xnbay.com
+u2.xnbay.com
+u2-local.xnbay.com
+
+// XS4ALL Internet bv : https://www.xs4all.nl/
+// Submitted by Daniel Mostertman <unixbeheer+publicsuffix@xs4all.net>
+cistron.nl
+demon.nl
+xs4all.space
+
+// Yandex.Cloud LLC: https://cloud.yandex.com
+// Submitted by Alexander Lodin <security+psl@yandex-team.ru>
+yandexcloud.net
+storage.yandexcloud.net
+website.yandexcloud.net
+
+// YesCourse Pty Ltd : https://yescourse.com
+// Submitted by Atul Bhouraskar <atul@yescourse.com>
+official.academy
+
+// Yola : https://www.yola.com/
+// Submitted by Stefano Rivera <stefano@yola.com>
+yolasite.com
+
+// Yombo : https://yombo.net
+// Submitted by Mitch Schwenk <mitch@yombo.net>
+ybo.faith
+yombo.me
+homelink.one
+ybo.party
+ybo.review
+ybo.science
+ybo.trade
+
+// Yunohost : https://yunohost.org
+// Submitted by Valentin Grimaud <security@yunohost.org>
+nohost.me
+noho.st
+
+// ZaNiC : http://www.za.net/
+// Submitted by registry <hostmaster@nic.za.net>
+za.net
+za.org
+
+// Zine EOOD : https://zine.bg/
+// Submitted by Martin Angelov <martin@zine.bg>
+bss.design
+
+// Zitcom A/S : https://www.zitcom.dk
+// Submitted by Emil Stahl <esp@zitcom.dk>
+basicserver.io
+virtualserver.io
+enterprisecloud.nu
+
+// Mintere : https://mintere.com/
+// Submitted by Ben Aubin <security@mintere.com>
+mintere.site
+
+// Cityhost LLC  : https://cityhost.ua
+// Submitted by Maksym Rivtin <support@cityhost.net.ua>
+cx.ua
+
+// WP Engine : https://wpengine.com/
+// Submitted by Michael Smith <michael.smith@wpengine.com>
+// Submitted by Brandon DuRette <brandon.durette@wpengine.com>
+wpenginepowered.com
+js.wpenginepowered.com
+
+// Impertrix Solutions : <https://impertrixcdn.com>
+// Submitted by Zhixiang Zhao <csuite@impertrix.com>
+impertrixcdn.com
+impertrix.com
+
+// GignoSystemJapan: http://gsj.bz
+// Submitted by GignoSystemJapan <kakutou-ec@gsj.bz>
+gsj.bz
+// ===END PRIVATE DOMAINS===

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -1,0 +1,131 @@
+"""Helpers """
+import errno
+import json
+import logging
+import os
+import os.path
+from hashlib import md5
+
+from filelock import FileLock
+
+try:
+    unicode
+except NameError:
+    unicode = str  # pylint: disable=invalid-name,redefined-builtin
+
+
+# pylint: enable=import-error,invalid-name,no-name-in-module,redefined-builtin
+
+
+LOG = logging.getLogger(__name__)
+
+
+class DiskCache(object):
+    """Disk _cache that only works for jsonable values"""
+
+    def __init__(self, cache_dir, lock_timeout=20):
+        self.cache_dir = os.path.expanduser(str(cache_dir) or '')
+        self.enabled = bool(cache_dir)
+        self.lock_timeout = lock_timeout
+        # using a unique extension provides some safety that an incorrectly set cache_dir
+        # combined with a call to `.clear()` wont wipe someones hard drive
+        self.file_ext = ".tldextract.json"
+
+    def get(self, namespace, key):
+        """Retrieve a value from the disk cache"""
+        if not self.enabled:
+            raise KeyError("Cache is disabled")
+        cache_filepath = self._key_to_cachefile_path(namespace, key)
+
+        lock_path = cache_filepath + '.lock'
+
+        with FileLock(lock_path, timeout=self.lock_timeout):
+            if not os.path.isfile(cache_filepath):
+                raise KeyError("namespace: " + namespace + " key: " + repr(key))
+            try:
+                with open(cache_filepath) as cache_file:
+                    return json.load(cache_file)
+            except (IOError, ValueError) as exc:
+                LOG.error(
+                    "error reading TLD cache file %s: %s",
+                    cache_filepath,
+                    exc
+                )
+                raise KeyError("namespace: " + namespace + " key: " + repr(key))
+        raise Exception("Should be unreachable")
+
+    def set(self, namespace, key, value):
+        """Set a value in the disk cache"""
+        if not self.enabled:
+            return False
+        cache_filepath = self._key_to_cachefile_path(namespace, key)
+        lock_path = cache_filepath + '.lock'
+        with FileLock(lock_path, timeout=self.lock_timeout):
+            try:
+                with open(cache_filepath, 'w') as cache_file:
+                    json.dump(value, cache_file)
+            except IOError as ioe:
+                LOG.warning(
+                    (
+                        "unable to cache %s.%s in %s. This could refresh the "
+                        "Public Suffix List over HTTP every app startup. "
+                        "Construct your `TLDExtract` with a writable `cache_dir` or "
+                        "set `cache_dir=False` to silence this warning. %s"
+                    ),
+                    namespace,
+                    key,
+                    cache_filepath,
+                    ioe,
+                )
+        return None
+
+    def clear(self):
+        """Clear the disk cache"""
+        for root, _, files in os.walk(self.cache_dir):
+            for filename in files:
+                if filename.endswith(self.file_ext) or filename.endswith(self.file_ext + ".lock"):
+                    os.unlink(os.path.join(root, filename))
+
+    def _key_to_cachefile_path(self, namespace, key):
+        namespace_path = self.cache_dir + '/' + namespace + '/'
+        namespace_path = namespace_path.replace("//", "/")
+        hashed_key = _make_cache_key(key)
+
+        cache_path = namespace_path + '/' + hashed_key + self.file_ext
+
+        _make_dir(cache_path)
+        return cache_path
+
+    def fetch_url(self, session, url, timeout):
+        """Get a url but cache the response"""
+        try:
+            text = self.get(namespace="urls", key=url)
+        except KeyError:
+            response = session.get(url, timeout=timeout)
+            response.raise_for_status()
+            text = response.text
+
+            if not isinstance(text, unicode):
+                text = unicode(text, 'utf-8')
+            self.set(namespace="urls", key=url, value=text)
+
+        return text
+
+
+def _make_cache_key(inputs):
+    key = repr(inputs)
+    try:
+        key = md5(key).hexdigest()
+    except TypeError:
+        key = md5(key.encode('utf8')).hexdigest()
+    return key
+
+
+def _make_dir(filename):
+    """Make a directory if it doesn't already exist"""
+    if not os.path.exists(os.path.dirname(filename)):
+        try:
+            os.makedirs(os.path.dirname(filename))
+        except OSError as exc:  # Guard against race condition
+            if exc.errno != errno.EEXIST:
+                raise

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -13,6 +13,12 @@ try:
 except NameError:
     unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
+try:
+    FileNotFoundError
+except NameError:
+    class FileNotFoundError(Exception):
+        pass
+
 LOG = logging.getLogger(__name__)
 
 
@@ -20,8 +26,8 @@ class DiskCache(object):
     """Disk _cache that only works for jsonable values"""
 
     def __init__(self, cache_dir, lock_timeout=20):
-        self.cache_dir = os.path.expanduser(str(cache_dir) or '')
         self.enabled = bool(cache_dir)
+        self.cache_dir = os.path.expanduser(str(cache_dir) or '')
         self.lock_timeout = lock_timeout
         # using a unique extension provides some safety that an incorrectly set cache_dir
         # combined with a call to `.clear()` wont wipe someones hard drive
@@ -33,46 +39,41 @@ class DiskCache(object):
             raise KeyError("Cache is disabled")
         cache_filepath = self._key_to_cachefile_path(namespace, key)
 
-        lock_path = cache_filepath + '.lock'
-
-        with FileLock(lock_path, timeout=self.lock_timeout):
-            if not os.path.isfile(cache_filepath):
-                raise KeyError("namespace: " + namespace + " key: " + repr(key))
-            try:
-                with open(cache_filepath) as cache_file:
-                    return json.load(cache_file)
-            except (IOError, ValueError) as exc:
-                LOG.error(
-                    "error reading TLD cache file %s: %s",
-                    cache_filepath,
-                    exc
-                )
-                raise KeyError("namespace: " + namespace + " key: " + repr(key))
-        raise Exception("Should be unreachable")
+        if not os.path.isfile(cache_filepath):
+            raise KeyError("namespace: " + namespace + " key: " + repr(key))
+        try:
+            with open(cache_filepath) as cache_file:
+                return json.load(cache_file)
+        except (IOError, ValueError) as exc:
+            LOG.error(
+                "error reading TLD cache file %s: %s",
+                cache_filepath,
+                exc
+            )
+            raise KeyError("namespace: " + namespace + " key: " + repr(key))
 
     def set(self, namespace, key, value):
         """Set a value in the disk cache"""
         if not self.enabled:
             return False
         cache_filepath = self._key_to_cachefile_path(namespace, key)
-        lock_path = cache_filepath + '.lock'
-        with FileLock(lock_path, timeout=self.lock_timeout):
-            try:
-                with open(cache_filepath, 'w') as cache_file:
-                    json.dump(value, cache_file)
-            except IOError as ioe:
-                LOG.warning(
-                    (
-                        "unable to cache %s.%s in %s. This could refresh the "
-                        "Public Suffix List over HTTP every app startup. "
-                        "Construct your `TLDExtract` with a writable `cache_dir` or "
-                        "set `cache_dir=False` to silence this warning. %s"
-                    ),
-                    namespace,
-                    key,
-                    cache_filepath,
-                    ioe,
-                )
+
+        try:
+            with open(cache_filepath, 'w') as cache_file:
+                json.dump(value, cache_file)
+        except IOError as ioe:
+            LOG.warning(
+                (
+                    "unable to cache %s.%s in %s. This could refresh the "
+                    "Public Suffix List over HTTP every app startup. "
+                    "Construct your `TLDExtract` with a writable `cache_dir` or "
+                    "set `cache_dir=False` to silence this warning. %s"
+                ),
+                namespace,
+                key,
+                cache_filepath,
+                ioe,
+            )
         return None
 
     def clear(self):
@@ -80,7 +81,15 @@ class DiskCache(object):
         for root, _, files in os.walk(self.cache_dir):
             for filename in files:
                 if filename.endswith(self.file_ext) or filename.endswith(self.file_ext + ".lock"):
-                    os.unlink(os.path.join(root, filename))
+                    try:
+                        os.unlink(os.path.join(root, filename))
+                    except FileNotFoundError:
+                        pass
+                    except OSError as exc:
+                        # errno.ENOENT == "No such file or directory"
+                        # https://docs.python.org/2/library/errno.html#errno.ENOENT
+                        if exc.errno != errno.ENOENT:
+                            raise
 
     def _key_to_cachefile_path(self, namespace, key):
         namespace_path = os.path.join(self.cache_dir, namespace)
@@ -91,20 +100,48 @@ class DiskCache(object):
         _make_dir(cache_path)
         return cache_path
 
+    def run_and_cache(self, func, namespace, kwargs, hashed_argnames):
+        """Get a url but cache the response"""
+        if not self.enabled:
+            return func(**kwargs)
+
+        key_args = {k: v for k, v in kwargs.items() if k in hashed_argnames}
+        cache_filepath = self._key_to_cachefile_path(namespace, key_args)
+        lock_path = cache_filepath + '.lock'
+        # print(lock_path)
+        with FileLock(lock_path, timeout=self.lock_timeout):
+            try:
+                result = self.get(namespace=namespace, key=key_args)
+            except KeyError:
+                result = func(**kwargs)
+                self.set(namespace="urls", key=key_args, value=result)
+
+            return result
+
     def cached_fetch_url(self, session, url, timeout):
         """Get a url but cache the response"""
-        try:
-            text = self.get(namespace="urls", key=url)
-        except KeyError:
-            response = session.get(url, timeout=timeout)
-            response.raise_for_status()
-            text = response.text
+        return self.run_and_cache(
+            func=_fetch_url,
+            namespace="urls",
+            kwargs={
+                "session": session,
+                "url": url,
+                "timeout": timeout
+            },
+            hashed_argnames=["url"]
+        )
 
-            if not isinstance(text, unicode):
-                text = unicode(text, 'utf-8')
-            self.set(namespace="urls", key=url, value=text)
 
-        return text
+def _fetch_url(session, url, timeout):
+
+    response = session.get(url, timeout=timeout)
+    response.raise_for_status()
+    text = response.text
+
+    if not isinstance(text, unicode):
+        text = unicode(text, 'utf-8')
+
+    return text
 
 
 def _make_cache_key(inputs):

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -13,10 +13,6 @@ try:
 except NameError:
     unicode = str  # pylint: disable=invalid-name,redefined-builtin
 
-
-# pylint: enable=import-error,invalid-name,no-name-in-module,redefined-builtin
-
-
 LOG = logging.getLogger(__name__)
 
 
@@ -87,16 +83,15 @@ class DiskCache(object):
                     os.unlink(os.path.join(root, filename))
 
     def _key_to_cachefile_path(self, namespace, key):
-        namespace_path = self.cache_dir + '/' + namespace + '/'
-        namespace_path = namespace_path.replace("//", "/")
+        namespace_path = os.path.join(self.cache_dir, namespace)
         hashed_key = _make_cache_key(key)
 
-        cache_path = namespace_path + '/' + hashed_key + self.file_ext
+        cache_path = os.path.join(namespace_path, hashed_key + self.file_ext)
 
         _make_dir(cache_path)
         return cache_path
 
-    def fetch_url(self, session, url, timeout):
+    def cached_fetch_url(self, session, url, timeout):
         """Get a url but cache the response"""
         try:
             text = self.get(namespace="urls", key=url)

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -29,15 +29,15 @@ def main():
 
     parser.add_argument('-u', '--update', default=False, action='store_true',
                         help='force fetch the latest TLD definitions')
-    parser.add_argument('-c', '--cache_file',
-                        help='use an alternate TLD definition file')
+    parser.add_argument('-c', '--cache_dir',
+                        help='use an alternate TLD definition caching folder')
     parser.add_argument('-p', '--private_domains', default=False, action='store_true',
                         help='Include private domains')
 
     args = parser.parse_args()
     tld_extract = TLDExtract(include_psl_private_domains=args.private_domains)
 
-    if args.cache_file:
+    if args.cache_dir:
         tld_extract.cache_file = args.cache_file
 
     if args.update:

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -1,64 +1,21 @@
 'tldextract helpers for testing and fetching remote resources.'
 
-
-import logging
 import re
 import socket
 import sys
 
-import requests
-from requests_file import FileAdapter
-
-# pylint: disable=import-error,invalid-name,no-name-in-module,redefined-builtin
+# pylint: disable=import-error,no-name-in-module
 if sys.version_info < (3,):  # pragma: no cover
     from urlparse import scheme_chars
 else:  # pragma: no cover
     from urllib.parse import scheme_chars
-    unicode = str
-# pylint: enable=import-error,invalid-name,no-name-in-module,redefined-builtin
+# pylint: enable=import-error,no-name-in-module
 
 
-IP_RE = re.compile(r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')  # pylint: disable=line-too-long
+IP_RE = re.compile(
+    r'^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$')  # pylint: disable=line-too-long
 
 SCHEME_RE = re.compile(r'^([' + scheme_chars + ']+:)?//')
-
-LOG = logging.getLogger('tldextract')
-
-
-def find_first_response(urls, cache_fetch_timeout=None):
-    """ Decode the first successfully fetched URL, from UTF-8 encoding to
-    Python unicode.
-    """
-    with requests.Session() as session:
-        session.mount('file://', FileAdapter())
-
-        for url in urls:
-            try:
-                resp = session.get(url, timeout=cache_fetch_timeout)
-                resp.raise_for_status()
-            except requests.exceptions.RequestException:
-                LOG.exception(
-                    'Exception reading Public Suffix List url %s',
-                    url
-                )
-            else:
-                return _decode_utf8(resp.text)
-
-    LOG.error(
-        'No Public Suffix List found. Consider using a mirror or constructing '
-        'your TLDExtract with `suffix_list_urls=None`.'
-    )
-    return unicode('')
-
-
-def _decode_utf8(text):
-    """ Decode from utf8 to Python unicode string.
-
-    The suffix list, wherever its origin, should be UTF-8 encoded.
-    """
-    if not isinstance(text, unicode):
-        return unicode(text, 'utf-8')
-    return text
 
 
 def looks_like_ip(maybe_ip):

--- a/tldextract/suffix_list.py
+++ b/tldextract/suffix_list.py
@@ -1,0 +1,72 @@
+'tldextract helpers for testing and fetching remote resources.'
+
+import logging
+import pkgutil
+import re
+import sys
+
+import requests
+from requests_file import FileAdapter
+
+# pylint: disable=invalid-name,redefined-builtin
+if sys.version_info >= (3,):  # pragma: no cover
+    unicode = str
+# pylint: enable=invalid-name,redefined-builtin
+
+LOG = logging.getLogger('tldextract')
+
+PUBLIC_SUFFIX_RE = re.compile(r'^(?P<suffix>[.*!]*\w[\S]*)', re.UNICODE | re.MULTILINE)
+
+
+class SuffixListNotFound(LookupError):
+    pass
+
+
+def find_first_response(cache, urls, cache_fetch_timeout=None):
+    """ Decode the first successfully fetched URL, from UTF-8 encoding to
+    Python unicode.
+    """
+    with requests.Session() as session:
+        session.mount('file://', FileAdapter())
+
+        for url in urls:
+            try:
+                return cache.fetch_url(session=session, url=url, timeout=cache_fetch_timeout)
+            except requests.exceptions.RequestException:
+                LOG.exception(
+                    'Exception reading Public Suffix List url %s',
+                    url
+                )
+    raise SuffixListNotFound(
+        'No Public Suffix List found. Consider using a mirror or constructing '
+        'your TLDExtract with `suffix_list_urls=None`.'
+    )
+
+
+def extract_tlds_from_suffix_list(suffix_list_text):
+    public_text, _, private_text = suffix_list_text.partition('// ===BEGIN PRIVATE DOMAINS===')
+
+    public_tlds = [m.group('suffix') for m in PUBLIC_SUFFIX_RE.finditer(public_text)]
+    private_tlds = [m.group('suffix') for m in PUBLIC_SUFFIX_RE.finditer(private_text)]
+    return public_tlds, private_tlds
+
+
+def get_suffix_lists(cache, urls, cache_fetch_timeout, fallback_to_snapshot):
+    """Fetch, parse, and cache the suffix lists"""
+    try:
+        public_tlds, private_tlds = cache.get(namespace="publicsuffix.org-tlds", key=urls)
+    except KeyError:
+        try:
+            text = find_first_response(cache, urls, cache_fetch_timeout=cache_fetch_timeout)
+        except SuffixListNotFound as exc:
+            if fallback_to_snapshot:
+                text = pkgutil.get_data('tldextract', '.tld_set_snapshot')
+                if not isinstance(text, unicode):
+                    text = unicode(text, 'utf-8')
+            else:
+                raise exc
+
+        public_tlds, private_tlds = extract_tlds_from_suffix_list(text)
+        cache.set(namespace="publicsuffix.org-tlds", key=urls, value=(public_tlds, private_tlds))
+
+    return public_tlds, private_tlds

--- a/tldextract/suffix_list.py
+++ b/tldextract/suffix_list.py
@@ -31,7 +31,7 @@ def find_first_response(cache, urls, cache_fetch_timeout=None):
 
         for url in urls:
             try:
-                return cache.fetch_url(session=session, url=url, timeout=cache_fetch_timeout)
+                return cache.cached_fetch_url(session=session, url=url, timeout=cache_fetch_timeout)
             except requests.exceptions.RequestException:
                 LOG.exception(
                     'Exception reading Public Suffix List url %s',

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest-pylint
     responses
     requests
+    filelock
 
 commands = pytest {posargs}
 


### PR DESCRIPTION
This is a second attempt at doing what was done in https://github.com/john-kurkowski/tldextract/pull/144.

Addresses #66 

- Adds `include_psl_private_domains` to the `__call__` method.  This is now something you can choose on a per-call basis.  The object level argument now is only a default value for each call.
- The entire dataset from publicsuffix.org is saved to cache
- Ensured no weird cache issues happen when using with different `suffix_list_urls` by using different filenames per `suffix_list_urls`
- Use filelock to support multiprocessing and multithreading use cases
- Updates the bundled snapshot to be the raw publicsuffix data. Need to look at performance impact of this.
- various other cleanups
- Breaking change `cache_file` => `cache_dir`