### PR TITLE
Reject IPv4 addresses with trailing whitespaces + non-whitespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tldextract.egg-info
 tldextract/.suffix_cache/*
 .tox
 .pytest_cache
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ tldextract.egg-info
 tldextract/.suffix_cache/*
 .tox
 .pytest_cache
-.coverage

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -38,8 +38,16 @@ def test_cli_posargs(capsys, monkeypatch):
 
 def test_cli_namedargs(capsys, monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", ["tldextract", "--suffix_list_url", PUBLIC_SUFFIX_LIST_URLS[0],
-                      "example.com", "bbc.co.uk", "forums.bbc.co.uk"]
+        sys,
+        "argv",
+        [
+            "tldextract",
+            "--suffix_list_url",
+            PUBLIC_SUFFIX_LIST_URLS[0],
+            "example.com",
+            "bbc.co.uk",
+            "forums.bbc.co.uk",
+        ],
     )
 
     main()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 from tldextract.cli import main
+from tldextract.tldextract import PUBLIC_SUFFIX_LIST_URLS
 
 
 def test_cli_no_input(monkeypatch):
@@ -26,6 +27,19 @@ def test_cli_parses_args(monkeypatch):
 def test_cli_posargs(capsys, monkeypatch):
     monkeypatch.setattr(
         sys, "argv", ["tldextract", "example.com", "bbc.co.uk", "forums.bbc.co.uk"]
+    )
+
+    main()
+
+    stdout, stderr = capsys.readouterr()
+    assert not stderr
+    assert stdout == " example com\n bbc co.uk\nforums bbc co.uk\n"
+
+
+def test_cli_namedargs(capsys, monkeypatch):
+    monkeypatch.setattr(
+        sys, "argv", ["tldextract", "--suffix_list_url", PUBLIC_SUFFIX_LIST_URLS[0],
+                      "example.com", "bbc.co.uk", "forums.bbc.co.uk"]
     )
 
     main()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -204,9 +204,7 @@ def test_invalid_puny_with_puny():
 
 
 def test_invalid_puny_with_nonpuny():
-    assert_extract(
-        "xn--ß‌꫶ᢥ.com", ("xn--ß‌꫶ᢥ.com", "", "xn--ß‌꫶ᢥ", "com")
-    )
+    assert_extract("xn--ß‌꫶ᢥ.com", ("xn--ß‌꫶ᢥ.com", "", "xn--ß‌꫶ᢥ", "com"))
 
 
 def test_puny_with_non_puny():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -150,6 +150,8 @@ def test_looks_like_ip_without_inet_pton():
 
 def test_similar_to_ip():
     assert_extract("1\xe9", ("", "", "1\xe9", ""))
+    assert_extract("1.1.1.1\ncom", ("", "1.1.1", "1\ncom", ""))
+    assert_extract("1.1.1.1\rcom", ("", "1.1.1", "1\rcom", ""))
 
 
 def test_punycode():

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -199,6 +199,12 @@ def test_invalid_puny_with_puny():
     )
 
 
+def test_invalid_puny_with_nonpuny():
+    assert_extract(
+        "xn--ß‌꫶ᢥ.com", ("xn--ß‌꫶ᢥ.com", "", "xn--ß‌꫶ᢥ", "com")
+    )
+
+
 def test_puny_with_non_puny():
     assert_extract(
         "http://xn--zckzap6140b352by.blog.so-net.教育.hk",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -136,12 +136,14 @@ def test_ip():
 @pytest.mark.skipif(not inet_pton, reason="inet_pton unavailable")
 def test_looks_like_ip_with_inet_pton():
     assert looks_like_ip("1.1.1.1", inet_pton) is True
+    assert looks_like_ip("a.1.1.1", inet_pton) is False
     assert looks_like_ip("1.1.1.1\n", inet_pton) is False
     assert looks_like_ip("256.256.256.256", inet_pton) is False
 
 
 def test_looks_like_ip_without_inet_pton():
     assert looks_like_ip("1.1.1.1", None) is True
+    assert looks_like_ip("a.1.1.1", None) is False
     assert looks_like_ip("1.1.1.1\n", None) is False
     assert looks_like_ip("256.256.256.256", None) is False
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -172,7 +172,7 @@ def test_punycode():
             "com",
         ),
     )
-    # This subdomain generates UnicodeError 'incomplete punicode string'
+    # This subdomain generates UnicodeError 'incomplete punycode string'
     assert_extract(
         "xn--tub-1m9d15sfkkhsifsbqygyujjrw60.google.com",
         (

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -136,11 +136,13 @@ def test_ip():
 @pytest.mark.skipif(not inet_pton, reason="inet_pton unavailable")
 def test_looks_like_ip_with_inet_pton():
     assert looks_like_ip("1.1.1.1", inet_pton) is True
+    assert looks_like_ip("1.1.1.1\n", inet_pton) is False
     assert looks_like_ip("256.256.256.256", inet_pton) is False
 
 
 def test_looks_like_ip_without_inet_pton():
     assert looks_like_ip("1.1.1.1", None) is True
+    assert looks_like_ip("1.1.1.1\n", None) is False
     assert looks_like_ip("256.256.256.256", None) is False
 
 

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import errno
-import hashlib
 import json
 import logging
 import os
@@ -41,7 +40,7 @@ def get_pkg_unique_identifier() -> str:
     tldextract_version = "tldextract-" + version
     python_env_name = os.path.basename(sys.prefix)
     # just to handle the edge case of two identically named python environments
-    python_binary_path_short_hash = hashlib.md5(sys.prefix.encode("utf-8")).hexdigest()[
+    python_binary_path_short_hash = md5(sys.prefix.encode("utf-8")).hexdigest()[
         :6
     ]
     python_version = ".".join([str(v) for v in sys.version_info[:-1]])

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -40,9 +40,7 @@ def get_pkg_unique_identifier() -> str:
     tldextract_version = "tldextract-" + version
     python_env_name = os.path.basename(sys.prefix)
     # just to handle the edge case of two identically named python environments
-    python_binary_path_short_hash = md5(sys.prefix.encode("utf-8")).hexdigest()[
-        :6
-    ]
+    python_binary_path_short_hash = md5(sys.prefix.encode("utf-8")).hexdigest()[:6]
     python_version = ".".join([str(v) for v in sys.version_info[:-1]])
     identifier_parts = [
         python_version,

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -65,4 +65,4 @@ def looks_like_ip(
             return True
         except OSError:
             return False
-    return IP_RE.match(maybe_ip) is not None
+    return IP_RE.fullmatch(maybe_ip) is not None

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -126,7 +126,7 @@ class ExtractResult(NamedTuple):
         >>> extract('http://256.1.1.1').ipv4
         ''
         """
-        if not (self.suffix or self.subdomain) and IP_RE.match(self.domain):
+        if not (self.suffix or self.subdomain) and IP_RE.fullmatch(self.domain):
             return self.domain
         return ""
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -63,7 +63,7 @@ from typing import (
 import idna
 
 from .cache import DiskCache, get_cache_dir
-from .remote import IP_RE, lenient_netloc, looks_like_ip
+from .remote import lenient_netloc, looks_like_ip
 from .suffix_list import get_suffix_lists
 
 LOG = logging.getLogger("tldextract")
@@ -126,7 +126,11 @@ class ExtractResult(NamedTuple):
         >>> extract('http://256.1.1.1').ipv4
         ''
         """
-        if not (self.suffix or self.subdomain) and IP_RE.fullmatch(self.domain):
+        if (
+            self.domain
+            and not (self.suffix or self.subdomain)
+            and looks_like_ip(self.domain)
+        ):
             return self.domain
         return ""
 


### PR DESCRIPTION
### Proposed changes

- Reject edge cases where inputs like `1.1.1.1 com` or `1.1.1.1\rsomething` are parsed as IPv4 addresses. **fullmatch** is about 10% slower than **match** but it'll only affect systems that do not support **pton** (non-Unix/Windows).
- Added some tests for test coverage.
- Fixed a minor typo.