### PR TITLE
Use isdecimal() instead of isdigit().

### DIFF
--- a/tldextract/remote.py
+++ b/tldextract/remote.py
@@ -55,7 +55,7 @@ def _schemeless_url(url: str) -> str:
 
 def looks_like_ip(maybe_ip: str) -> bool:
     """Check whether the given str looks like an IPv4 address."""
-    if not maybe_ip[0].isdigit():
+    if not maybe_ip[0].isdecimal():
         return False
 
     return IP_RE.fullmatch(maybe_ip) is not None


### PR DESCRIPTION
The search space for `str.isdecimal()` is a subset of `str.isdigit()`. This helps to avoid expensive regex for strings beginning with "non-decimal digits" like `³`. There appears to be no change in execution time for existing test cases.

```python
"³".isdigit()
True
"³".isdecimal()
False
```