### PR TITLE
Add Markdown doctest coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ extract = tldextract.TLDExtract(
 ```python
 from urllib.parse import urlsplit
 
-split_url = urlsplit("https://example.com:8080/path")
-result = tldextract.extract_urllib(split_url)
+extract = tldextract.TLDExtract()
+split_url = urlsplit("https://example.com/path")
+result = extract.extract_urllib(split_url)
 ```
 
 ## Command Line

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ no_fetch_extract('http://www.google.com')
 
 Via environment variable:
 
-```python
+```zsh
 export TLDEXTRACT_CACHE="/path/to/cache"
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ extract = tldextract.TLDExtract(
 ```python
 from urllib.parse import urlsplit
 
-extract = tldextract.TLDExtract()
-split_url = urlsplit("https://example.com/path")
-result = extract.extract_urllib(split_url)
+split_url = urlsplit("https://example.com:8080/path")
+result = tldextract.extract_urllib(split_url)
 ```
 
 ## Command Line

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+"""Project-wide pytest configuration.
+
+This lives at the repo root so pytest can collect root-level docs like
+README.md via Sybil. Test-only fixtures still live under tests/conftest.py.
+"""
+
+from sybil import Sybil
+from sybil.parsers.markdown import PythonCodeBlockParser
+
+pytest_collect_file = Sybil(
+    parsers=[PythonCodeBlockParser()],
+    patterns=["README.md"],
+).pytest()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ testing = [
     "pytest-mock",
     "responses",
     "ruff",
+    "sybil[pytest]",
     "syrupy",
     "tox",
     "tox-uv",


### PR DESCRIPTION
This would've avoided #360.

## Changes

- Install Sybil
- Fix errant `python` code block

## Test plan

See CI failures in 7596a41, caught by this PR, still fixed on `master`.