### PR TITLE
Migrate ExtractResult from namedtuple to dataclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,6 @@ ExtractResult(subdomain='forums', domain='bbc', suffix='co.uk', is_private=False
 ExtractResult(subdomain='www', domain='worldbank', suffix='org.kg', is_private=False)
 ```
 
-`ExtractResult` is a namedtuple, so it's simple to access the parts you want.
-
-```python
->>> ext = tldextract.extract('http://forums.bbc.co.uk')
->>> (ext.subdomain, ext.domain, ext.suffix)
-('forums', 'bbc', 'co.uk')
->>> # rejoin subdomain and domain
->>> '.'.join(ext[:2])
-'forums.bbc'
->>> # a common alias
->>> ext.registered_domain
-'bbc.co.uk'
-```
-
 Note subdomain and suffix are _optional_. Not all URL-like inputs have a
 subdomain or a valid suffix.
 
@@ -59,17 +45,14 @@ ExtractResult(subdomain='google', domain='notavalidsuffix', suffix='', is_privat
 ExtractResult(subdomain='', domain='127.0.0.1', suffix='', is_private=False)
 ```
 
-If you want to rejoin the whole namedtuple, regardless of whether a subdomain
-or suffix were found:
+To rejoin the original hostname, if it was indeed a valid, registered hostname:
 
 ```python
->>> ext = tldextract.extract('http://127.0.0.1:8080/deployed/')
->>> # this has unwanted dots
->>> '.'.join(ext[:3])
-'.127.0.0.1.'
->>> # join each part only if it's truthy
->>> '.'.join(part for part in ext[:3] if part)
-'127.0.0.1'
+>>> ext = tldextract.extract('http://forums.bbc.co.uk')
+>>> ext.registered_domain
+'bbc.co.uk'
+>>> ext.fqdn
+'forums.bbc.co.uk'
 ```
 
 By default, this package supports the public ICANN TLDs and their exceptions.

--- a/tests/custom_suffix_test.py
+++ b/tests/custom_suffix_test.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 
 import tldextract
+from tldextract.tldextract import ExtractResult
 
 FAKE_SUFFIX_LIST_URL = "file://" + os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "fixtures/fake_suffix_list_fixture.dat"
@@ -27,8 +28,8 @@ def test_private_extraction() -> None:
     """Test this library's uncached, offline, private domain extraction."""
     tld = tldextract.TLDExtract(cache_dir=tempfile.mkdtemp(), suffix_list_urls=[])
 
-    assert tld("foo.blogspot.com") == ("foo", "blogspot", "com", False)
-    assert tld("foo.blogspot.com", include_psl_private_domains=True) == (
+    assert tld("foo.blogspot.com") == ExtractResult("foo", "blogspot", "com", False)
+    assert tld("foo.blogspot.com", include_psl_private_domains=True) == ExtractResult(
         "",
         "foo",
         "blogspot.com",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -412,20 +412,6 @@ def test_ipv4_lookalike() -> None:
     )
 
 
-def test_result_as_dict() -> None:
-    """Test that the result is a namedtuple."""
-    result = extract(
-        "http://admin:password1@www.google.com:666/secret/admin/interface?param1=42"
-    )
-    expected_dict = {
-        "subdomain": "www",
-        "domain": "google",
-        "suffix": "com",
-        "is_private": False,
-    }
-    assert result._asdict() == expected_dict
-
-
 def test_cache_permission(
     mocker: pytest_mock.MockerFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -88,5 +88,5 @@ def main() -> None:
         sys.exit(1)
 
     for i in args.input:
-        subdomain, domain, suffix, _ = tld_extract(i)
-        print(f"{subdomain} {domain} {suffix}")
+        ext = tld_extract(i)
+        print(f"{ext.subdomain} {ext.domain} {ext.suffix}")


### PR DESCRIPTION
The bugfix in #300 was not the breaking change I wanted. It resulted in #305. To properly allow the original bugfix, add flexibility to the library to e.g. add more metadata fields going forward, and really warrant a major version bump, this PR changes the type of this library's core type `ExtractResult` from `namedtuple` to `dataclass`. I'm considering yanking version 3.6.0 and making _this_ PR's change the 4.0.0.

# Open Issues

- [ ] Does this greatly affect space?
- [ ] Does this greatly affect speed?