### PR TITLE
Enforce opinionated code style in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,3 +264,12 @@ Run all tests against a specific Python environment configuration:
 tox -l
 tox -e py37
 ```
+
+### Code Style
+
+Automatically format all code:
+
+```zsh
+pip install black
+black .
+```

--- a/tldextract/__main__.py
+++ b/tldextract/__main__.py
@@ -1,8 +1,7 @@
-'''tldextract __main__.'''
+"""tldextract __main__."""
 
 
 from .cli import main
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -2,9 +2,7 @@
 
 import re
 import socket
-
 from urllib.parse import scheme_chars
-
 
 IP_RE = re.compile(
     # pylint: disable-next=line-too-long

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,12 @@ deps =
 commands = pytest --pylint {posargs}
 
 [testenv:codestyle]
-deps = pycodestyle
-commands = pycodestyle tldextract tests {posargs}
+deps =
+    black
+    pycodestyle
+commands =
+    pycodestyle tldextract tests {posargs}
+    black --check {posargs:.}
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
I've been manually running Black on files in this project and other projects. I like how it looks, how it removes inconsistencies, and how it removes nitpicks between developers. We've all got bigger fish to fry. This reduces mental burden.

This PR only enforces Black's opinionated code style when running tests. It does not apply it nor enforce it with a e.g. Git pre-commit hook, like using [pre-commit](https://pre-commit.com/).

# Open Issues

* [x] Some way to run automatically apply Black in this project, not just check it
    * It's annoying for CI to bark at you, with no recourse locally. If you don't already have Black wired up in your IDE, independent of this project.
    * [pre-commit](https://pre-commit.com/) is the top candidate. But pre-commit does require a manual install step? Could things be simpler? Just to get this opinionated code style started in this project.