### PR TITLE
Add "-j, --json" option to support output in json format

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -69,11 +69,17 @@ def test_cli_namedargs(
 def test_cli_json_output(
     capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Test CLI with --json option"""
+    """Test CLI with --json option."""
     monkeypatch.setattr(sys, "argv", ["tldextract", "--json", "www.bbc.co.uk"])
 
     main()
 
     stdout, stderr = capsys.readouterr()
     assert not stderr
-    assert json.loads(stdout) == dict(subdomain="www", domain="bbc", suffix="co.uk", fqdn="www.bbc.co.uk", registered_domain="bbc.co.uk")
+    assert json.loads(stdout) == {
+        "subdomain": "www",
+        "domain": "bbc",
+        "suffix": "co.uk",
+        "fqdn": "www.bbc.co.uk",
+        "registered_domain": "bbc.co.uk",
+    }

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,5 +1,6 @@
 """tldextract integration tests."""
 
+import json
 import sys
 
 import pytest
@@ -63,3 +64,16 @@ def test_cli_namedargs(
     stdout, stderr = capsys.readouterr()
     assert not stderr
     assert stdout == " example com\n bbc co.uk\nforums bbc co.uk\n"
+
+
+def test_cli_json_output(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test CLI with --json option"""
+    monkeypatch.setattr(sys, "argv", ["tldextract", "--json", "www.bbc.co.uk"])
+
+    main()
+
+    stdout, stderr = capsys.readouterr()
+    assert not stderr
+    assert json.loads(stdout) == dict(subdomain="www", domain="bbc", suffix="co.uk", fqdn="www.bbc.co.uk", registered_domain="bbc.co.uk")

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -2,6 +2,7 @@
 
 
 import argparse
+import json
 import logging
 import os.path
 import pathlib
@@ -21,6 +22,13 @@ def main() -> None:
 
     parser.add_argument(
         "--version", action="version", version="%(prog)s " + __version__
+    )
+    parser.add_argument(
+        "-j",
+        "--json",
+        default=False,
+        action="store_true",
+        help="output in json format",
     )
     parser.add_argument(
         "input", metavar="fqdn|url", type=str, nargs="*", help="fqdn or url"
@@ -89,4 +97,13 @@ def main() -> None:
 
     for i in args.input:
         ext = tld_extract(i)
-        print(f"{ext.subdomain} {ext.domain} {ext.suffix}")
+        if args.json:
+            print(json.dumps({
+                "subdomain": ext.subdomain,
+                "domain": ext.domain,
+                "suffix": ext.suffix,
+                "fqdn": ext.fqdn,
+                "registered_domain": ext.registered_domain,
+            }))
+        else:
+            print(f"{ext.subdomain} {ext.domain} {ext.suffix}")

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -98,12 +98,16 @@ def main() -> None:
     for i in args.input:
         ext = tld_extract(i)
         if args.json:
-            print(json.dumps({
-                "subdomain": ext.subdomain,
-                "domain": ext.domain,
-                "suffix": ext.suffix,
-                "fqdn": ext.fqdn,
-                "registered_domain": ext.registered_domain,
-            }))
+            print(
+                json.dumps(
+                    {
+                        "subdomain": ext.subdomain,
+                        "domain": ext.domain,
+                        "suffix": ext.suffix,
+                        "fqdn": ext.fqdn,
+                        "registered_domain": ext.registered_domain,
+                    }
+                )
+            )
         else:
             print(f"{ext.subdomain} {ext.domain} {ext.suffix}")


### PR DESCRIPTION
Hi
Maybe this is helpful.

```
$ tldextract -j www.bbc.co.uk | jq .
{
  "subdomain": "www",
  "domain": "bbc",
  "suffix": "co.uk",
  "fqdn": "www.bbc.co.uk",
  "registered_domain": "bbc.co.uk"
}
```