### PR TITLE
Extract all testing deps from tox.ini to pyproject.toml extras

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ matrix:
     - env: TOXENV=lint
     - env: TOXENV=typecheck
 python: "3.10"
-install: pip install tox
+install: pip install --upgrade --editable '.[testing]'
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ matrix:
     - env: TOXENV=lint
     - env: TOXENV=typecheck
 python: "3.10"
-install: pip install --upgrade --editable '.[testing]'
+install:
+    - pip install --upgrade pip
+    - pip install --upgrade --editable '.[testing]'
 script: tox

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ receiving exceptions or error metadata on results.
 
 1. `git clone` this repository.
 2. Change into the new directory.
-3. `pip install tox`
+3. `pip install --upgrade --editable '.[testing]'`
 
 ### Running the test suite
 
@@ -269,6 +269,5 @@ tox -e py311
 Automatically format all code:
 
 ```zsh
-pip install black
 black .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,29 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.8"
+dynamic = ["version"]
+readme = "README.md"
+
 dependencies = [
     "idna",
     "requests>=2.1.0",
     "requests-file>=1.4",
     "filelock>=3.0.8",
 ]
-dynamic = ["version"]
-readme = "README.md"
+
+[project.optional-dependencies]
+testing = [
+    "black",
+    "mypy",
+    "pytest",
+    "pytest-gitignore",
+    "pytest-mock",
+    "responses",
+    "ruff",
+    "tox",
+    "types-filelock",
+    "types-requests",
+]
 
 [project.urls]
 Homepage = "https://github.com/john-kurkowski/tldextract"

--- a/tox.ini
+++ b/tox.ini
@@ -2,34 +2,21 @@
 envlist = py{38,39,310,311,py3},codestyle,lint,typecheck
 
 [testenv]
-deps =
-    pytest
-    pytest-gitignore
-    pytest-mock
-    responses
 commands = pytest {posargs}
+extras = testing
 
 [testenv:codestyle]
 basepython = python3.8
-deps =
-    black
 commands =
     black --check {posargs:.}
+extras = testing
 
 [testenv:lint]
 basepython = python3.8
-deps =
-    ruff
 commands = ruff check {posargs:.}
+extras = testing
 
 [testenv:typecheck]
 basepython = python3.8
-deps =
-    mypy
-    pytest
-    pytest-gitignore
-    pytest-mock
-    responses
-    types-filelock
-    types-requests
 commands = mypy --show-error-codes tldextract tests
+extras = testing


### PR DESCRIPTION
This eases maintainers running tests and tooling without going through tox. For example, running this project's mypy configuration directly in their IDE. tox remains the SPOT for these checks.