### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ matrix:
       env: TOXENV=pypy3
     - env: TOXENV=codestyle
     - env: TOXENV=lint
+    #powerjobs
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=codestyle
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=lint
+    
 python: 3.7
 install: pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - env: TOXENV=lint
     #powerjobs
     - python: 3.8
+      arch: ppc64le
       env: TOXENV=py38
     - python: 3.7
       arch: ppc64le


### PR DESCRIPTION
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. 
