### PR TITLE
Add CLI option to not fall back to the snapshot

### DIFF
--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -41,11 +41,19 @@ def main():
         action="store_true",
         help="Include private domains",
     )
+    parser.add_argument(
+        "--no_fallback_to_snapshot",
+        default=True,
+        action="store_false",
+        dest="fallback_to_snapshot",
+        help="Don't fall back to the package's snapshot of the prefix list",
+    )
 
     args = parser.parse_args()
 
     obj_kwargs = {
         "include_psl_private_domains": args.private_domains,
+        "fallback_to_snapshot": args.fallback_to_snapshot,
     }
     if args.cache_dir:
         obj_kwargs["cache_dir"] = args.cache_dir

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -46,7 +46,7 @@ def main() -> None:
         default=True,
         action="store_false",
         dest="fallback_to_snapshot",
-        help="Don't fall back to the package's snapshot of the prefix list",
+        help="Don't fall back to the package's snapshot of the suffix list",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
This fixes #259.

It adds a new commandline option which will prevent the lookup / update from using the package's cache.