### PR TITLE
Switch from pycodestyle and Pylint to Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,9 @@ select = [
   "UP",
   "W",
 ]
-# E501 - line too long; if Black does its job, not worried about the rare long line
-ignore = ["E501"]
+ignore = [
+  "E501", # line too long; if Black does its job, not worried about the rare long line
+]
 
 [tool.ruff.per-file-ignores]
 "**/tests/**/*" = ["D103"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,21 @@ disallow_untyped_calls = true
 module = ["tldextract.*"]
 disallow_untyped_defs = true
 
-[tool.pylint.master]
-disable = "fixme"
-no-docstring-rgx = "(^_|test_.*)"
+[tool.ruff]
+select = [
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "I",
+  "N",
+  "UP",
+  "W",
+]
+# E501 - line too long; if Black does its job, not worried about the rare long line
+ignore = ["E501"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,8 @@ select = [
 # E501 - line too long; if Black does its job, not worried about the rare long line
 ignore = ["E501"]
 
+[tool.ruff.per-file-ignores]
+"**/tests/**/*" = ["D103"]
+
 [tool.ruff.pydocstyle]
 convention = "pep257"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[pycodestyle]
-# E203 - whitespace before; disagrees with PEP8 https://github.com/psf/black/issues/354#issuecomment-397684838
-# E501 - line too long
-# W503 - line break before binary operator; disagrees with PEP8 https://github.com/psf/black/issues/52
-ignore = E203, E501, W503

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,5 @@ def reset_log_level():
 
     Generally want test output the Unix way: silence is golden.
     """
-    tldextract.cache._DID_LOG_UNABLE_TO_CACHE = (  # pylint: disable=protected-access
-        False
-    )
+    tldextract.cache._DID_LOG_UNABLE_TO_CACHE = False
     logging.getLogger().setLevel(logging.WARN)

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -83,6 +83,7 @@ class DiskCache:
     """Disk _cache that only works for jsonable values."""
 
     def __init__(self, cache_dir: str | None, lock_timeout: int = 20):
+        """Construct a disk cache in the given directory."""
         self.enabled = bool(cache_dir)
         self.cache_dir = os.path.expanduser(str(cache_dir) or "")
         self.lock_timeout = lock_timeout
@@ -106,7 +107,7 @@ class DiskCache:
             LOG.error("error reading TLD cache file %s: %s", cache_filepath, exc)
             raise KeyError("namespace: " + namespace + " key: " + repr(key)) from None
 
-    def set(
+    def set(  # noqa: A003
         self, namespace: str, key: str | dict[str, Hashable], value: object
     ) -> None:
         """Set a value in the disk cache."""
@@ -124,12 +125,10 @@ class DiskCache:
             global _DID_LOG_UNABLE_TO_CACHE  # pylint: disable=global-statement
             if not _DID_LOG_UNABLE_TO_CACHE:
                 LOG.warning(
-                    (
-                        "unable to cache %s.%s in %s. This could refresh the "
-                        "Public Suffix List over HTTP every app startup. "
-                        "Construct your `TLDExtract` with a writable `cache_dir` or "
-                        "set `cache_dir=None` to silence this warning. %s"
-                    ),
+                    "unable to cache %s.%s in %s. This could refresh the "
+                    "Public Suffix List over HTTP every app startup. "
+                    "Construct your `TLDExtract` with a writable `cache_dir` or "
+                    "set `cache_dir=None` to silence this warning. %s",
                     namespace,
                     key,
                     cache_filepath,
@@ -184,12 +183,10 @@ class DiskCache:
             global _DID_LOG_UNABLE_TO_CACHE  # pylint: disable=global-statement
             if not _DID_LOG_UNABLE_TO_CACHE:
                 LOG.warning(
-                    (
-                        "unable to cache %s.%s in %s. This could refresh the "
-                        "Public Suffix List over HTTP every app startup. "
-                        "Construct your `TLDExtract` with a writable `cache_dir` or "
-                        "set `cache_dir=None` to silence this warning. %s"
-                    ),
+                    "unable to cache %s.%s in %s. This could refresh the "
+                    "Public Suffix List over HTTP every app startup. "
+                    "Construct your `TLDExtract` with a writable `cache_dir` or "
+                    "set `cache_dir=None` to silence this warning. %s",
                     namespace,
                     key_args,
                     cache_filepath,

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger(__name__)
 
 _DID_LOG_UNABLE_TO_CACHE = False
 
-T = TypeVar("T")  # pylint: disable=invalid-name
+T = TypeVar("T")
 
 
 def get_pkg_unique_identifier() -> str:
@@ -32,7 +32,6 @@ def get_pkg_unique_identifier() -> str:
     a new version of tldextract
     """
     try:
-        # pylint: disable=import-outside-toplevel
         from tldextract._version import version
     except ImportError:
         version = "dev"
@@ -100,7 +99,6 @@ class DiskCache:
         if not os.path.isfile(cache_filepath):
             raise KeyError("namespace: " + namespace + " key: " + repr(key))
         try:
-            # pylint: disable-next=unspecified-encoding
             with open(cache_filepath) as cache_file:
                 return json.load(cache_file)
         except (OSError, ValueError) as exc:
@@ -118,11 +116,10 @@ class DiskCache:
 
         try:
             _make_dir(cache_filepath)
-            # pylint: disable-next=unspecified-encoding
             with open(cache_filepath, "w") as cache_file:
                 json.dump(value, cache_file)
         except OSError as ioe:
-            global _DID_LOG_UNABLE_TO_CACHE  # pylint: disable=global-statement
+            global _DID_LOG_UNABLE_TO_CACHE
             if not _DID_LOG_UNABLE_TO_CACHE:
                 LOG.warning(
                     "unable to cache %s.%s in %s. This could refresh the "
@@ -180,7 +177,7 @@ class DiskCache:
         try:
             _make_dir(cache_filepath)
         except OSError as ioe:
-            global _DID_LOG_UNABLE_TO_CACHE  # pylint: disable=global-statement
+            global _DID_LOG_UNABLE_TO_CACHE
             if not _DID_LOG_UNABLE_TO_CACHE:
                 LOG.warning(
                     "unable to cache %s.%s in %s. This could refresh the "
@@ -196,8 +193,6 @@ class DiskCache:
 
             return func(**kwargs)
 
-        # Disable lint of 3rd party (see also https://github.com/tox-dev/py-filelock/issues/102)
-        # pylint: disable-next=abstract-class-instantiated
         with FileLock(lock_path, timeout=self.lock_timeout):
             try:
                 result = cast(T, self.get(namespace=namespace, key=key_args))

--- a/tldextract/suffix_list.py
+++ b/tldextract/suffix_list.py
@@ -19,7 +19,7 @@ PUBLIC_SUFFIX_RE = re.compile(r"^(?P<suffix>[.*!]*\w[\S]*)", re.UNICODE | re.MUL
 PUBLIC_PRIVATE_SUFFIX_SEPARATOR = "// ===BEGIN PRIVATE DOMAINS==="
 
 
-class SuffixListNotFound(LookupError):
+class SuffixListNotFound(LookupError):  # noqa: N818
     """A recoverable error while looking up a suffix list.
 
     Recoverable because you can specify backups, or use this library's bundled

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -78,8 +78,7 @@ PUBLIC_SUFFIX_LIST_URLS = (
 
 
 class ExtractResult(NamedTuple):
-    """namedtuple of a URL's subdomain, domain, suffix,
-    and flag that indicates if URL has private suffix."""
+    """namedtuple of a URL's subdomain, domain, suffix, and flag that indicates if URL has private suffix."""
 
     subdomain: str
     domain: str
@@ -371,6 +370,7 @@ class Trie:
     def __init__(
         self, matches: dict | None = None, end: bool = False, is_private: bool = False
     ) -> None:
+        """TODO."""
         self.matches = matches if matches else {}
         self.end = end
         self.is_private = is_private
@@ -411,16 +411,14 @@ class Trie:
 
 
 @wraps(TLD_EXTRACTOR.__call__)
-def extract(  # pylint: disable=missing-function-docstring
+def extract(  # noqa: D103
     url: str, include_psl_private_domains: bool | None = False
 ) -> ExtractResult:
     return TLD_EXTRACTOR(url, include_psl_private_domains=include_psl_private_domains)
 
 
 @wraps(TLD_EXTRACTOR.update)
-def update(  # type: ignore[no-untyped-def]
-    *args, **kwargs
-):  # pylint: disable=missing-function-docstring
+def update(*args, **kwargs):  # type: ignore[no-untyped-def]  # noqa: D103
     return TLD_EXTRACTOR.update(*args, **kwargs)
 
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -110,8 +110,6 @@ class ExtractResult(NamedTuple):
         ''
         """
         if self.suffix and (self.domain or self.is_private):
-            # Disable bogus lint error (https://github.com/PyCQA/pylint/issues/2568)
-            # pylint: disable-next=not-an-iterable,unsubscriptable-object
             return ".".join(i for i in self[:3] if i)
         return ""
 
@@ -163,8 +161,8 @@ class ExtractResult(NamedTuple):
 class TLDExtract:
     """A callable for extracting, subdomain, domain, and suffix components from a URL."""
 
-    # TODO: Agreed with Pylint: too-many-arguments
-    def __init__(  # pylint: disable=too-many-arguments
+    # TODO: too-many-arguments
+    def __init__(
         self,
         cache_dir: str | None = get_cache_dir(),
         suffix_list_urls: Sequence[str] = PUBLIC_SUFFIX_LIST_URLS,

--- a/tox.ini
+++ b/tox.ini
@@ -3,32 +3,24 @@ envlist = py{37,38,39,310,311,py3},codestyle,lint,typecheck
 
 [testenv]
 deps =
-    pylint
     pytest
     pytest-gitignore
     pytest-mock
-    pytest-pylint
     responses
-
-commands = pytest --pylint {posargs}
+commands = pytest {posargs}
 
 [testenv:codestyle]
 basepython = python3.7
 deps =
     black
-    pycodestyle
 commands =
-    pycodestyle tldextract tests {posargs}
     black --check {posargs:.}
 
 [testenv:lint]
 basepython = python3.7
 deps =
-    pytest
-    pytest-gitignore
-    pytest-pylint
-    responses
-commands = pytest --pylint -m pylint {posargs}
+    ruff
+commands = ruff check {posargs:.}
 
 [testenv:typecheck]
 basepython = python3.7
@@ -36,7 +28,6 @@ deps =
     mypy
     pytest
     pytest-gitignore
-    pytest-pylint
     responses
     types-filelock
     types-requests


### PR DESCRIPTION
Ruff subsumes pycodestyle. Ruff is much faster and less error-prone than Pylint.

Ruff is not a drop-in replacement for Pylint. Rules it does implement are not necessarily 1-1 with the source. I'm not sure what Pylint protections are lost with this switch. However, the simplicity and speed of Ruff feel better than fighting with Pylint dependencies and false positives.