### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "exceptions. You can optionally support the Public Suffix "
         "List's private domains as well."
     ),
-    license="BSD License",
+    license="BSD-3-Clause",
     keywords=(
         "tld domain subdomain url parse extract urlparse urlsplit public suffix list"
         " publicsuffix publicsuffixlist"


### PR DESCRIPTION
Use SPDX license identifier: BSD-3-Clause
This will help tools to produce valid SPDX.