### PR TITLE
Add properties for top domain under public suffix and registry suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To rejoin the original hostname, if it was indeed a valid, registered hostname:
 
 ```python
 >>> ext = tldextract.extract('http://forums.bbc.co.uk')
->>> ext.registered_domain
+>>> ext.top_domain_under_public_suffix
 'bbc.co.uk'
 >>> ext.fqdn
 'forums.bbc.co.uk'
@@ -246,7 +246,7 @@ For example:
 extractor = TLDExtract()
 split_url = urllib.parse.urlsplit("https://foo.bar.com:8080")
 split_suffix = extractor.extract_urllib(split_url)
-url_to_crawl = f"{split_url.scheme}://{split_suffix.registered_domain}:{split_url.port}"
+url_to_crawl = f"{split_url.scheme}://{split_suffix.top_domain_under_public_suffix}:{split_url.port}"
 ```
 
 `tldextract`'s lenient string parsing stance lowers the learning curve of using

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ A public suffix is also sometimes called an effective TLD (eTLD).
 >>> import tldextract
 
 >>> tldextract.extract('http://forums.news.cnn.com/')
-ExtractResult(subdomain='forums.news', domain='cnn', suffix='com', is_private=False, registry_suffix='com')
+ExtractResult(subdomain='forums.news', domain='cnn', suffix='com', is_private=False)
 
 >>> tldextract.extract('http://forums.bbc.co.uk/') # United Kingdom
-ExtractResult(subdomain='forums', domain='bbc', suffix='co.uk', is_private=False, registry_suffix='co.uk')
+ExtractResult(subdomain='forums', domain='bbc', suffix='co.uk', is_private=False)
 
 >>> tldextract.extract('http://www.worldbank.org.kg/') # Kyrgyzstan
-ExtractResult(subdomain='www', domain='worldbank', suffix='org.kg', is_private=False, registry_suffix='org.kg')
+ExtractResult(subdomain='www', domain='worldbank', suffix='org.kg', is_private=False)
 ```
 
 Note subdomain and suffix are _optional_. Not all URL-like inputs have a
@@ -36,13 +36,13 @@ subdomain or a valid suffix.
 
 ```python
 >>> tldextract.extract('google.com')
-ExtractResult(subdomain='', domain='google', suffix='com', is_private=False, registry_suffix='com')
+ExtractResult(subdomain='', domain='google', suffix='com', is_private=False)
 
 >>> tldextract.extract('google.notavalidsuffix')
-ExtractResult(subdomain='google', domain='notavalidsuffix', suffix='', is_private=False, registry_suffix=''))
+ExtractResult(subdomain='google', domain='notavalidsuffix', suffix='', is_private=False)
 
 >>> tldextract.extract('http://127.0.0.1:8080/deployed/')
-ExtractResult(subdomain='', domain='127.0.0.1', suffix='', is_private=False, registry_suffix='')
+ExtractResult(subdomain='', domain='127.0.0.1', suffix='', is_private=False)
 ```
 
 To rejoin the original hostname, if it was indeed a valid, registered hostname:
@@ -146,7 +146,7 @@ By default, `tldextract` treats public and private domains the same.
 ```python
 >>> extract = tldextract.TLDExtract()
 >>> extract('waiterrant.blogspot.com')
-ExtractResult(subdomain='waiterrant', domain='blogspot', suffix='com', is_private=False, registry_suffix='com')
+ExtractResult(subdomain='waiterrant', domain='blogspot', suffix='com', is_private=False)
 ```
 
 The following overrides this.
@@ -154,7 +154,7 @@ The following overrides this.
 ```python
 >>> extract = tldextract.TLDExtract()
 >>> extract('waiterrant.blogspot.com', include_psl_private_domains=True)
-ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True, registry_suffix='com')
+ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True)
 ```
 
 To change the default for all extract calls:
@@ -162,7 +162,7 @@ To change the default for all extract calls:
 ```python
 >>> extract = tldextract.TLDExtract(include_psl_private_domains=True)
 >>> extract('waiterrant.blogspot.com')
-ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True, registry_suffix='com')
+ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True)
 ```
 
 The thinking behind the default is, it's the more common case when people

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ A public suffix is also sometimes called an effective TLD (eTLD).
 >>> import tldextract
 
 >>> tldextract.extract('http://forums.news.cnn.com/')
-ExtractResult(subdomain='forums.news', domain='cnn', suffix='com', is_private=False)
+ExtractResult(subdomain='forums.news', domain='cnn', suffix='com', is_private=False, registry_suffix='com')
 
 >>> tldextract.extract('http://forums.bbc.co.uk/') # United Kingdom
-ExtractResult(subdomain='forums', domain='bbc', suffix='co.uk', is_private=False)
+ExtractResult(subdomain='forums', domain='bbc', suffix='co.uk', is_private=False, registry_suffix='co.uk')
 
 >>> tldextract.extract('http://www.worldbank.org.kg/') # Kyrgyzstan
-ExtractResult(subdomain='www', domain='worldbank', suffix='org.kg', is_private=False)
+ExtractResult(subdomain='www', domain='worldbank', suffix='org.kg', is_private=False, registry_suffix='org.kg')
 ```
 
 Note subdomain and suffix are _optional_. Not all URL-like inputs have a
@@ -36,13 +36,13 @@ subdomain or a valid suffix.
 
 ```python
 >>> tldextract.extract('google.com')
-ExtractResult(subdomain='', domain='google', suffix='com', is_private=False)
+ExtractResult(subdomain='', domain='google', suffix='com', is_private=False, registry_suffix='com')
 
 >>> tldextract.extract('google.notavalidsuffix')
-ExtractResult(subdomain='google', domain='notavalidsuffix', suffix='', is_private=False)
+ExtractResult(subdomain='google', domain='notavalidsuffix', suffix='', is_private=False, registry_suffix=''))
 
 >>> tldextract.extract('http://127.0.0.1:8080/deployed/')
-ExtractResult(subdomain='', domain='127.0.0.1', suffix='', is_private=False)
+ExtractResult(subdomain='', domain='127.0.0.1', suffix='', is_private=False, registry_suffix='')
 ```
 
 To rejoin the original hostname, if it was indeed a valid, registered hostname:
@@ -146,21 +146,23 @@ By default, `tldextract` treats public and private domains the same.
 ```python
 >>> extract = tldextract.TLDExtract()
 >>> extract('waiterrant.blogspot.com')
-ExtractResult(subdomain='waiterrant', domain='blogspot', suffix='com', is_private=False)
+ExtractResult(subdomain='waiterrant', domain='blogspot', suffix='com', is_private=False, registry_suffix='com')
 ```
 
 The following overrides this.
+
 ```python
 >>> extract = tldextract.TLDExtract()
 >>> extract('waiterrant.blogspot.com', include_psl_private_domains=True)
-ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True)
+ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True, registry_suffix='com')
 ```
 
-or to change the default for all extract calls,
+To change the default for all extract calls:
+
 ```python
->>> extract = tldextract.TLDExtract( include_psl_private_domains=True)
+>>> extract = tldextract.TLDExtract(include_psl_private_domains=True)
 >>> extract('waiterrant.blogspot.com')
-ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True)
+ExtractResult(subdomain='', domain='waiterrant', suffix='blogspot.com', is_private=True, registry_suffix='com')
 ```
 
 The thinking behind the default is, it's the more common case when people

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -77,12 +77,14 @@ def test_cli_json_output(
     stdout, stderr = capsys.readouterr()
     assert not stderr
     assert json.loads(stdout) == {
-        "subdomain": "www",
         "domain": "bbc",
-        "suffix": "co.uk",
         "fqdn": "www.bbc.co.uk",
         "ipv4": "",
         "ipv6": "",
         "is_private": False,
         "registered_domain": "bbc.co.uk",
+        "subdomain": "www",
+        "suffix": "co.uk",
+        "top_domain_under_public_suffix": "bbc.co.uk",
+        "top_domain_under_registry_suffix": "bbc.co.uk",
     }

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -83,6 +83,7 @@ def test_cli_json_output(
         "ipv6": "",
         "is_private": False,
         "registered_domain": "bbc.co.uk",
+        "registry_suffix": "co.uk",
         "subdomain": "www",
         "suffix": "co.uk",
         "top_domain_under_public_suffix": "bbc.co.uk",

--- a/tests/custom_suffix_test.py
+++ b/tests/custom_suffix_test.py
@@ -32,12 +32,19 @@ def test_private_extraction() -> None:
     """Test this library's uncached, offline, private domain extraction."""
     tld = tldextract.TLDExtract(cache_dir=tempfile.mkdtemp(), suffix_list_urls=[])
 
-    assert tld("foo.blogspot.com") == ExtractResult("foo", "blogspot", "com", False)
+    assert tld("foo.blogspot.com") == ExtractResult(
+        subdomain="foo",
+        domain="blogspot",
+        suffix="com",
+        is_private=False,
+        registry_suffix="com",
+    )
     assert tld("foo.blogspot.com", include_psl_private_domains=True) == ExtractResult(
-        "",
-        "foo",
-        "blogspot.com",
-        True,
+        subdomain="",
+        domain="foo",
+        suffix="blogspot.com",
+        is_private=True,
+        registry_suffix="com",
     )
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -374,6 +374,24 @@ def test_dns_root_label() -> None:
     )
 
 
+def test_top_domain_under_registry_suffix() -> None:
+    """Test property `top_domain_under_registry_suffix`."""
+    assert (
+        tldextract.extract(
+            "http://www.example.auth.us-east-1.amazoncognito.com",
+            include_psl_private_domains=False,
+        ).top_domain_under_registry_suffix
+        == "amazoncognito.com"
+    )
+    assert (
+        tldextract.extract(
+            "http://www.example.auth.us-east-1.amazoncognito.com",
+            include_psl_private_domains=True,
+        ).top_domain_under_registry_suffix
+        == "example.auth.us-east-1.amazoncognito.com"
+    )
+
+
 def test_ipv4() -> None:
     """Test IPv4 addresses."""
     assert_extract(

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -374,6 +374,24 @@ def test_dns_root_label() -> None:
     )
 
 
+def test_top_domain_under_public_suffix() -> None:
+    """Test property `top_domain_under_public_suffix`."""
+    assert (
+        tldextract.extract(
+            "http://www.example.auth.us-east-1.amazoncognito.com",
+            include_psl_private_domains=False,
+        ).top_domain_under_public_suffix
+        == "amazoncognito.com"
+    )
+    assert (
+        tldextract.extract(
+            "http://www.example.auth.us-east-1.amazoncognito.com",
+            include_psl_private_domains=True,
+        ).top_domain_under_public_suffix
+        == "example.auth.us-east-1.amazoncognito.com"
+    )
+
+
 def test_top_domain_under_registry_suffix() -> None:
     """Test property `top_domain_under_registry_suffix`."""
     assert (
@@ -388,7 +406,7 @@ def test_top_domain_under_registry_suffix() -> None:
             "http://www.example.auth.us-east-1.amazoncognito.com",
             include_psl_private_domains=True,
         ).top_domain_under_registry_suffix
-        == "example.auth.us-east-1.amazoncognito.com"
+        == "amazoncognito.com"
     )
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -530,12 +530,22 @@ def test_include_psl_private_domain_attr() -> None:
     extract_public1 = tldextract.TLDExtract()
     extract_public2 = tldextract.TLDExtract(include_psl_private_domains=False)
     assert extract_private("foo.uk.com") == ExtractResult(
-        subdomain="", domain="foo", suffix="uk.com", is_private=True
+        subdomain="",
+        domain="foo",
+        suffix="uk.com",
+        is_private=True,
+        registry_suffix="com",
     )
     assert (
         extract_public1("foo.uk.com")
         == extract_public2("foo.uk.com")
-        == ExtractResult(subdomain="foo", domain="uk", suffix="com", is_private=False)
+        == ExtractResult(
+            subdomain="foo",
+            domain="uk",
+            suffix="com",
+            is_private=False,
+            registry_suffix="com",
+        )
     )
 
 
@@ -558,11 +568,21 @@ def test_global_extract() -> None:
     """
     assert tldextract.extract(
         "blogspot.com", include_psl_private_domains=True
-    ) == ExtractResult(subdomain="", domain="", suffix="blogspot.com", is_private=True)
+    ) == ExtractResult(
+        subdomain="",
+        domain="",
+        suffix="blogspot.com",
+        is_private=True,
+        registry_suffix="com",
+    )
     assert tldextract.extract(
         "foo.blogspot.com", include_psl_private_domains=True
     ) == ExtractResult(
-        subdomain="", domain="foo", suffix="blogspot.com", is_private=True
+        subdomain="",
+        domain="foo",
+        suffix="blogspot.com",
+        is_private=True,
+        registry_suffix="com",
     )
 
 
@@ -578,15 +598,26 @@ def test_private_domains_depth() -> None:
         domain="amazonaws",
         suffix="com",
         is_private=False,
+        registry_suffix="com",
     )
     assert tldextract.extract(
         "ap-south-1.amazonaws.com", include_psl_private_domains=True
     ) == ExtractResult(
-        subdomain="ap-south-1", domain="amazonaws", suffix="com", is_private=False
+        subdomain="ap-south-1",
+        domain="amazonaws",
+        suffix="com",
+        is_private=False,
+        registry_suffix="com",
     )
     assert tldextract.extract(
         "amazonaws.com", include_psl_private_domains=True
-    ) == ExtractResult(subdomain="", domain="amazonaws", suffix="com", is_private=False)
+    ) == ExtractResult(
+        subdomain="",
+        domain="amazonaws",
+        suffix="com",
+        is_private=False,
+        registry_suffix="com",
+    )
     assert tldextract.extract(
         "the-quick-brown-fox.cn-north-1.amazonaws.com.cn",
         include_psl_private_domains=True,
@@ -595,16 +626,25 @@ def test_private_domains_depth() -> None:
         domain="amazonaws",
         suffix="com.cn",
         is_private=False,
+        registry_suffix="com.cn",
     )
     assert tldextract.extract(
         "cn-north-1.amazonaws.com.cn", include_psl_private_domains=True
     ) == ExtractResult(
-        subdomain="cn-north-1", domain="amazonaws", suffix="com.cn", is_private=False
+        subdomain="cn-north-1",
+        domain="amazonaws",
+        suffix="com.cn",
+        is_private=False,
+        registry_suffix="com.cn",
     )
     assert tldextract.extract(
         "amazonaws.com.cn", include_psl_private_domains=True
     ) == ExtractResult(
-        subdomain="", domain="amazonaws", suffix="com.cn", is_private=False
+        subdomain="",
+        domain="amazonaws",
+        suffix="com.cn",
+        is_private=False,
+        registry_suffix="com.cn",
     )
     assert tldextract.extract(
         "another.icann.compute.amazonaws.com", include_psl_private_domains=True
@@ -613,6 +653,7 @@ def test_private_domains_depth() -> None:
         domain="another",
         suffix="icann.compute.amazonaws.com",
         is_private=True,
+        registry_suffix="com",
     )
     assert tldextract.extract(
         "another.s3.dualstack.us-east-1.amazonaws.com", include_psl_private_domains=True
@@ -621,12 +662,17 @@ def test_private_domains_depth() -> None:
         domain="another",
         suffix="s3.dualstack.us-east-1.amazonaws.com",
         is_private=True,
+        registry_suffix="com",
     )
 
     assert tldextract.extract(
         "s3.ap-south-1.amazonaws.com", include_psl_private_domains=True
     ) == ExtractResult(
-        subdomain="", domain="", suffix="s3.ap-south-1.amazonaws.com", is_private=True
+        subdomain="",
+        domain="",
+        suffix="s3.ap-south-1.amazonaws.com",
+        is_private=True,
+        registry_suffix="com",
     )
     assert tldextract.extract(
         "s3.cn-north-1.amazonaws.com.cn", include_psl_private_domains=True
@@ -635,11 +681,16 @@ def test_private_domains_depth() -> None:
         domain="",
         suffix="s3.cn-north-1.amazonaws.com.cn",
         is_private=True,
+        registry_suffix="com.cn",
     )
     assert tldextract.extract(
         "icann.compute.amazonaws.com", include_psl_private_domains=True
     ) == ExtractResult(
-        subdomain="", domain="", suffix="icann.compute.amazonaws.com", is_private=True
+        subdomain="",
+        domain="",
+        suffix="icann.compute.amazonaws.com",
+        is_private=True,
+        registry_suffix="com",
     )
 
     # Entire URL is private suffix which ends with another private suffix
@@ -651,4 +702,5 @@ def test_private_domains_depth() -> None:
         domain="",
         suffix="s3.dualstack.us-east-1.amazonaws.com",
         is_private=True,
+        registry_suffix="com",
     )

--- a/tldextract/cli.py
+++ b/tldextract/cli.py
@@ -98,7 +98,14 @@ def main() -> None:
     for i in args.input:
         ext = tld_extract(i)
         if args.json:
-            properties = ("fqdn", "ipv4", "ipv6", "registered_domain")
+            properties = (
+                "fqdn",
+                "ipv4",
+                "ipv6",
+                "registered_domain",
+                "top_domain_under_public_suffix",
+                "top_domain_under_registry_suffix",
+            )
             print(
                 json.dumps(
                     {

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -28,7 +28,7 @@ subdomain or a valid suffix.
 To rejoin the original hostname, if it was indeed a valid, registered hostname:
 
     >>> ext = tldextract.extract('http://forums.bbc.co.uk')
-    >>> ext.registered_domain
+    >>> ext.top_domain_under_public_suffix
     'bbc.co.uk'
     >>> ext.fqdn
     'forums.bbc.co.uk'

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -596,33 +596,36 @@ class _PublicSuffixListTLDExtractor:
             if include_psl_private_domains
             else self.tlds_excl_private_trie
         )
-        i = j = k = len(spl)
+        suffix_idx = label_idx = reg_idx = len(spl)
         for label in reversed(spl):
             decoded_label = _decode_punycode(label)
             if decoded_label in node.matches:
-                j -= 1
+                label_idx -= 1
                 node = node.matches[decoded_label]
                 if node.end:
-                    i = j
+                    suffix_idx = label_idx
                     if not node.is_private:
                         registry_node = node
-                        k = j
+                        reg_idx = label_idx
                 continue
 
             is_wildcard = "*" in node.matches
             if is_wildcard:
                 is_wildcard_exception = "!" + decoded_label in node.matches
-                return (j if is_wildcard_exception else j - 1, node.matches["*"]), (
-                    k,
+                return (
+                    label_idx if is_wildcard_exception else label_idx - 1,
+                    node.matches["*"],
+                ), (
+                    reg_idx,
                     registry_node,
                 )
 
             break
 
-        if i == len(spl):
+        if suffix_idx == len(spl):
             return None
 
-        return ((i, node), (k, registry_node))
+        return ((suffix_idx, node), (reg_idx, registry_node))
 
 
 def _decode_punycode(label: str) -> str:

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -194,7 +194,7 @@ class ExtractResult:
         if not top_domain_under_public_suffix or not self.is_private:
             return top_domain_under_public_suffix
 
-        num_labels = self.registry_suffix.count(".") + 1
+        num_labels = self.registry_suffix.count(".") + 2
         return ".".join(top_domain_under_public_suffix.split(".")[-num_labels:])
 
     @property

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -77,6 +77,29 @@ class ExtractResult:
         'bbc.co.uk'
         >>> extract('http://localhost:8080').registered_domain
         ''
+
+        This is roughly the domain the owner paid to register with a registrar
+        or, in the case of a private domain, "registered" with the domain
+        owner.
+
+        To distinguish the latter case of private domains, consider Blogspot,
+        which is in the PSL's private domains. If `TLDExtract`'s
+        `include_psl_private_domains=False`, which is the default, public and
+        private domains are not distinguished, the `registered_domain` property
+        of a Blogspot URL represents the domain the owner of Blogspot
+        registered with a registrar, i.e. `blogspot.com`. If
+        `include_psl_private_domains=True`, the `registered_domain` property
+        represents the blogspot.com subdomain the owner of a Blogspot blog
+        registered with Blogspot.
+
+        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=False).registered_domain
+        'blogspot.com'
+        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=True).registered_domain
+        'waiterrant.blogspot.com'
+
+        To always get the same joined string, regardless of the
+        `include_psl_private_domains` setting, consider the TODO and TODO
+        properties.
         """
         if self.suffix and self.domain:
             return f"{self.domain}.{self.suffix}"

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -66,7 +66,7 @@ class ExtractResult:
     They can be used to rebuild the original URL's hostname.
 
     Beyond the first 3 fields, the class contains metadata fields, like a flag
-    that indicates if the URL has a private suffix.
+    that indicates if the input URL's suffix is from a private domain.
     """
 
     subdomain: str
@@ -75,23 +75,37 @@ class ExtractResult:
     domain: str
     """The topmost domain of the input URL, if it contained a domain name, or else everything hostname-like in the input.
 
-    If the input URL didn't contain a real domain name, this field tends to
-    catch values like an IP address, or private network hostnames like
-    "localhost".
+    If the input URL didn't contain a real domain name, the `suffix` field will
+    be empty, and this field will catch values like an IP address, or
+    private network hostnames like "localhost".
     """
 
     suffix: str
-    """The public suffix of the input URL, if it contained one, or else the empty string."""
+    """The public suffix of the input URL, if it contained one, or else the empty string.
+
+    If `include_psl_private_domains` was set to `False`, this field is the same
+    as `registry_suffix`, i.e. a domain under which people can register
+    subdomains through a registrar. If `include_psl_private_domains` was set to
+    `True`, this field may be a PSL private domain, like "blogspot.com".
+    """
 
     is_private: bool
     """Whether the input URL belongs in the Public Suffix List's private domains.
 
-    If `include_psl_private_domains` was set to `False`, this is always
+    If `include_psl_private_domains` was set to `False`, this field is always
     `False`.
     """
 
     registry_suffix: str = field(repr=False)
-    """The registry suffix of the input URL, if it contained one, or else the empty string."""
+    """The registry suffix of the input URL, if it contained one, or else the empty string.
+
+    This field is a domain under which people can register subdomains through a
+    registar.
+
+    This field is unaffected by the `include_psl_private_domains` setting. If
+    `include_psl_private_domains` was set to `False`, this field is always the
+    same as `suffix`.
+    """
 
     @property
     def fqdn(self) -> str:
@@ -164,13 +178,12 @@ class ExtractResult:
         something one could register, this property returns the empty string.
 
         To distinguish the case of private domains, consider Blogspot, which is
-        in the PSL's private domains. If `TLDExtract`'s
-        `include_psl_private_domains=False`, which is the default, public and
-        private domains are not distinguished, the `registered_domain` property
-        of a Blogspot URL represents the domain the owner of Blogspot
-        registered with a registrar, i.e. `blogspot.com`. If
+        in the PSL's private domains. If `include_psl_private_domains` was set
+        to `False`, the `registered_domain` property of a Blogspot URL
+        represents the domain the owner of Blogspot registered with a
+        registrar, i.e. Google registered "blogspot.com". If
         `include_psl_private_domains=True`, the `registered_domain` property
-        represents the blogspot.com _subdomain_ the owner of a blog
+        represents the "blogspot.com" _subdomain_ the owner of a blog
         "registered" with Blogspot.
 
         >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=False).registered_domain

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -381,7 +381,7 @@ class TLDExtract:
 
         labels = netloc_with_ascii_dots.split(".")
 
-        maybe_indexes = self._get_tld_extractor(session=session).suffix_index(
+        maybe_indexes = self._get_tld_extractor(session).suffix_index(
             labels, include_psl_private_domains=include_psl_private_domains
         )
 
@@ -591,12 +591,12 @@ class _PublicSuffixListTLDExtractor:
         if include_psl_private_domains is None:
             include_psl_private_domains = self.include_psl_private_domains
 
-        node = registry_node = (
+        node = reg_node = (
             self.tlds_incl_private_trie
             if include_psl_private_domains
             else self.tlds_excl_private_trie
         )
-        suffix_idx = label_idx = reg_idx = len(spl)
+        suffix_idx = reg_idx = label_idx = len(spl)
         for label in reversed(spl):
             decoded_label = _decode_punycode(label)
             if decoded_label in node.matches:
@@ -605,7 +605,7 @@ class _PublicSuffixListTLDExtractor:
                 if node.end:
                     suffix_idx = label_idx
                     if not node.is_private:
-                        registry_node = node
+                        reg_node = node
                         reg_idx = label_idx
                 continue
 
@@ -617,7 +617,7 @@ class _PublicSuffixListTLDExtractor:
                     node.matches["*"],
                 ), (
                     reg_idx,
-                    registry_node,
+                    reg_node,
                 )
 
             break
@@ -625,7 +625,7 @@ class _PublicSuffixListTLDExtractor:
         if suffix_idx == len(spl):
             return None
 
-        return ((suffix_idx, node), (reg_idx, registry_node))
+        return ((suffix_idx, node), (reg_idx, reg_node))
 
 
 def _decode_punycode(label: str) -> str:

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -190,10 +190,12 @@ class ExtractResult:
         >>> extract('http://localhost:8080').top_domain_under_registry_suffix
         ''
         """
-        if not self.is_private:
-            return self.top_domain_under_public_suffix
+        top_domain_under_public_suffix = self.top_domain_under_public_suffix
+        if not top_domain_under_public_suffix or not self.is_private:
+            return top_domain_under_public_suffix
 
-        raise NotImplementedError
+        num_labels = self.registry_suffix.count(".") + 1
+        return ".".join(top_domain_under_public_suffix.split(".")[-num_labels:])
 
     @property
     def top_domain_under_public_suffix(self) -> str:

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -86,43 +86,6 @@ class ExtractResult:
     """
 
     @property
-    def registered_domain(self) -> str:
-        """Joins the `domain` and `suffix` fields with a dot, if they're both set, or else the empty string.
-
-        >>> extract('http://forums.bbc.co.uk').registered_domain
-        'bbc.co.uk'
-        >>> extract('http://localhost:8080').registered_domain
-        ''
-
-        This is roughly the domain the owner paid to register with a registrar
-        or, in the case of a private domain, "registered" with the domain
-        owner. If the input was not something one could register, this property
-        returns the empty string.
-
-        To distinguish the case of private domains, consider Blogspot, which is
-        in the PSL's private domains. If `TLDExtract`'s
-        `include_psl_private_domains=False`, which is the default, public and
-        private domains are not distinguished, the `registered_domain` property
-        of a Blogspot URL represents the domain the owner of Blogspot
-        registered with a registrar, i.e. `blogspot.com`. If
-        `include_psl_private_domains=True`, the `registered_domain` property
-        represents the blogspot.com _subdomain_ the owner of a blog registered
-        with Blogspot.
-
-        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=False).registered_domain
-        'blogspot.com'
-        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=True).registered_domain
-        'waiterrant.blogspot.com'
-
-        To always get the same joined string, regardless of the
-        `include_psl_private_domains` setting, consider the TODO and TODO
-        properties.
-        """
-        if self.suffix and self.domain:
-            return f"{self.domain}.{self.suffix}"
-        return ""
-
-    @property
     def fqdn(self) -> str:
         """Returns a Fully Qualified Domain Name (FQDN), if there is a proper `domain` and `suffix`, or else the empty string.
 
@@ -175,6 +138,74 @@ class ExtractResult:
             debracketed = self.domain[1:-1]
             if looks_like_ipv6(debracketed):
                 return debracketed
+        return ""
+
+    @property
+    def registered_domain(self) -> str:
+        """Joins the `domain` and `suffix` fields with a dot, if they're both set, or else the empty string.
+
+        >>> extract('http://forums.bbc.co.uk').registered_domain
+        'bbc.co.uk'
+        >>> extract('http://localhost:8080').registered_domain
+        ''
+
+        This is an alias for the `top_domain_under_public_suffix` property.
+        `registered_domain` is so called because is roughly the domain the
+        owner paid to register with a registrar or, in the case of a private
+        domain, "registered" with the domain owner. If the input was not
+        something one could register, this property returns the empty string.
+
+        To distinguish the case of private domains, consider Blogspot, which is
+        in the PSL's private domains. If `TLDExtract`'s
+        `include_psl_private_domains=False`, which is the default, public and
+        private domains are not distinguished, the `registered_domain` property
+        of a Blogspot URL represents the domain the owner of Blogspot
+        registered with a registrar, i.e. `blogspot.com`. If
+        `include_psl_private_domains=True`, the `registered_domain` property
+        represents the blogspot.com _subdomain_ the owner of a blog
+        "registered" with Blogspot.
+
+        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=False).registered_domain
+        'blogspot.com'
+        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=True).registered_domain
+        'waiterrant.blogspot.com'
+
+        To always get the same joined string, regardless of the
+        `include_psl_private_domains` setting, consider the
+        `top_domain_under_registry_suffix` property.
+        """
+        return self.top_domain_under_public_suffix
+
+    @property
+    def top_domain_under_registry_suffix(self) -> str:
+        """Joins the rightmost domain and `registry_suffix` with a dot, if such a domain is available and `registry_suffix` is set, or else the empty string.
+
+        If the input was not in the Public Suffix List's private domains, this
+        is equivalent to `top_domain_under_public_suffix`.
+
+        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=False).top_domain_under_registry_suffix
+        'blogspot.com'
+        >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=True).top_domain_under_registry_suffix
+        'blogspot.com'
+        >>> extract('http://localhost:8080').top_domain_under_registry_suffix
+        ''
+        """
+        if not self.is_private:
+            return self.top_domain_under_public_suffix
+
+        raise NotImplementedError
+
+    @property
+    def top_domain_under_public_suffix(self) -> str:
+        """Joins the `domain` and `suffix` fields with a dot, if they're both set, or else the empty string.
+
+        >>> extract('http://forums.bbc.co.uk').top_domain_under_public_suffix
+        'bbc.co.uk'
+        >>> extract('http://localhost:8080').top_domain_under_public_suffix
+        ''
+        """
+        if self.suffix and self.domain:
+            return f"{self.domain}.{self.suffix}"
         return ""
 
 

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -232,10 +232,14 @@ class ExtractResult:
 
     @property
     def top_domain_under_registry_suffix(self) -> str:
-        """The rightmost domain and `registry_suffix` joined with a dot, if such a domain is available and `registry_suffix` is set, or else the empty string.
+        """The rightmost domain label and `registry_suffix` joined with a dot, if such a domain is available and `registry_suffix` is set, or else the empty string.
 
-        If the input was not in the Public Suffix List's private domains, this
-        is equivalent to `top_domain_under_public_suffix`.
+        The rightmost domain label might be in the `domain` field, or, if the
+        input URL's suffix is a PSL private domain, in the public suffix
+        `suffix` field.
+
+        If the input was not in the PSL's private domains, this property is
+        equivalent to `top_domain_under_public_suffix`.
 
         >>> extract(
         ...     "http://waiterrant.blogspot.com", include_psl_private_domains=False

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -80,17 +80,18 @@ class ExtractResult:
 
         This is roughly the domain the owner paid to register with a registrar
         or, in the case of a private domain, "registered" with the domain
-        owner.
+        owner. If the input was not something one could register, this property
+        returns the empty string.
 
-        To distinguish the latter case of private domains, consider Blogspot,
-        which is in the PSL's private domains. If `TLDExtract`'s
+        To distinguish the case of private domains, consider Blogspot, which is
+        in the PSL's private domains. If `TLDExtract`'s
         `include_psl_private_domains=False`, which is the default, public and
         private domains are not distinguished, the `registered_domain` property
         of a Blogspot URL represents the domain the owner of Blogspot
         registered with a registrar, i.e. `blogspot.com`. If
         `include_psl_private_domains=True`, the `registered_domain` property
-        represents the blogspot.com subdomain the owner of a Blogspot blog
-        registered with Blogspot.
+        represents the blogspot.com _subdomain_ the owner of a blog registered
+        with Blogspot.
 
         >>> extract('http://waiterrant.blogspot.com', include_psl_private_domains=False).registered_domain
         'blogspot.com'

--- a/tldextract/tldextract.py
+++ b/tldextract/tldextract.py
@@ -65,9 +65,25 @@ class ExtractResult:
     """
 
     subdomain: str
+    """All subdomains beneath the domain of the input URL, if it contained any such subdomains, or else the empty string."""
+
     domain: str
+    """The topmost domain of the input URL, if it contained a domain name, or else everything hostname-like in the input.
+
+    If the input URL didn't contain a real domain name, this field tends to
+    catch values like an IP address, or private network hostnames like
+    "localhost".
+    """
+
     suffix: str
+    """The public suffix of the input URL, if it contained one, or else the empty string."""
+
     is_private: bool
+    """Whether the input URL belongs in the Public Suffix List's private domains.
+
+    If `include_psl_private_domains` was set to `False`, this is always
+    `False`.
+    """
 
     @property
     def registered_domain(self) -> str:


### PR DESCRIPTION
Adds registry suffix field. Adds properties for commonly constructed top domain under public suffix and top domain under registry suffix. The former property already existed as `registered_domain`, now an alias to the new, clearer name. Document all of these. Addresses #138.

# Changes

* Add result field `registry_suffix`
  * To complement the existing public suffix field `suffix`
* Add result property `top_domain_under_public_suffix`
* Add result property `top_domain_under_registry_suffix`
* Document semantics of `registered_domain` property
  * Alias it to `top_domain_under_public_suffix`
* ~~Document existing `ExtractResult` fields~~ - I cut this into fd9c6e05c0e951e01af19520944c6cfd28258b08
* Expand internal `suffix_index` return type to include the registry suffix during trie traversal
  * Expand it to include slightly richer types, with `None` to signal "not found", instead of entirely magic ints and bools (although it's still a little magic, with its ints and tuples)