### PR TITLE
Keep more of GitHub release notes body

### DIFF
--- a/tests/__snapshots__/test_release.ambr
+++ b/tests/__snapshots__/test_release.ambr
@@ -72,6 +72,9 @@
               * Misc.
                   * Increase typecheck aggression
               
+              ## New Contributors
+              * @jdoe contributed
+              
               **Full Changelog**: fake-body
             ''',
             'draft': True,

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -76,7 +76,7 @@ def test_happy_path(
         return mock.Mock(
             json=mock.Mock(
                 return_value={
-                    "body": "Body start **Full Changelog**: fake-body",
+                    "body": "## What's Changed\nGitHub changelog here\n\n## New Contributors\n* @jdoe contributed\n\n**Full Changelog**: fake-body",
                     "html_url": "https://github.com/path/to/release",
                 }
             ),


### PR DESCRIPTION
Only omit the first paragraph, "What's Changed." Keep the e.g. "New Contributors" paragraph and "Full Changelog" link.