### PR TITLE
Remove py2 tag from wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE


### PR DESCRIPTION
Universal wheels are for supporting Python 2 and 3, and adds the unnecessary `py2` tag to the wheel metadata and filename:

* `tldextract-3.1.2-py2.py3-none-any.whl`

https://pypi.org/project/tldextract/3.1.2/#files

https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels