### PR TITLE
Restrict CI workflow access privileges to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: build
+permissions:
+  contents: read
 on:
   pull_request: {}
   push:


### PR DESCRIPTION
GitHub security recommends setting permissions for this workflow to read-only since write access is not being used.