### PR TITLE
Optimise suffix_index() for URLs with long subdomains

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -7,6 +7,7 @@ from typing import Sequence, Tuple
 
 import pytest
 import responses
+
 import tldextract
 import tldextract.suffix_list
 from tldextract.cache import DiskCache
@@ -84,6 +85,12 @@ def test_odd_but_possible():
 def test_suffix():
     assert_extract("com", ("", "", "", "com"))
     assert_extract("co.uk", ("", "", "", "co.uk"))
+    assert_extract("example.ck", ("", "", "", "example.ck"))
+    assert_extract("www.example.ck", ("www.example.ck", "", "www", "example.ck"))
+    assert_extract(
+        "sub.www.example.ck", ("sub.www.example.ck", "sub", "www", "example.ck")
+    )
+    assert_extract("www.ck", ("www.ck", "", "www", "ck"))
 
 
 def test_local_host():
@@ -270,6 +277,16 @@ def test_tld_is_a_website_too():
     # This is unhandled by the PSL. Or is it?
     # assert_extract(http://www.net.cn',
     #                ('www.net.cn', 'www', 'net', 'cn'))
+
+
+def test_no_1st_level_tld():
+    assert_extract("za", ("", "", "za", ""))
+    assert_extract("example.za", ("", "example", "za", ""))
+    assert_extract("co.za", ("", "", "", "co.za"))
+    assert_extract("example.co.za", ("example.co.za", "", "example", "co.za"))
+    assert_extract(
+        "sub.example.co.za", ("sub.example.co.za", "sub", "example", "co.za")
+    )
 
 
 def test_dns_root_label():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -91,6 +91,8 @@ def test_suffix():
         "sub.www.example.ck", ("sub.www.example.ck", "sub", "www", "example.ck")
     )
     assert_extract("www.ck", ("www.ck", "", "www", "ck"))
+    assert_extract("nes.buskerud.no", ("", "", "", "nes.buskerud.no"))
+    assert_extract("buskerud.no", ("buskerud.no", "", "buskerud", "no"))
 
 
 def test_local_host():
@@ -387,3 +389,29 @@ def test_global_extract():
     assert tldextract.extract(
         "s3.ap-south-1.amazonaws.com", include_psl_private_domains=True
     ) == ExtractResult(subdomain="", domain="", suffix="s3.ap-south-1.amazonaws.com")
+    assert tldextract.extract(
+        "the-quick-brown-fox.ap-south-1.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(
+        subdomain="the-quick-brown-fox.ap-south-1", domain="amazonaws", suffix="com"
+    )
+    assert tldextract.extract(
+        "ap-south-1.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="ap-south-1", domain="amazonaws", suffix="com")
+    assert tldextract.extract(
+        "amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="", domain="amazonaws", suffix="com")
+    assert tldextract.extract(
+        "s3.cn-north-1.amazonaws.com.cn", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="", domain="", suffix="s3.cn-north-1.amazonaws.com.cn")
+    assert tldextract.extract(
+        "the-quick-brown-fox.cn-north-1.amazonaws.com.cn",
+        include_psl_private_domains=True,
+    ) == ExtractResult(
+        subdomain="the-quick-brown-fox.cn-north-1", domain="amazonaws", suffix="com.cn"
+    )
+    assert tldextract.extract(
+        "cn-north-1.amazonaws.com.cn", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="cn-north-1", domain="amazonaws", suffix="com.cn")
+    assert tldextract.extract(
+        "amazonaws.com.cn", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="", domain="amazonaws", suffix="com.cn")

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -384,3 +384,6 @@ def test_global_extract():
     assert tldextract.extract(
         "foo.blogspot.com", include_psl_private_domains=True
     ) == ExtractResult(subdomain="", domain="foo", suffix="blogspot.com")
+    assert tldextract.extract(
+        "s3.ap-south-1.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="", domain="", suffix="s3.ap-south-1.amazonaws.com")

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -18,11 +18,11 @@ def lenient_netloc(url: str) -> str:
     without raising errors."""
 
     return (
-        SCHEME_RE.sub("", url)
+        SCHEME_RE.sub("", url, 1)
         .partition("/")[0]
         .partition("?")[0]
         .partition("#")[0]
-        .split("@")[-1]
+        .rpartition("@")[-1]
         .partition(":")[0]
         .strip()
         .rstrip(".")

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -5,8 +5,8 @@ import socket
 from urllib.parse import scheme_chars
 
 IP_RE = re.compile(
-    # pylint: disable-next=line-too-long
-    r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+    r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)"
+    r"{3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
 )
 
 SCHEME_RE = re.compile(r"^([" + scheme_chars + "]+:)?//")

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -88,8 +88,8 @@ class ExtractResult(NamedTuple):
         >>> extract('http://localhost:8080').registered_domain
         ''
         """
-        if self.domain and self.suffix:
-            return self.domain + "." + self.suffix
+        if self.suffix and self.domain:
+            return f"{self.domain}.{self.suffix}"
         return ""
 
     @property
@@ -102,7 +102,7 @@ class ExtractResult(NamedTuple):
         >>> extract('http://localhost:8080').fqdn
         ''
         """
-        if self.domain and self.suffix:
+        if self.suffix and self.domain:
             # Disable bogus lint error (https://github.com/PyCQA/pylint/issues/2568)
             # pylint: disable-next=not-an-iterable
             return ".".join(i for i in self if i)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -50,7 +50,6 @@ or suffix were found:
 
 import logging
 import os
-import re
 import urllib.parse
 from functools import wraps
 from typing import FrozenSet, List, NamedTuple, Optional, Sequence, Union
@@ -70,8 +69,6 @@ PUBLIC_SUFFIX_LIST_URLS = (
     "https://publicsuffix.org/list/public_suffix_list.dat",
     "https://raw.githubusercontent.com/publicsuffix/list/master/public_suffix_list.dat",
 )
-
-_UNICODE_DOTS_RE = re.compile("[\u002e\u3002\uff0e\uff61]")
 
 
 class ExtractResult(NamedTuple):
@@ -251,7 +248,12 @@ class TLDExtract:
     def _extract_netloc(
         self, netloc: str, include_psl_private_domains: Optional[bool]
     ) -> ExtractResult:
-        labels = _UNICODE_DOTS_RE.split(netloc)
+        labels = (
+            netloc.replace("\u3002", "\u002e")
+            .replace("\uff0e", "\u002e")
+            .replace("\uff61", "\u002e")
+            .split(".")
+        )
 
         suffix_index = self._get_tld_extractor().suffix_index(
             labels, include_psl_private_domains=include_psl_private_domains

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -52,7 +52,7 @@ import logging
 import os
 import urllib.parse
 from functools import wraps
-from typing import FrozenSet, List, NamedTuple, Optional, Sequence, Set, Union
+from typing import FrozenSet, List, NamedTuple, Optional, Sequence, Union
 
 import idna
 
@@ -364,13 +364,11 @@ class _PublicSuffixListTLDExtractor:
         Example: If valid TLDs include only ["a.b.c.d", "d"], then
         ["b.c.d", "c.d"] are false intermediate suffixes.
         """
-        valid_tlds: Set[str] = set(tlds)
-        false_tlds: Set[str] = set()
+        valid_tlds = set(tlds)
+        false_tlds = set()
         for tld in valid_tlds:
-            labels: List[str] = tld.split(".")
-            variants: Set[str] = set(
-                ".".join(labels[-i:]) for i in range(1, len(labels))
-            )
+            labels = tld.split(".")
+            variants = {".".join(labels[-i:]) for i in range(1, len(labels))}
             false_tlds.update(variants)
         return list(false_tlds.difference(valid_tlds))
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -253,9 +253,8 @@ class TLDExtract:
     ) -> ExtractResult:
         labels = _UNICODE_DOTS_RE.split(netloc)
 
-        translations = [_decode_punycode(label) for label in labels]
         suffix_index = self._get_tld_extractor().suffix_index(
-            translations, include_psl_private_domains=include_psl_private_domains
+            labels, include_psl_private_domains=include_psl_private_domains
         )
 
         suffix = ".".join(labels[suffix_index:])
@@ -373,7 +372,11 @@ class _PublicSuffixListTLDExtractor:
         maybe_tld = ""
         prev_maybe_tld = ""
         for label in reversed(lower_spl):
-            maybe_tld = f"{label}.{maybe_tld}" if maybe_tld else label
+            maybe_tld = (
+                f"{_decode_punycode(label)}.{maybe_tld}"
+                if maybe_tld
+                else _decode_punycode(label)
+            )
 
             if "!" + maybe_tld in tlds:
                 return i + 1
@@ -386,10 +389,10 @@ class _PublicSuffixListTLDExtractor:
                 continue
             if i >= 2:
                 prev_maybe_tld = maybe_tld
-                if f"{lower_spl[i - 2]}.{maybe_tld}" in tlds:
+                if f"{_decode_punycode(lower_spl[i-2])}.{maybe_tld}" in tlds:
                     i -= 1
                     continue
-                if f"!{lower_spl[i - 2]}.{maybe_tld}" in tlds:
+                if f"!{_decode_punycode(lower_spl[i-2])}.{maybe_tld}" in tlds:
                     return i - 1
                 if "*." + prev_maybe_tld in tlds:
                     return i - 2

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -389,10 +389,11 @@ class _PublicSuffixListTLDExtractor:
                 continue
             if i >= 2:
                 prev_maybe_tld = maybe_tld
-                if f"{_decode_punycode(lower_spl[i-2])}.{maybe_tld}" in tlds:
+                next_maybe_tld = f"{_decode_punycode(lower_spl[i-2])}.{maybe_tld}"
+                if next_maybe_tld in tlds:
                     i -= 1
                     continue
-                if f"!{_decode_punycode(lower_spl[i-2])}.{maybe_tld}" in tlds:
+                if f"!{next_maybe_tld}" in tlds:
                     return i - 1
                 if "*." + prev_maybe_tld in tlds:
                     return i - 2

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -431,17 +431,6 @@ class _PublicSuffixListTLDExtractor:
                 j -= 1
                 prev_maybe_tld = maybe_tld
                 continue
-            if j >= 2:
-                prev_maybe_tld = maybe_tld
-                next_maybe_tld = f"{_decode_punycode(spl[j-2])}.{maybe_tld}"
-                if next_maybe_tld in tlds:
-                    j -= 1
-                    i = j
-                    continue
-                if f"!{next_maybe_tld}" in tlds:
-                    return j - 1
-                if "*." + prev_maybe_tld in tlds:
-                    return j - 2
             break
         return i
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -399,18 +399,18 @@ class _PublicSuffixListTLDExtractor:
         )
 
     def suffix_index(
-        self, lower_spl: List[str], include_psl_private_domains: Optional[bool] = None
+        self, spl: List[str], include_psl_private_domains: Optional[bool] = None
     ) -> int:
         """Returns the index of the first suffix label.
         Returns len(spl) if no suffix is found
         """
         tlds = self.tlds(include_psl_private_domains)
         false_tlds = self.false_tlds(include_psl_private_domains)
-        i = len(lower_spl)
+        i = len(spl)
         j = i
         maybe_tld = ""
         prev_maybe_tld = ""
-        for label in reversed(lower_spl):
+        for label in reversed(spl):
             maybe_tld = (
                 f"{_decode_punycode(label)}.{maybe_tld}"
                 if maybe_tld
@@ -433,7 +433,7 @@ class _PublicSuffixListTLDExtractor:
                 continue
             if j >= 2:
                 prev_maybe_tld = maybe_tld
-                next_maybe_tld = f"{_decode_punycode(lower_spl[j-2])}.{maybe_tld}"
+                next_maybe_tld = f"{_decode_punycode(spl[j-2])}.{maybe_tld}"
                 if next_maybe_tld in tlds:
                     j -= 1
                     i = j

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -88,8 +88,8 @@ class ExtractResult(NamedTuple):
         >>> extract('http://localhost:8080').registered_domain
         ''
         """
-        if self.suffix and self.domain:
-            return f"{self.domain}.{self.suffix}"
+        if self.domain and self.suffix:
+            return self.domain + "." + self.suffix
         return ""
 
     @property
@@ -102,7 +102,7 @@ class ExtractResult(NamedTuple):
         >>> extract('http://localhost:8080').fqdn
         ''
         """
-        if self.suffix and self.domain:
+        if self.domain and self.suffix:
             # Disable bogus lint error (https://github.com/PyCQA/pylint/issues/2568)
             # pylint: disable-next=not-an-iterable
             return ".".join(i for i in self if i)


### PR DESCRIPTION
Current implementation of **suffix_index()**  searches for longest matching TLDs starting from the left side.

This disadvantages URLs with long subdomains like `a.very.long.subdomain.example.co.uk`:

- a.very.long.subdomain.example.co.uk
- very.long.subdomain.example.co.uk
- long.subdomain.example.co.uk
- subdomain.example.co.uk
- example.co.uk
- co.uk **match**

By searching from the right side instead, we can reduce the number of steps to:

- uk
- co.uk **match**

Since we are now searching from the right, we can optimise **suffix_index()** even further by moving calls to **_decode_punycode()** into **suffix_index()**'s loop; this reduces execution time even for short URLs by converting label to punycode only when necessary.

I also found that **str.replace 3 times + str.split** is consistently faster than **re.compile + re.split**. In fact, the performance gap is wider for larger strings with many unicode dots to replace (see the last 2 test cases in the benchmarks).

### Benchmarks

Unicode dots are used. On average **10%-40%** reduction in execution time. Time savings would be even longer for very long subdomains. The last line is a large string filled with all 3 non-ascii dots.

Helps #175. A trie should be much faster, but it is more complex to implement correctly. Perhaps in a future PR?

Python 3.10, Linux x64, Ryzen 7 5800X

```python
import tldextract

%timeit tldextract.extract("")
%timeit tldextract.extract("com")
%timeit tldextract.extract("example\u3002com")
%timeit tldextract.extract("subdomain\uff0eexample\uff61com")
%timeit tldextract.extract("a\u3002very\uff0elong\uff61subdomain\u3002example\uff0ecom")
%timeit tldextract.extract("an\uff61even\u3002longer\uff0eand\uff61complex\u3002subdomain\uff0eexample\uff61com")
%timeit tldextract.extract("https://a\u3002b\uff0ec\uff61d\u3002e\uff0ef\uff61g\u3002h\uff0ei\uff61j\u3002k\uff0el\uff61m\u3002n\uff0eoo\uff61pp\u3002qqq\uff0errrr\uff61ssssss\u3002tttttttt\uff0euuuuuuuuuuu\uff61vvvvvvvvvvvvvvv\u3002wwwwwwwwwwwwwwwwwwwwww\uff0exxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\uff61yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\u3002zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.tw")
%timeit tldextract.extract("\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61")
```
#### Before

```python
1.77 µs ± 13.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.92 µs ± 9.67 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.62 µs ± 6.85 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.26 µs ± 2.66 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
4.99 µs ± 10.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
6.24 µs ± 9.04 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
26.3 µs ± 29.8 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
164 µs ± 369 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

#### After Changes 1-3

```python
1.76 µs ± 9.35 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.91 µs ± 12.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.62 µs ± 9.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.1 µs ± 7.18 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.39 µs ± 12.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.64 µs ± 61.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
6.91 µs ± 64 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
11.4 µs ± 45.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```


#### After Changes 1-4 (re.split replaced with str.replace + str.split)

```python
1.66 µs ± 14.6 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.84 µs ± 9.78 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.46 µs ± 7.12 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.88 µs ± 3.83 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.09 µs ± 31 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.21 µs ± 11.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
4.01 µs ± 20.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
5.26 µs ± 25.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## Changes

1. Added test cases for exceptions `!` and `*.`, and edge cases for `.za` (no first level TLD).
2. Refactored **suffix_index()** to search for longest matching TLDs starting from right side instead of left side.
3. Moved **_decode_punycode()** call into **suffix_index()**
4. Replaced re.split with str.replace + str.split