### PR TITLE
Improve clarity of absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ If you want to use input data from your local filesystem, just use the `file://`
 
 ```python
 extract = tldextract.TLDExtract(
-    suffix_list_urls=["file://absolute/path/to/your/local/suffix/list/file"],
+    suffix_list_urls=["file://" + "/absolute/path/to/your/local/suffix/list/file"],
     cache_dir='/path/to/your/cache/',
     fallback_to_snapshot=False)
 ```


### PR DESCRIPTION
For a local suffix list file, I was confused whether for a given absolute path (UNIX style) **/absolute/path/to/your/local/suffix/list/file**,

should it be

**file://absolute/path/to/your/local/suffix/list/file**

or

**file:///absolute/path/to/your/local/suffix/list/file**

In this case, it should be 3 slashes. Currently the README seems to imply that `file://` can be treated like a first slash.

The following README edit clears up the ambiguity.