### PR TITLE
Dedupe GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: build
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - "master"
+    tags-ignore:
+      - "**"
 jobs:
   test:
     strategy:


### PR DESCRIPTION
This is a minor optimization of the following.

1. Only run the workflow 1x instead of 2x on a PR that's from a branch
   instead of a fork.
    * This is done by only triggering on push events when they're to the
      master branch. If you want to trigger the workflow on other
      branches, be sure to open a PR.
2. Do not run the workflow on tags.
    * Tags are made on existing commits on the master branch, which
      already has workflow coverage, per the previous point.

Optimizing this isn't a big deal for an open source project on GitHub,
where GitHub Actions usage is free. However, it is a big deal for
private repository development, where usage is limited (where I've been
doing some testing).

# Test Plan

1. Manually compare the number of checks decreases going from a PR from a branch instead of a fork, #322, to this PR 
2. Manually test a bogus tag does not trigger checks - _can't be done until this PR merges to master_

| Before | After |
| --- | --- |
| <img width="611" alt="Screenshot 2024-03-05 at 10 32 17 PM" src="https://github.com/john-kurkowski/tldextract/assets/299487/83b56bba-bf95-4f29-be81-6c45f42cebd2"> | <img width="619" alt="Screenshot 2024-03-05 at 10 32 10 PM" src="https://github.com/john-kurkowski/tldextract/assets/299487/dafbac78-26a8-4697-a248-a5ffecccb730"> |
