### PR TITLE
Accept only 4 decimal octet IPv4 addresses. Support IPv4 addresses with unicode dots.

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -134,11 +134,10 @@ def test_ip():
 
 
 def test_looks_like_ip():
-    assert inet_pton is not None and looks_like_ip("1.1.1.1", inet_pton) is True
+    assert callable(inet_pton)
+    assert looks_like_ip("1.1.1.1", inet_pton) is True
+    assert looks_like_ip("256.256.256.256", inet_pton) is False
     assert looks_like_ip("1.1.1.1", None) is True
-    assert (
-        inet_pton is not None and looks_like_ip("256.256.256.256", inet_pton) is False
-    )
     assert looks_like_ip("256.256.256.256", None) is False
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -133,10 +133,13 @@ def test_ip():
     )
 
 
-def test_looks_like_ip():
-    assert callable(inet_pton)
+@pytest.mark.skipif(not inet_pton, reason="inet_pton unavailable")
+def test_looks_like_ip_with_inet_pton():
     assert looks_like_ip("1.1.1.1", inet_pton) is True
     assert looks_like_ip("256.256.256.256", inet_pton) is False
+
+
+def test_looks_like_ip_without_inet_pton():
     assert looks_like_ip("1.1.1.1", None) is True
     assert looks_like_ip("256.256.256.256", None) is False
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -6,7 +6,6 @@ import logging
 import os
 import tempfile
 from collections.abc import Sequence
-from socket import inet_pton
 
 import pytest
 import responses
@@ -14,7 +13,7 @@ import responses
 import tldextract
 import tldextract.suffix_list
 from tldextract.cache import DiskCache
-from tldextract.remote import looks_like_ip
+from tldextract.remote import inet_pton, looks_like_ip
 from tldextract.suffix_list import SuffixListNotFound
 from tldextract.tldextract import ExtractResult
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -328,6 +328,11 @@ def test_ipv4():
         ("", "", "127.0.0.1", ""),
         expected_ip_data="127.0.0.1",
     )
+    assert_extract(
+        "http://127\u30020\uff0e0\uff611/foo/bar",
+        ("", "", "127.0.0.1", ""),
+        expected_ip_data="127.0.0.1",
+    )
 
 
 def test_ipv4_bad():
@@ -339,6 +344,12 @@ def test_ipv4_bad():
 
 
 def test_ipv4_lookalike():
+    assert_extract(
+        "http://127.0.0/foo/bar", ("", "127.0", "0", ""), expected_ip_data=""
+    )
+    assert_extract(
+        "http://127.0.0.0x1/foo/bar", ("", "127.0.0", "0x1", ""), expected_ip_data=""
+    )
     assert_extract(
         "http://127.0.0.1.9/foo/bar", ("", "127.0.0.1", "9", ""), expected_ip_data=""
     )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -6,6 +6,7 @@ import logging
 import os
 import tempfile
 from collections.abc import Sequence
+from socket import inet_pton
 
 import pytest
 import responses
@@ -13,6 +14,7 @@ import responses
 import tldextract
 import tldextract.suffix_list
 from tldextract.cache import DiskCache
+from tldextract.remote import looks_like_ip
 from tldextract.suffix_list import SuffixListNotFound
 from tldextract.tldextract import ExtractResult
 
@@ -133,6 +135,15 @@ def test_ip():
 
 
 def test_looks_like_ip():
+    assert inet_pton is not None and looks_like_ip("1.1.1.1", inet_pton) is True
+    assert looks_like_ip("1.1.1.1", None) is True
+    assert (
+        inet_pton is not None and looks_like_ip("256.256.256.256", inet_pton) is False
+    )
+    assert looks_like_ip("256.256.256.256", None) is False
+
+
+def test_similar_to_ip():
     assert_extract("1\xe9", ("", "", "1\xe9", ""))
 
 

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -1,11 +1,16 @@
 """tldextract helpers for testing and fetching remote resources."""
 
-try:
-    from socket import inet_pton, AF_INET  # Availability: Unix, Windows.
-except ImportError:
-    inet_pton = None  # type: ignore
+from __future__ import annotations
+
 import re
+from collections.abc import Callable
 from urllib.parse import scheme_chars
+
+inet_pton: Callable[[int, str], bytes] | None
+try:
+    from socket import AF_INET, inet_pton  # Availability: Unix, Windows.
+except ImportError:
+    inet_pton = None
 
 IP_RE = re.compile(
     r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.)"

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -52,16 +52,17 @@ def _schemeless_url(url: str) -> str:
     return url[double_slashes_start + 2 :]
 
 
-def looks_like_ip(maybe_ip: str) -> bool:
+def looks_like_ip(
+    maybe_ip: str, pton: Callable[[int, str], bytes] | None = inet_pton
+) -> bool:
     """Check whether the given str looks like an IP address."""
     if not maybe_ip[0].isdigit():
         return False
 
-    if inet_pton is not None:
+    if pton is not None:
         try:
-            inet_pton(AF_INET, maybe_ip)
+            pton(AF_INET, maybe_ip)
             return True
         except OSError:
             return False
-    assert inet_pton is None
     return IP_RE.match(maybe_ip) is not None

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -63,5 +63,5 @@ def looks_like_ip(maybe_ip: str) -> bool:
             return True
         except OSError:
             return False
-
+    assert inet_pton is None
     return IP_RE.match(maybe_ip) is not None

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -251,19 +251,19 @@ class TLDExtract:
     def _extract_netloc(
         self, netloc: str, include_psl_private_domains: bool | None
     ) -> ExtractResult:
-        labels = (
+        netloc_with_ascii_dots = (
             netloc.replace("\u3002", "\u002e")
             .replace("\uff0e", "\u002e")
             .replace("\uff61", "\u002e")
-            .split(".")
         )
+        labels = netloc_with_ascii_dots.split(".")
 
         suffix_index = self._get_tld_extractor().suffix_index(
             labels, include_psl_private_domains=include_psl_private_domains
         )
 
-        if suffix_index == len(labels) and netloc and looks_like_ip(netloc):
-            return ExtractResult("", netloc, "")
+        if suffix_index == len(labels) == 4 and looks_like_ip(netloc_with_ascii_dots):
+            return ExtractResult("", netloc_with_ascii_dots, "")
 
         suffix = ".".join(labels[suffix_index:]) if suffix_index != len(labels) else ""
         subdomain = ".".join(labels[: suffix_index - 1]) if suffix_index >= 2 else ""


### PR DESCRIPTION
## Changes

- IPv4 addresses with unicode dots are now recognized. Closes #287
- IPv4 addresses must have 4 decimal octets. Closes #290

**ipaddress.IPv4Address** was not used as fallback because it is 5 times slower than regex, and its behavior is [inconsistent](https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Address) across Python versions 3.8 and 3.9 (w.r.t. recognition of leading zeroes). For example, on Raspberry Pi OS Bullseye, the latest Python version is 3.9.2-3, which allows leading zeroes. To update to the latest patch version of Python 3.9, one has to manually install from source.