### PR TITLE
Add support for Python 3.10, drop EOL 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: TOXENV=py39
     - python: "3.10"
       env: TOXENV=py310
-    - python: pypy3
+    - python: pypy3.7
       env: TOXENV=pypy3
     - env: TOXENV=codestyle
     - env: TOXENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: TOXENV=py39
     - python: "3.10"
       env: TOXENV=py310
-    - python: pypy3.7
+    - python: pypy3.7-7.3.5
       dist: xenial
       env: TOXENV=pypy3
     - env: TOXENV=codestyle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
   include:
-    - python: "3.6"
-      env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37
     - python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,21 @@
 language: python
 matrix:
   include:
-    - python: 3.6
+    - python: "3.6"
       env: TOXENV=py36
-    - python: 3.7
+    - python: "3.7"
       env: TOXENV=py37
-    - python: 3.8
+    - python: "3.8"
       env: TOXENV=py38
-    - python: 3.9
+    - python: "3.9"
       env: TOXENV=py39
+    - python: "3.10"
+      env: TOXENV=py310
     - python: pypy3
       env: TOXENV=pypy3
     - env: TOXENV=codestyle
     - env: TOXENV=lint
     - env: TOXENV=typecheck
-python: 3.9
+python: "3.10"
 install: pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - python: "3.10"
       env: TOXENV=py310
     - python: pypy3.7
+      dist: xenial
       env: TOXENV=pypy3
     - env: TOXENV=codestyle
     - env: TOXENV=lint

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 5):
+if sys.version_info < (3, 7):
     raise RuntimeError(
         "Python %s.%s is EOL and no longer supported. "
         "Please upgrade your Python or use an older "
@@ -54,7 +54,7 @@ setup(
     url="https://github.com/john-kurkowski/tldextract",
     packages=["tldextract"],
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     long_description=__doc__,
     long_description_content_type="text/markdown",
     classifiers=[
@@ -62,7 +62,6 @@ setup(
         "Topic :: Utilities",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     entry_points={"console_scripts": ["tldextract = tldextract.cli:main", ]},
     setup_requires=["setuptools_scm"],

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Main tldextract unit tests."""
 
 import logging

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -23,7 +23,7 @@ def looks_like_ip(maybe_ip):
     except (AttributeError, UnicodeError):
         if IP_RE.match(maybe_ip):
             return True
-    except socket.error:
+    except OSError:
         pass
 
     return False

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """`tldextract` accurately separates the gTLD or ccTLD (generic or country code
 top-level domain) from the registered domain and subdomains of a URL.
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,py3},codestyle,lint,typecheck
+envlist = py{36,37,38,39,310,py3},codestyle,lint,typecheck
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,39,310,py3},codestyle,lint,typecheck
+envlist = py{37,38,39,310,py3},codestyle,lint,typecheck
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

Python 3.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

https://endoflife.date/python
