### PR TITLE
Drop support for EOL Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,22 +14,20 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         language:
           [
-            {python-version: "3.8", toxenv: "py38"},
             {python-version: "3.9", toxenv: "py39"},
             {python-version: "3.10", toxenv: "py310"},
             {python-version: "3.11", toxenv: "py311"},
             {python-version: "3.12", toxenv: "py312"},
-            {python-version: "pypy3.8", toxenv: "pypy38"},
             {python-version: "pypy3.9", toxenv: "pypy39"},
             {python-version: "pypy3.10", toxenv: "pypy310"},
           ]
         include:
           - os: ubuntu-latest
-            language: {python-version: "3.8", toxenv: "codestyle"}
+            language: {python-version: "3.9", toxenv: "codestyle"}
           - os: ubuntu-latest
-            language: {python-version: "3.8", toxenv: "lint"}
+            language: {python-version: "3.9", toxenv: "lint"}
           - os: ubuntu-latest
-            language: {python-version: "3.8", toxenv: "typecheck"}
+            language: {python-version: "3.9", toxenv: "typecheck"}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,12 @@ classifiers = [
     "Topic :: Utilities",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dynamic = ["version"]
 readme = "README.md"
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import sys
 import tempfile
 from collections.abc import Sequence
 from pathlib import Path
@@ -168,8 +167,7 @@ def test_looks_like_ipv6() -> None:
     assert looks_like_ipv6("aBcD:ef01:2345:6789:aBcD:ef01:aaaa:2288") is True
     assert looks_like_ipv6("aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1") is True
     assert looks_like_ipv6("ZBcD:ef01:2345:6789:aBcD:ef01:127.0.0.1") is False
-    if sys.version_info >= (3, 8, 12):  # noqa: UP036
-        assert looks_like_ipv6("aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.01") is False
+    assert looks_like_ipv6("aBcD:ef01:2345:6789:aBcD:ef01:127.0.0.01") is False
     assert looks_like_ipv6("aBcD:ef01:2345:6789:aBcD:") is False
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,7 +32,7 @@ def test_disk_cache(tmp_path: Path) -> None:
 
 def test_get_pkg_unique_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test generating a unique identifier for the version of this package."""
-    monkeypatch.setattr(sys, "version_info", (3, 8, 1, "final", 0))
+    monkeypatch.setattr(sys, "version_info", (3, 9, 1, "final", 0))
     monkeypatch.setattr(sys, "prefix", "/home/john/.pyenv/versions/myvirtualenv")
 
     mock_version_module = types.ModuleType("tldextract._version", "mocked module")
@@ -41,13 +41,13 @@ def test_get_pkg_unique_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert (
         get_pkg_unique_identifier()
-        == "3.8.1.final__myvirtualenv__f01a7b__tldextract-1.2.3"
+        == "3.9.1.final__myvirtualenv__f01a7b__tldextract-1.2.3"
     )
 
 
 def test_get_cache_dir(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test finding the cache directory."""
-    pkg_identifier = "3.8.1.final__myvirtualenv__f01a7b__tldextract-1.2.3"
+    pkg_identifier = "3.9.1.final__myvirtualenv__f01a7b__tldextract-1.2.3"
     monkeypatch.setattr(
         tldextract.cache, "get_pkg_unique_identifier", lambda: pkg_identifier
     )

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -34,11 +34,12 @@ class Mocks:
 @pytest.fixture
 def mocks() -> Iterator[Mocks]:
     """Stub network and subprocesses."""
-    with mock.patch("builtins.input") as mock_input, mock.patch(
-        "os.listdir"
-    ) as mock_listdir, mock.patch("requests.post") as mock_requests, mock.patch(
-        "subprocess.run"
-    ) as mock_subprocess:
+    with (
+        mock.patch("builtins.input") as mock_input,
+        mock.patch("os.listdir") as mock_listdir,
+        mock.patch("requests.post") as mock_requests,
+        mock.patch("subprocess.run") as mock_subprocess,
+    ):
         yield Mocks(
             input=mock_input,
             listdir=mock_listdir,

--- a/tldextract/cache.py
+++ b/tldextract/cache.py
@@ -24,18 +24,6 @@ _DID_LOG_UNABLE_TO_CACHE = False
 
 T = TypeVar("T")
 
-if sys.version_info >= (3, 9):
-
-    def md5(*args: bytes) -> hashlib._Hash:
-        """Use argument only available in newer Python.
-
-        In this file, MD5 is only used for cache location, not security.
-        """
-        return hashlib.md5(*args, usedforsecurity=False)
-
-else:
-    md5 = hashlib.md5
-
 
 def get_pkg_unique_identifier() -> str:
     """Generate an identifier unique to the python version, tldextract version, and python instance.
@@ -51,7 +39,9 @@ def get_pkg_unique_identifier() -> str:
     tldextract_version = "tldextract-" + version
     python_env_name = os.path.basename(sys.prefix)
     # just to handle the edge case of two identically named python environments
-    python_binary_path_short_hash = md5(sys.prefix.encode("utf-8")).hexdigest()[:6]
+    python_binary_path_short_hash = hashlib.md5(
+        sys.prefix.encode("utf-8"), usedforsecurity=False
+    ).hexdigest()[:6]
     python_version = ".".join([str(v) for v in sys.version_info[:-1]])
     identifier_parts = [
         python_version,
@@ -237,7 +227,7 @@ def _fetch_url(session: requests.Session, url: str, timeout: int | None) -> str:
 
 def _make_cache_key(inputs: str | dict[str, Hashable]) -> str:
     key = repr(inputs)
-    return md5(key.encode("utf8")).hexdigest()
+    return hashlib.md5(key.encode("utf8"), usedforsecurity=False).hexdigest()
 
 
 def _make_dir(filename: str) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,22 @@
 [tox]
-envlist = py{38,39,310,311,312,py38,py39,py310},codestyle,lint,typecheck
+envlist = py{39,310,311,312,py39,py310},codestyle,lint,typecheck
 
 [testenv]
 commands = pytest {posargs}
 extras = testing
 
 [testenv:codestyle]
-basepython = python3.8
+basepython = python3.9
 commands =
     ruff format --check {posargs:.}
 extras = testing
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.9
 commands = ruff check {posargs:.}
 extras = testing
 
 [testenv:typecheck]
-basepython = python3.8
+basepython = python3.9
 commands = mypy --show-error-codes scripts tldextract tests
 extras = testing


### PR DESCRIPTION
It is EOL as of 2024-10-07.

* Accept output of newer `ruff format`