### PR TITLE
Add support for IPv6 addresses

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -300,11 +300,15 @@ def test_username():
         expected_ip_data="127.0.0.1",
     )
     assert_extract(
+        "https://apple:pass@[::]:50/a",
+        ("", "", "[::]", ""),
+        expected_ipv6_data="::",
+    )
+    assert_extract(
         "https://apple:pass@[aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1]:50/a",
         ("", "", "[aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1]", ""),
         expected_ipv6_data="aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1",
     )
-
 
 def test_query_fragment():
     assert_extract("http://google.com?q=cats", ("google.com", "", "google", "com"))

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -310,6 +310,7 @@ def test_username():
         expected_ipv6_data="aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1",
     )
 
+
 def test_query_fragment():
     assert_extract("http://google.com?q=cats", ("google.com", "", "google", "com"))
     assert_extract("http://google.com#Welcome", ("google.com", "", "google", "com"))

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
+from ipaddress import AddressValueError, IPv6Address
 from urllib.parse import scheme_chars
 
 inet_pton: Callable[[int, str], bytes] | None
 try:
-    from socket import AF_INET, inet_pton  # Availability: Unix, Windows.
+    from socket import AF_INET, AF_INET6, inet_pton  # Availability: Unix, Windows.
 except ImportError:
     inet_pton = None
 
@@ -27,16 +28,18 @@ def lenient_netloc(url: str) -> str:
     urllib.parse.{urlparse,urlsplit}, but extract more leniently, without
     raising errors.
     """
-    return (
+    after_userinfo = (
         _schemeless_url(url)
         .partition("/")[0]
         .partition("?")[0]
         .partition("#")[0]
         .rpartition("@")[-1]
-        .partition(":")[0]
-        .strip()
-        .rstrip(".\u3002\uff0e\uff61")
     )
+    if after_userinfo and after_userinfo[0] == "[":
+        maybe_ipv6 = after_userinfo.partition("]")
+        if maybe_ipv6[1] == "]":
+            return f"{maybe_ipv6[0]}]"
+    return after_userinfo.partition(":")[0].strip().rstrip(".\u3002\uff0e\uff61")
 
 
 def _schemeless_url(url: str) -> str:
@@ -66,3 +69,23 @@ def looks_like_ip(
         except OSError:
             return False
     return IP_RE.fullmatch(maybe_ip) is not None
+
+
+def looks_like_ipv6(
+    maybe_ip: str, pton: Callable[[int, str], bytes] | None = inet_pton
+) -> bool:
+    """Check whether the given str looks like an IPv6 address."""
+    if not maybe_ip[0].isalnum():
+        return False
+
+    if pton is not None:
+        try:
+            pton(AF_INET6, maybe_ip)
+            return True
+        except OSError:
+            return False
+    try:
+        IPv6Address(maybe_ip)
+    except AddressValueError:
+        return False
+    return True

--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -75,9 +75,6 @@ def looks_like_ipv6(
     maybe_ip: str, pton: Callable[[int, str], bytes] | None = inet_pton
 ) -> bool:
     """Check whether the given str looks like an IPv6 address."""
-    if not maybe_ip[0].isalnum():
-        return False
-
     if pton is not None:
         try:
             pton(AF_INET6, maybe_ip)

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -63,7 +63,7 @@ from typing import (
 import idna
 
 from .cache import DiskCache, get_cache_dir
-from .remote import lenient_netloc, looks_like_ip
+from .remote import lenient_netloc, looks_like_ip, looks_like_ipv6
 from .suffix_list import get_suffix_lists
 
 LOG = logging.getLogger("tldextract")
@@ -132,6 +132,26 @@ class ExtractResult(NamedTuple):
             and looks_like_ip(self.domain)
         ):
             return self.domain
+        return ""
+
+    @property
+    def ipv6(self) -> str:
+        """
+        Returns the ipv6 if that is what the presented domain/url is.
+
+        >>> extract('http://[aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1]/path/to/file').ipv6
+        'aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1'
+        >>> extract('http://[aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1.1]/path/to/file').ipv6
+        ''
+        >>> extract('http://[aBcD:ef01:2345:6789:aBcD:ef01:256.0.0.1]').ipv6
+        ''
+        """
+        if len(self.domain) >= 4 and not (  # Shortest ipv6 address is "[::]"
+            self.suffix or self.subdomain
+        ):
+            debracketed = self.domain[1:-1]
+            if looks_like_ipv6(debracketed):
+                return debracketed
         return ""
 
 
@@ -260,6 +280,15 @@ class TLDExtract:
             .replace("\uff0e", "\u002e")
             .replace("\uff61", "\u002e")
         )
+
+        if (
+            netloc_with_ascii_dots
+            and netloc_with_ascii_dots[0] == "["
+            and netloc_with_ascii_dots[-1] == "]"
+        ):
+            if looks_like_ipv6(netloc_with_ascii_dots[1:-1]):
+                return ExtractResult("", netloc_with_ascii_dots, "")
+
         labels = netloc_with_ascii_dots.split(".")
 
         suffix_index = self._get_tld_extractor().suffix_index(

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -146,8 +146,11 @@ class ExtractResult(NamedTuple):
         >>> extract('http://[aBcD:ef01:2345:6789:aBcD:ef01:256.0.0.1]').ipv6
         ''
         """
-        if len(self.domain) >= 4 and not (  # Shortest ipv6 address is "[::]"
-            self.suffix or self.subdomain
+        if (
+            len(self.domain) >= 4
+            and self.domain[0] == "["
+            and self.domain[-1] == "]"
+            and not (self.suffix or self.subdomain)  # Shortest ipv6 address is "[::]"
         ):
             debracketed = self.domain[1:-1]
             if looks_like_ipv6(debracketed):

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -282,7 +282,7 @@ class TLDExtract:
         )
 
         if (
-            netloc_with_ascii_dots
+            len(netloc_with_ascii_dots) >= 4
             and netloc_with_ascii_dots[0] == "["
             and netloc_with_ascii_dots[-1] == "]"
         ):


### PR DESCRIPTION
Closes #263

- This could possibly break an unusual use case where square brackets are considered valid domain name labels, such as `sub[.example.com` -> `sub[` + `example` + `com`. It's not compliant with [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3) to begin with so it probably isn't an issue.

- If the IPv6 literal contains a trailing IPv4 address, non-ASCII dots are allowed, similar to behaviour in the Chrome and Edge web browsers. Firefox however does not allow non-ASCII dots in IPv6 literals.

- I don't see any performance regressions as of yet.

- Pure IPv6 addresses without square brackets are deemed invalid because they are invalid in the context of URLs.