### PR TITLE
Add CI for PyPy3.9 and PyPy3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
             {python-version: "3.11", toxenv: "py311"},
             {python-version: "3.12", toxenv: "py312"},
             {python-version: "pypy3.8", toxenv: "pypy38"},
-            {python-version: "pypy3.9-v7.3.14", toxenv: "pypy39"},
-            {python-version: "pypy3.10-v7.3.14", toxenv: "pypy310"},
+            {python-version: "pypy3.9", toxenv: "pypy39"},
+            {python-version: "pypy3.10", toxenv: "pypy310"},
           ]
         include:
           - os: ubuntu-latest
@@ -29,7 +29,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.language.python-version }}
       - name: Install Python requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
             {python-version: "3.11", toxenv: "py311"},
             {python-version: "3.12", toxenv: "py312"},
             {python-version: "pypy3.8", toxenv: "pypy38"},
+            {python-version: "pypy3.9-v7.3.14", toxenv: "pypy39"},
+            {python-version: "pypy3.10-v7.3.14", toxenv: "pypy310"},
           ]
         include:
           - os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312,py38},codestyle,lint,typecheck
+envlist = py{38,39,310,311,312,py38,py39,py310},codestyle,lint,typecheck
 
 [testenv]
 commands = pytest {posargs}


### PR DESCRIPTION
I have identified the cause of the erroneous CLI output from #314.

It was due to a [rogue print statement](https://github.com/pypy/pypy/issues/4009) that affects **PyPy 3.9-v7.3.13** and **PyPy 3.10-v7.3.13**. This was fixed in **v7.3.14**.

GitHub Action's cached PyPy versions are still on **v7.3.13** as of today because **v7.3.14** is just 2 weeks old. This PR will be updated to remove the `-v7.3.14` suffixes once the upstream cached versions are updated.

PyPy 3.8 is no longer supported upstream as of today.
