### PR TITLE
Switch from Black to Ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,5 +269,5 @@ tox -e py311
 Automatically format all code:
 
 ```zsh
-black .
+ruff format .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ release = [
     "twine",
 ]
 testing = [
-    "black",
     "mypy",
     "pytest",
     "pytest-gitignore",
@@ -105,7 +104,7 @@ select = [
   "W",
 ]
 ignore = [
-  "E501", # line too long; if Black does its job, not worried about the rare long line
+  "E501", # line too long; if formatter does its job, not worried about the rare long line
 ]
 
 [tool.ruff.lint.pydocstyle]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ extras = testing
 [testenv:codestyle]
 basepython = python3.8
 commands =
-    black --check {posargs:.}
+    ruff format --check {posargs:.}
 extras = testing
 
 [testenv:lint]


### PR DESCRIPTION
`ruff format` is a drop-in replacement for formatting. One fewer tool to maintain.