### PR TITLE
Revert "Pin tox and uv versions, to fix CI (#335)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           check-latest: true
       - name: Install Python requirements
         run: |
-          pip install --upgrade 'tox==4.16.0' 'tox-uv==1.9.1' 'uv==0.2.21'
+          pip install --upgrade tox tox-uv
       - name: Test
         run: tox
         env:


### PR DESCRIPTION
Instead of #335's rollback of tool versions, trying to roll forward. This library no longer supports Python 3.8, so the CI issue with newer tool versions no longer happens.

# Changes

* ~~Drop PyPy 3.8 from CI~~
  * ~~It's causing issues with `uv` in CI that aren't worth hoop jumping. PyPy 3.8 hasn't received updates in years. CPython 3.8's EOL is 2024-10-31.~~
* Thanks to upstream changes, this PR just contains a revert

# TODO

- [x] Wait for upstream CPython 3.8 to be EOL 2024-10-31?
- [x] Remove noisy commits