### PR TITLE
Add method to extract from a urllib.parse.{ParseResult,SplitResult}

### DIFF
--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -12,6 +12,23 @@ IP_RE = re.compile(
 SCHEME_RE = re.compile(r"^([" + scheme_chars + "]+:)?//")
 
 
+def lenient_netloc(url: str) -> str:
+    """Extract the netloc of a URL-like string, similar to the netloc attribute
+    returned by urllib.parse.{urlparse,urlsplit}, but extract more leniently,
+    without raising errors."""
+
+    return (
+        SCHEME_RE.sub("", url)
+        .partition("/")[0]
+        .partition("?")[0]
+        .partition("#")[0]
+        .split("@")[-1]
+        .partition(":")[0]
+        .strip()
+        .rstrip(".")
+    )
+
+
 def looks_like_ip(maybe_ip: str) -> bool:
     """Does the given str look like an IP address?"""
     if not maybe_ip[0].isdigit():


### PR DESCRIPTION
* Add method `extract_urllib`
* Add method `extract_str`, an alias for `__call__`
* Move this library's lenient netloc extraction to its own function

The new method `extract_urllib` is like `extract_str` or `__call__` but faster, as the string's domain name has already been parsed.