### PR TITLE
Optimize netloc extraction

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -218,6 +218,8 @@ def test_scheme():
     assert_extract("://", ("", "", "", ""))
     assert_extract("://example.com", ("", "", "", ""))
     assert_extract("a+-.://example.com", ("example.com", "", "example", "com"))
+    assert_extract("a#//example.com", ("", "", "a", ""))
+    assert_extract("a@://example.com", ("", "", "", ""))
     assert_extract("#//example.com", ("", "", "", ""))
     assert_extract(
         "https://mail.google.com/mail", ("mail.google.com", "mail", "google", "com")

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -205,6 +205,11 @@ def test_empty():
 
 
 def test_scheme():
+    assert_extract("//", ("", "", "", ""))
+    assert_extract("://", ("", "", "", ""))
+    assert_extract("://example.com", ("", "", "", ""))
+    assert_extract("a+-.://example.com", ("example.com", "", "example", "com"))
+    assert_extract("#//example.com", ("", "", "", ""))
     assert_extract(
         "https://mail.google.com/mail", ("mail.google.com", "mail", "google", "com")
     )

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -12,10 +12,10 @@ IP_RE = re.compile(
 scheme_chars_set = set(scheme_chars)
 
 
-def without_netloc_right(schemeless_netloc: str) -> str:
-    """Returns schemeless netloc without any URL components on its right"""
+def extract_netloc(schemeless_url: str) -> str:
+    """Extract netloc from a schemeless URL"""
     return (
-        schemeless_netloc.partition("/")[0]
+        schemeless_url.partition("/")[0]
         .partition("?")[0]
         .partition("#")[0]
         .rpartition("@")[-1]
@@ -32,14 +32,14 @@ def lenient_netloc(url: str) -> str:
 
     double_slashes_start = url.find("//")
     if double_slashes_start == 0:
-        return without_netloc_right(url[2:])
+        return extract_netloc(url[2:])
     if (
         double_slashes_start < 2
         or not url[double_slashes_start - 1] == ":"
         or set(url[: double_slashes_start - 1]) - scheme_chars_set
     ):
-        return without_netloc_right(url)
-    return without_netloc_right(url[double_slashes_start + 2 :])
+        return extract_netloc(url)
+    return extract_netloc(url[double_slashes_start + 2 :])
 
 
 def looks_like_ip(maybe_ip: str) -> bool:

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -13,7 +13,7 @@ scheme_chars_set = set(scheme_chars)
 
 
 def without_netloc_right(schemeless_netloc: str) -> str:
-    """Returns schemelss netloc without any URL components on its right"""
+    """Returns schemeless netloc without any URL components on its right"""
     return (
         schemeless_netloc.partition("/")[0]
         .partition("?")[0]

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -12,10 +12,13 @@ IP_RE = re.compile(
 scheme_chars_set = set(scheme_chars)
 
 
-def extract_netloc(schemeless_url: str) -> str:
-    """Extract netloc from a schemeless URL"""
+def lenient_netloc(url: str) -> str:
+    """Extract the netloc of a URL-like string, similar to the netloc attribute
+    returned by urllib.parse.{urlparse,urlsplit}, but extract more leniently,
+    without raising errors."""
     return (
-        schemeless_url.partition("/")[0]
+        _schemeless_url(url)
+        .partition("/")[0]
         .partition("?")[0]
         .partition("#")[0]
         .rpartition("@")[-1]
@@ -25,21 +28,17 @@ def extract_netloc(schemeless_url: str) -> str:
     )
 
 
-def lenient_netloc(url: str) -> str:
-    """Extract the netloc of a URL-like string, similar to the netloc attribute
-    returned by urllib.parse.{urlparse,urlsplit}, but extract more leniently,
-    without raising errors."""
-
+def _schemeless_url(url: str) -> str:
     double_slashes_start = url.find("//")
     if double_slashes_start == 0:
-        return extract_netloc(url[2:])
+        return url[2:]
     if (
         double_slashes_start < 2
         or not url[double_slashes_start - 1] == ":"
         or set(url[: double_slashes_start - 1]) - scheme_chars_set
     ):
-        return extract_netloc(url)
-    return extract_netloc(url[double_slashes_start + 2 :])
+        return url
+    return url[double_slashes_start + 2 :]
 
 
 def looks_like_ip(maybe_ip: str) -> bool:


### PR DESCRIPTION
**SCHEME_RE** can be replaced with an **if-else** equivalent for tangible speed improvement.

Benchmarks of this optimization together with improvements in #283

Python 3.10, Linux x64, Ryzen 7 5800X

```python
import tldextract

%timeit tldextract.extract("")
%timeit tldextract.extract("com")
%timeit tldextract.extract("example\u3002com")
%timeit tldextract.extract("subdomain\uff0eexample\uff61com")
%timeit tldextract.extract("a\u3002very\uff0elong\uff61subdomain\u3002example\uff0ecom")
%timeit tldextract.extract("an\uff61even\u3002longer\uff0eand\uff61complex\u3002subdomain\uff0eexample\uff61com")
%timeit tldextract.extract("https://a\u3002b\uff0ec\uff61d\u3002e\uff0ef\uff61g\u3002h\uff0ei\uff61j\u3002k\uff0el\uff61m\u3002n\uff0eoo\uff61pp\u3002qqq\uff0errrr\uff61ssssss\u3002tttttttt\uff0euuuuuuuuuuu\uff61vvvvvvvvvvvvvvv\u3002wwwwwwwwwwwwwwwwwwwwww\uff0exxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\uff61yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\u3002zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.tw")
%timeit tldextract.extract("\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61")
```

```python
1.72 µs ± 14.4 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.75 µs ± 15.7 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.34 µs ± 9.41 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.41 µs ± 4.97 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.6 µs ± 4.92 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.67 µs ± 18.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.76 µs ± 13.4 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
4.49 µs ± 21.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## Changes

- Replaced **SCHEME_RE** with faster **if-else** equivalent