### PR TITLE
Accept next largest suffix if entire URL is private suffix

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -475,6 +475,11 @@ def test_global_extract():
     ) == ExtractResult(
         subdomain="", domain="another", suffix="icann.compute.amazonaws.com"
     )
+    assert tldextract.extract(
+        "another.s3.dualstack.us-east-1.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(
+        subdomain="", domain="another", suffix="s3.dualstack.us-east-1.amazonaws.com"
+    )
 
     assert tldextract.extract(
         "s3.ap-south-1.amazonaws.com", include_psl_private_domains=True

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -448,9 +448,6 @@ def test_global_extract():
         "foo.blogspot.com", include_psl_private_domains=True
     ) == ExtractResult(subdomain="", domain="foo", suffix="blogspot.com")
     assert tldextract.extract(
-        "s3.ap-south-1.amazonaws.com", include_psl_private_domains=True
-    ) == ExtractResult(subdomain="", domain="", suffix="s3.ap-south-1.amazonaws.com")
-    assert tldextract.extract(
         "the-quick-brown-fox.ap-south-1.amazonaws.com", include_psl_private_domains=True
     ) == ExtractResult(
         subdomain="the-quick-brown-fox.ap-south-1", domain="amazonaws", suffix="com"
@@ -461,9 +458,6 @@ def test_global_extract():
     assert tldextract.extract(
         "amazonaws.com", include_psl_private_domains=True
     ) == ExtractResult(subdomain="", domain="amazonaws", suffix="com")
-    assert tldextract.extract(
-        "s3.cn-north-1.amazonaws.com.cn", include_psl_private_domains=True
-    ) == ExtractResult(subdomain="", domain="", suffix="s3.cn-north-1.amazonaws.com.cn")
     assert tldextract.extract(
         "the-quick-brown-fox.cn-north-1.amazonaws.com.cn",
         include_psl_private_domains=True,
@@ -476,3 +470,26 @@ def test_global_extract():
     assert tldextract.extract(
         "amazonaws.com.cn", include_psl_private_domains=True
     ) == ExtractResult(subdomain="", domain="amazonaws", suffix="com.cn")
+    assert tldextract.extract(
+        "another.icann.compute.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(
+        subdomain="", domain="another", suffix="icann.compute.amazonaws.com"
+    )
+
+    assert tldextract.extract(
+        "s3.ap-south-1.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="s3.ap-south-1", domain="amazonaws", suffix="com")
+    assert tldextract.extract(
+        "s3.cn-north-1.amazonaws.com.cn", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="s3.cn-north-1", domain="amazonaws", suffix="com.cn")
+    assert tldextract.extract(
+        "icann.compute.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(subdomain="icann.compute", domain="amazonaws", suffix="com")
+
+    # Entire URL is private suffix which ends with another private suffix
+    # i.e. "s3.dualstack.us-east-1.amazonaws.com" ends with "us-east-1.amazonaws.com"
+    assert tldextract.extract(
+        "s3.dualstack.us-east-1.amazonaws.com", include_psl_private_domains=True
+    ) == ExtractResult(
+        subdomain="s3", domain="dualstack", suffix="us-east-1.amazonaws.com"
+    )

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -5,19 +5,11 @@ from tldextract.tldextract import Trie
 
 
 def test_nested_dict() -> None:
-    original_keys_sequence = [
-        ["a"],
-        ["a", "d"],
-        ["a", "b"],
-        ["a", "b", "c"],
-        ["c"],
-        ["c", "b"],
-        ["d", "f"],
-    ]
-    for keys_sequence in permutations(original_keys_sequence):
+    suffixes = ["a", "d.a", "b.a", "c.b.a", "c", "b.c", "f.d"]
+    for suffixes_sequence in permutations(suffixes):
         trie = Trie()
-        for keys in keys_sequence:
-            trie.add_suffix(keys)
+        for suffix in suffixes_sequence:
+            trie.add_suffix(suffix)
         # check each nested value
         # Top level c
         assert "c" in trie.matches


### PR DESCRIPTION
Closes #178

### Changes

- If private suffixes are enabled, when the entire URL is a private suffix, the parser will accept the next largest suffix (can be either public or private). This is possible since every private suffix is guaranteed to contain at least one public suffix.
- This is a breaking change so perhaps we should use a flag to optionally enable this behaviour.

### Examples

- Entire URL is private suffix **icann.compute.amazonaws.com**
- Next largest suffix is **com**

`icann.compute.amazonaws.com` | subdomain="icann.compute", domain="amazonaws", suffix="com"
`another.icann.compute.amazonaws.com` | subdomain="", domain="another", suffix="icann.compute.amazonaws.com"

- Entire URL is private suffix **s3.dualstack.us-east-1.amazonaws.com**.
- Next largest suffix is **us-east-1.amazonaws.com** (which happens to be a private suffix too)

`s3.dualstack.us-east-1.amazonaws.com` | subdomain="s3", domain="dualstack", suffix="us-east-1.amazonaws.com"
`another.s3.dualstack.us-east-1.amazonaws.com` | subdomain="", domain="another", suffix=s3.dualstack.us-east-1.amazonaws.com"

### Misc

This can be a step towards fixing #138. Would need a consensus on whether **registered_domain** should strictly refer to domain + public suffix regardless of whether private suffixes are enabled.