### PR TITLE
Implement Trie for suffix detection

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -302,6 +302,15 @@ def test_dns_root_label():
     assert_extract(
         "http://www.example.com./", ("www.example.com", "www", "example", "com")
     )
+    assert_extract(
+        "http://www.example.com\u3002/", ("www.example.com", "www", "example", "com")
+    )
+    assert_extract(
+        "http://www.example.com\uff0e/", ("www.example.com", "www", "example", "com")
+    )
+    assert_extract(
+        "http://www.example.com\uff61/", ("www.example.com", "www", "example", "com")
+    )
 
 
 def test_private_domains():

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -1,0 +1,53 @@
+"""Trie tests"""
+from itertools import permutations
+
+from tldextract.tldextract import Trie
+
+
+def test_nested_dict() -> None:
+    original_keys_sequence = [
+        ["a"],
+        ["a", "d"],
+        ["a", "b"],
+        ["a", "b", "c"],
+        ["c"],
+        ["c", "b"],
+        ["d", "f"],
+    ]
+    for keys_sequence in permutations(original_keys_sequence):
+        trie = Trie()
+        for keys in keys_sequence:
+            trie.add_suffix(keys)
+        # check each nested value
+        # Top level c
+        assert "c" in trie.matches
+        top_c = trie.matches["c"]
+        assert len(top_c.matches) == 1
+        assert "b" in top_c.matches
+        assert top_c.end
+        # Top level a
+        assert "a" in trie.matches
+        top_a = trie.matches["a"]
+        assert len(top_a.matches) == 2
+        #  a -> d
+        assert "d" in top_a.matches
+        a_to_d = top_a.matches["d"]
+        assert not a_to_d.matches
+        #  a -> b
+        assert "b" in top_a.matches
+        a_to_b = top_a.matches["b"]
+        assert a_to_b.end
+        assert len(a_to_b.matches) == 1
+        #  a -> b -> c
+        assert "c" in a_to_b.matches
+        a_to_b_to_c = a_to_b.matches["c"]
+        assert not a_to_b_to_c.matches
+        assert top_a.end
+        #  d -> f
+        assert "d" in trie.matches
+        top_d = trie.matches["d"]
+        assert not top_d.end
+        assert "f" in top_d.matches
+        d_to_f = top_d.matches["f"]
+        assert d_to_f.end
+        assert not d_to_f.matches

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -24,7 +24,7 @@ def lenient_netloc(url: str) -> str:
         .rpartition("@")[-1]
         .partition(":")[0]
         .strip()
-        .rstrip(".")
+        .rstrip(".\u3002\uff0e\uff61")
     )
 
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -427,9 +427,11 @@ class _PublicSuffixListTLDExtractor:  # pylint: disable=too-many-instance-attrib
                     i = j
                 node = node.matches[decoded_label]
                 continue
-            if "!" + decoded_label in node.matches:
-                return j
             if "*" in node.matches:
+                # check if label falls under any wildcard exception rule
+                # e.g. !www.ck
+                if "!" + decoded_label in node.matches:
+                    return j
                 return j - 1
             break
         return i

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -343,13 +343,12 @@ class Trie:
         """Append a suffix's labels to this Trie node"""
         node = self
 
-        for idx, label in enumerate(labels, start=1):
+        for label in labels:
             if label not in node.matches:
                 node.matches[label] = Trie()
-            if idx != len(labels):
-                node = node.matches[label]
-            else:
-                node.matches[label].end = True
+            node = node.matches[label]
+
+        node.end = True
 
 
 @wraps(TLD_EXTRACTOR.__call__)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -90,7 +90,7 @@ class ExtractResult(NamedTuple):
         >>> extract('http://localhost:8080').registered_domain
         ''
         """
-        if self.domain and self.suffix:
+        if self.suffix and self.domain:
             return f"{self.domain}.{self.suffix}"
         return ""
 
@@ -104,7 +104,7 @@ class ExtractResult(NamedTuple):
         >>> extract('http://localhost:8080').fqdn
         ''
         """
-        if self.domain and self.suffix:
+        if self.suffix and self.domain:
             # Disable bogus lint error (https://github.com/PyCQA/pylint/issues/2568)
             # pylint: disable-next=not-an-iterable
             return ".".join(i for i in self if i)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -261,11 +261,11 @@ class TLDExtract:
             labels, include_psl_private_domains=include_psl_private_domains
         )
 
-        suffix = ".".join(labels[suffix_index:])
-        if not suffix and netloc and looks_like_ip(netloc):
+        if suffix_index == len(labels) and netloc and looks_like_ip(netloc):
             return ExtractResult("", netloc, "")
 
-        subdomain = ".".join(labels[: suffix_index - 1]) if suffix_index else ""
+        suffix = ".".join(labels[suffix_index:])
+        subdomain = ".".join(labels[: suffix_index - 1]) if suffix_index >= 2 else ""
         domain = labels[suffix_index - 1] if suffix_index else ""
         return ExtractResult(subdomain, domain, suffix)
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -91,7 +91,7 @@ class ExtractResult(NamedTuple):
         ''
         """
         if self.domain and self.suffix:
-            return self.domain + "." + self.suffix
+            return f"{self.domain}.{self.suffix}"
         return ""
 
     @property
@@ -421,16 +421,16 @@ class _PublicSuffixListTLDExtractor:  # pylint: disable=too-many-instance-attrib
         j = i
         for label in reversed(spl):
             decoded_label = _decode_punycode(label)
-            if "!" + decoded_label in node.matches:
-                return j
-            if "*" in node.matches:
-                return j - 1
             if decoded_label in node.matches:
                 j -= 1
                 if node.matches[decoded_label].end:
                     i = j
                 node = node.matches[decoded_label]
                 continue
+            if "!" + decoded_label in node.matches:
+                return j
+            if "*" in node.matches:
+                return j - 1
             break
         return i
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -428,13 +428,16 @@ class _PublicSuffixListTLDExtractor:
                     i = j
                 node = node.matches[decoded_label]
                 continue
-            if "*" in node.matches:
-                # check if label falls under any wildcard exception rule
-                # e.g. !www.ck
-                if "!" + decoded_label in node.matches:
+
+            is_wildcard = "*" in node.matches
+            if is_wildcard:
+                is_wildcard_exception = "!" + decoded_label in node.matches
+                if is_wildcard_exception:
                     return j
                 return j - 1
+
             break
+
         return i
 
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -342,17 +342,14 @@ class Trie:
     def add_suffix(self, labels: List[str]) -> None:
         """Append a suffix's labels to this Trie node"""
         node = self
-        labels_except_last = labels[: len(labels) - 1]
 
-        for label in labels_except_last:
+        for idx, label in enumerate(labels, start=1):
             if label not in node.matches:
                 node.matches[label] = Trie()
-            node = node.matches[label]
-
-        last_label = labels[len(labels) - 1]
-        if last_label not in node.matches:
-            node.matches[last_label] = Trie()
-        node.matches[last_label].end = True
+            if idx != len(labels):
+                node = node.matches[label]
+            else:
+                node.matches[label].end = True
 
 
 @wraps(TLD_EXTRACTOR.__call__)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -264,7 +264,7 @@ class TLDExtract:
         if suffix_index == len(labels) and netloc and looks_like_ip(netloc):
             return ExtractResult("", netloc, "")
 
-        suffix = ".".join(labels[suffix_index:])
+        suffix = ".".join(labels[suffix_index:]) if suffix_index != len(labels) else ""
         subdomain = ".".join(labels[: suffix_index - 1]) if suffix_index >= 2 else ""
         domain = labels[suffix_index - 1] if suffix_index else ""
         return ExtractResult(subdomain, domain, suffix)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -54,7 +54,16 @@ import logging
 import os
 import urllib.parse
 from functools import wraps
-from typing import Dict, FrozenSet, List, NamedTuple, Optional, Sequence, Union
+from typing import (
+    Collection,
+    Dict,
+    FrozenSet,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import idna
 
@@ -328,7 +337,7 @@ class Trie:
         self.end = end
 
     @staticmethod
-    def create(suffixes: List[str]) -> Trie:
+    def create(suffixes: Collection[str]) -> Trie:
         """Create a Trie from a list of suffixes and return its root node."""
         root_node = Trie()
 
@@ -382,8 +391,8 @@ class _PublicSuffixListTLDExtractor:
         self.private_tlds = private_tlds
         self.tlds_incl_private = frozenset(public_tlds + private_tlds + extra_tlds)
         self.tlds_excl_private = frozenset(public_tlds + extra_tlds)
-        self.tlds_incl_private_trie = Trie.create(list(self.tlds_incl_private))
-        self.tlds_excl_private_trie = Trie.create(list(self.tlds_excl_private))
+        self.tlds_incl_private_trie = Trie.create(self.tlds_incl_private)
+        self.tlds_excl_private_trie = Trie.create(self.tlds_excl_private)
 
     def tlds(
         self, include_psl_private_domains: Optional[bool] = None

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -372,7 +372,7 @@ def update(*args, **kwargs):  # type: ignore[no-untyped-def]
     return TLD_EXTRACTOR.update(*args, **kwargs)
 
 
-class _PublicSuffixListTLDExtractor:  # pylint: disable=too-many-instance-attributes
+class _PublicSuffixListTLDExtractor:
     """Wrapper around this project's main algo for PSL
     lookups.
     """

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -321,7 +321,7 @@ TLD_EXTRACTOR = TLDExtract()
 
 
 class Trie:
-    """Trie for storing eTLDs with their labels in reverse-order"""
+    """Trie for storing eTLDs with their labels in reverse-order."""
 
     def __init__(self, matches: Optional[Dict] = None, end: bool = False) -> None:
         self.matches = matches if matches else {}
@@ -329,7 +329,7 @@ class Trie:
 
     @staticmethod
     def create(suffixes: List[str]) -> Trie:
-        """Create a Trie from a list of suffixes and return its root node"""
+        """Create a Trie from a list of suffixes and return its root node."""
         root_node = Trie()
 
         for suffix in suffixes:
@@ -340,7 +340,7 @@ class Trie:
         return root_node
 
     def add_suffix(self, labels: List[str]) -> None:
-        """Append a suffix's labels to this Trie node"""
+        """Append a suffix's labels to this Trie node."""
         node = self
 
         for label in labels:

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -337,10 +337,6 @@ class Trie:
             suffix_labels.reverse()
             root_node.add_suffix(suffix_labels)
 
-        for value in root_node.matches.values():
-            if "*" in value.matches:
-                value.end = True
-
         return root_node
 
     def add_suffix(self, labels: List[str]) -> None:


### PR DESCRIPTION
**suffix_index()** now uses a trie, which eliminates some string concatenation overhead in the old implementation for about **10-15%** reduction in execution time.

Helps #175.

Python 3.10, Linux x64, Ryzen 7 5800X

```python
import tldextract

%timeit tldextract.extract("")
%timeit tldextract.extract("com")
%timeit tldextract.extract("example\u3002com")
%timeit tldextract.extract("subdomain\uff0eexample\uff61com")
%timeit tldextract.extract("a\u3002very\uff0elong\uff61subdomain\u3002example\uff0ecom")
%timeit tldextract.extract("an\uff61even\u3002longer\uff0eand\uff61complex\u3002subdomain\uff0eexample\uff61com")
%timeit tldextract.extract("https://a\u3002b\uff0ec\uff61d\u3002e\uff0ef\uff61g\u3002h\uff0ei\uff61j\u3002k\uff0el\uff61m\u3002n\uff0eoo\uff61pp\u3002qqq\uff0errrr\uff61ssssss\u3002tttttttt\uff0euuuuuuuuuuu\uff61vvvvvvvvvvvvvvv\u3002wwwwwwwwwwwwwwwwwwwwww\uff0exxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\uff61yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\u3002zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz.tw")
%timeit tldextract.extract("\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\u3002\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff0e\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61\uff61")
```

```python
1.44 µs ± 2.17 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.63 µs ± 12 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
1.95 µs ± 25.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
2.14 µs ± 75.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.31 µs ± 15.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.38 µs ± 10.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
3.38 µs ± 22.7 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
2.28 µs ± 19.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## Changes

- Refactor **suffix_index()** to use a trie
- Fix internationalized DNS root label