### PR TITLE
tests: do not run pylint by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --doctest-modules --pylint
+addopts = --doctest-modules

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     pytest-pylint
     responses
 
-commands = pytest {posargs}
+commands = pytest --pylint {posargs}
 
 [testenv:codestyle]
 deps = pycodestyle


### PR DESCRIPTION
Hi,
There is already a separate tox environment to run pylint tests. I think it makes sense not to run pylint by default.

While normal tests should be run by downstream (in particular Linux distributions which package tldextract), linter tests should not be run automatically.