### PR TITLE
Honor private domains flag on `self`, not only when passed to `__call__`

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -384,6 +384,17 @@ def test_cache_timeouts(tmpdir):
         tldextract.suffix_list.find_first_response(cache, [server], 5)
 
 
+def test_include_psl_private_domain_attr():
+    extract_private = tldextract.TLDExtract(include_psl_private_domains=True)
+    extract_public = tldextract.TLDExtract(include_psl_private_domains=False)
+    assert extract_private("foo.uk.com") == ExtractResult(
+        subdomain="", domain="foo", suffix="uk.com"
+    )
+    assert extract_public("foo.uk.com") == ExtractResult(
+        subdomain="foo", domain="uk", suffix="com"
+    )
+
+
 def test_tlds_property():
     extract_private = tldextract.TLDExtract(
         cache_dir=None, suffix_list_urls=(), include_psl_private_domains=True

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -411,6 +411,9 @@ class _PublicSuffixListTLDExtractor:
 
         Returns len(spl) if no suffix is found.
         """
+        if include_psl_private_domains is None:
+            include_psl_private_domains = self.include_psl_private_domains
+
         node = (
             self.tlds_incl_private_trie
             if include_psl_private_domains


### PR DESCRIPTION
While this flag check is still in the property `_PublicSuffixListTLDExtractor.tlds`, the check was effectively lost in #285, when we switched away from the property.

Fixes #288.