### PR TITLE
Pin tox and uv versions, to fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade tox 'tox-uv<1.10.0' 'uv==0.2.21'
+          pip install --upgrade 'tox==4.16.0' 'tox-uv==1.9.1' 'uv==0.2.21'
       - name: Test
         run: tox
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade tox tox-uv
+          pip install --upgrade tox tox-uv uv<0.3
       - name: Test
         run: tox
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade tox tox-uv 'uv<0.3'
+          pip install --upgrade tox 'tox-uv<1.11.0' 'uv<0.3'
       - name: Test
         run: tox
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade tox tox-uv uv<0.3
+          pip install --upgrade tox tox-uv 'uv<0.3'
       - name: Test
         run: tox
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade tox 'tox-uv<1.11.0' 'uv<0.3'
+          pip install --upgrade tox 'tox-uv<1.10.0' 'uv<0.3'
       - name: Test
         run: tox
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade tox 'tox-uv<1.10.0' 'uv<0.3'
+          pip install --upgrade tox 'tox-uv<1.10.0' 'uv==0.2.21'
       - name: Test
         run: tox
         env:


### PR DESCRIPTION
Work around regression introduced in newer tox, tox-uv, and uv. Most test runners work as before, while on the Windows pypy3.8 test runner, the newer tool versions fail to find the target version of Python. Fixes error in CI, `pypy38: skipped because could not find python interpreter with spec(s): C:\hostedtoolcache\windows\PyPy\3.8.16\x86\python.exe`. See CI for [e624fdc](https://github.com/john-kurkowski/tldextract/commit/e624fdcc25b28fa7463745f77af620fafaae504c).