### PR TITLE
Fix incorrect namespace used for caching function returns

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,7 +2,7 @@
 import os.path
 import sys
 import types
-from typing import Any, cast
+from typing import Any, Dict, Hashable, cast
 from unittest.mock import Mock
 
 import pytest
@@ -80,7 +80,7 @@ def test_run_and_cache(tmpdir):
 
     return_value1 = "unique return value"
     some_fn = Mock(return_value=return_value1)
-    kwargs1 = {"value": 1}
+    kwargs1: Dict[str, Hashable] = {"value": 1}
 
     assert some_fn.call_count == 0
 
@@ -92,7 +92,7 @@ def test_run_and_cache(tmpdir):
     assert call2 == return_value1
     assert some_fn.call_count == 1
 
-    kwargs2 = {"value": 2}
+    kwargs2: Dict[str, Hashable] = {"value": 2}
     return_value2 = "another return value"
     some_fn.return_value = return_value2
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -72,3 +72,23 @@ def test_get_cache_dir(monkeypatch):
     monkeypatch.setenv("TLDEXTRACT_CACHE", "/alt-tld-cache")
 
     assert get_cache_dir() == "/alt-tld-cache"
+
+
+def test_cache_and_run(tmpdir):
+    cache = DiskCache(tmpdir)
+
+    def return_value(value):
+        """Test function that returns whatever is passed to it."""
+        return value
+
+    # Call the cache with a function that returns any value
+    first_call = cache.run_and_cache(return_value, "testing", {"value": 1}, {"value"})
+
+    def raise_error(*args, **kwags):  # pylint: disable=unused-argument
+        """Test function that raises an error."""
+        raise RuntimeError()
+
+    # Calling it again with the same namespace and hash should give the same
+    # value
+    second_call = cache.run_and_cache(raise_error, "testing", {"value": 1}, {"value"})
+    assert first_call == second_call

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -7,7 +7,7 @@ import os
 import os.path
 import sys
 from hashlib import md5
-from typing import Callable, Dict, Hashable, List, Optional, TypeVar, Union
+from typing import Callable, Dict, Hashable, Iterable, Optional, TypeVar, Union
 
 from filelock import FileLock
 import requests
@@ -166,7 +166,7 @@ class DiskCache:
         func: Callable[..., T],
         namespace: str,
         kwargs: Dict[str, Hashable],
-        hashed_argnames: List[str],
+        hashed_argnames: Iterable[str],
     ) -> T:
         """Get a url but cache the response"""
         if not self.enabled:

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -203,7 +203,7 @@ class DiskCache:
                 result: T = self.get(namespace=namespace, key=key_args)
             except KeyError:
                 result = func(**kwargs)
-                self.set(namespace="urls", key=key_args, value=result)
+                self.set(namespace=namespace, key=key_args, value=result)
 
             return result
 


### PR DESCRIPTION
This PR fixes #257.

Currently, the namespace is not passed to the function that sets the cache, and instead the literal "urls" is passed. As a result, non-url related functions, such as the function to cache the public suffixes were not cached.

This PR fixes this by using the `namespace` argument which is passed in to the `run_and_cache` function, and adds a regression test.