### PR TITLE
Only install deps during tox, during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade pip
-          pip install --upgrade --editable '.[testing]'
+          pip install --upgrade tox
       - name: Test
         run: tox
         env:


### PR DESCRIPTION
tox installs deps itself. No need to do it first.

Saves some install time.