### PR TITLE
Rely on python_requires instead of runtime check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,6 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 7):
-    raise RuntimeError(
-        "Python %s.%s is EOL and no longer supported. "
-        "Please upgrade your Python or use an older "
-        "version of tldextract." % (sys.version_info[0], sys.version_info[1])
-    )
-
 INSTALL_REQUIRES = ["idna", "requests>=2.1.0", "requests-file>=1.4", "filelock>=3.0.8"]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,6 @@ By default, this package supports the public ICANN TLDs and their exceptions.
 You can optionally support the Public Suffix List's private domains as well.
 """
 
-import sys
-
 from setuptools import setup
 
 INSTALL_REQUIRES = ["idna", "requests>=2.1.0", "requests-file>=1.4", "filelock>=3.0.8"]


### PR DESCRIPTION
Re: https://github.com/john-kurkowski/tldextract/pull/246#discussion_r810826911

`python_requires` and the removal of the `py2` wheel tag render this unnecessary with modern tools.

