### PR TITLE
Switch from pip to uv, during tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade --system tox tox-uv
+          pip install --upgrade tox tox-uv
       - name: Test
         run: tox
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade pip
-          pip install --upgrade --editable '.[testing]'
+          pip install --upgrade --system tox tox-uv
       - name: Test
         run: tox
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ testing = [
     "responses",
     "ruff",
     "tox",
+    "tox-uv",
     "types-filelock",
     "types-requests",
 ]


### PR DESCRIPTION
Significantly speeds up fresh tox environments, like in CI. Does not require contributors to use uv directly, outside of tox.

# Open Issues

* [ ] How much do we like a new tool that's at version ~~0.1.16~~ 0.2.3? 😅
* [x] Await fix or work around PyPy tests failing on Windows: astral-sh/uv#2316